### PR TITLE
fix: Allow cohortextractor output in multiple dirs

### DIFF
--- a/tests/test_local_run.py
+++ b/tests/test_local_run.py
@@ -25,12 +25,14 @@ def test_local_run(tmp_path):
 
 @pytest.mark.slow_test
 @pytest.mark.needs_docker
-@pytest.mark.skipif(not os.environ.get('STATA_LICENSE'), reason="No STATA_LICENSE env var")
+@pytest.mark.skipif(
+    not os.environ.get("STATA_LICENSE"), reason="No STATA_LICENSE env var"
+)
 def test_local_run_stata(tmp_path, monkeypatch):
     project_fixture = str(Path(__file__).parent.resolve() / "fixtures/stata_project")
     project_dir = tmp_path / "project"
     shutil.copytree(project_fixture, project_dir)
-    monkeypatch.setattr("jobrunner.config.STATA_LICENSE", os.environ['STATA_LICENSE'])
+    monkeypatch.setattr("jobrunner.config.STATA_LICENSE", os.environ["STATA_LICENSE"])
     local_run.main(project_dir=project_dir, actions=["stata"])
     env_file = project_dir / "output/env.txt"
     assert "University of Oxford" in env_file.read_text()


### PR DESCRIPTION
Sometimes study authors want to create ancillary files alongside the
cohortextractor output. For instance, when study definitions or measures
are dynamically generated we may want to create a file recording the
parameters of the study/measure for use in later processing. Often it's
convenient to store this in a different directory from the standard
chortextractor output files.

The job-runner currently attempts to determine the expected directory
for cohortextractor output files by looking at the specified output
patterns and then appends this as an `--output-dir` argument to the
cohortextractor invocation. However if multiple output directories are
used in can't do this correctly and so throws an error.

This PR stops the error being thrown if an `--output-dir` is already
explicitly specified as one the cohortextractor arguments. The
assumption being that the user knows what they're doing in this case.

Longer term we should stop trying to automatically set `--output-dir`
and instead give the user a helpful error message if we can see that
their output patterns are never going to match.