### PR TITLE
feat: Pass `OPENSAFELY_BACKEND` env var to each job

### DIFF
--- a/jobrunner/manage_jobs.py
+++ b/jobrunner/manage_jobs.py
@@ -74,7 +74,7 @@ def start_job(job):
     volume = create_and_populate_volume(job)
     action_args = shlex.split(job.run_command)
     allow_network_access = False
-    env = {}
+    env = {"OPENSAFELY_BACKEND": config.BACKEND}
     if is_generate_cohort_command(action_args):
         if not config.USING_DUMMY_DATA_BACKEND:
             allow_network_access = True


### PR DESCRIPTION
This allows analysis scripts and study definitions to customise
themselves depending on which backend they are running under. This is
absolutely not the best long term solution to the cross-backend problem
but it's a simple and relatively non-invasive solution to unblock us for
now. We're deliberately not documenting this and only using it
internally at first.