### PR TITLE
feat: add PRESTO_TLS_* configs

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -59,25 +59,30 @@ PRESTO_TLS_KEY = PRESTO_TLS_CERT = None
 PRESTO_TLS_CERT_PATH = os.environ.get("PRESTO_TLS_CERT_PATH")
 PRESTO_TLS_KEY_PATH = os.environ.get("PRESTO_TLS_KEY_PATH")
 
-if PRESTO_TLS_KEY_PATH and PRESTO_TLS_CERT_PATH:
-    key_path = Path(PRESTO_TLS_KEY_PATH)
-    cert_path = Path(PRESTO_TLS_CERT_PATH)
+if bool(PRESTO_TLS_KEY_PATH) != bool(PRESTO_TLS_CERT_PATH):
+    raise ConfigException(
+            "Both PRESTO_TLS_KEY_PATH and PRESTO_TLS_CERT_PATH must be defined if either are"
+    )
 
-    if key_path.exists() and cert_path.exists():
+if PRESTO_TLS_KEY_PATH:
+    key_path = Path(PRESTO_TLS_KEY_PATH)
+    if key_path.exists():
         PRESTO_TLS_KEY = key_path.read_text()
-        PRESTO_TLS_CERT = cert_path.read_text()
-    elif key_path.exists():
-        raise ConfigException(
-            f"PRESTO_TLS_CERT_PATH={cert_path}, but file does not exist"
-        )
-    elif cert_path.exists():
+    else:
         raise ConfigException(
             f"PRESTO_TLS_KEY_PATH={key_path}, but file does not exist"
         )
+
+if PRESTO_TLS_CERT_PATH:
+    cert_path = Path(PRESTO_TLS_CERT_PATH)
+    if cert_path.exists():
+        PRESTO_TLS_CERT = cert_path.read_text()
     else:
         raise ConfigException(
-            f"PRESTO_TLS_KEY_PATH={key_path} and PRESTO_TLS_CERT_PATH={cert_path} but the files does not exist"
+            f"PRESTO_TLS_CERT_PATH={cert_path}, but file does not exist"
         )
+
+
 
 MAX_WORKERS = int(os.environ.get("MAX_WORKERS") or max(cpu_count() - 1, 1))
 

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -3,6 +3,10 @@ from pathlib import Path
 from multiprocessing import cpu_count
 
 
+class ConfigException(Exception):
+    pass
+
+
 default_work_dir = Path(__file__) / "../../workdir"
 
 WORK_DIR = Path(os.environ.get("WORK_DIR", default_work_dir)).resolve()
@@ -50,6 +54,30 @@ DATABASE_URLS = {
 }
 
 TEMP_DATABASE_NAME = os.environ.get("TEMP_DATABASE_NAME")
+
+PRESTO_TLS_KEY = PRESTO_TLS_CERT = None
+PRESTO_TLS_CERT_PATH = os.environ.get("PRESTO_TLS_CERT_PATH")
+PRESTO_TLS_KEY_PATH = os.environ.get("PRESTO_TLS_KEY_PATH")
+
+if PRESTO_TLS_KEY_PATH and PRESTO_TLS_CERT_PATH:
+    key_path = Path(PRESTO_TLS_KEY_PATH)
+    cert_path = Path(PRESTO_TLS_CERT_PATH)
+
+    if key_path.exists() and cert_path.exists():
+        PRESTO_TLS_KEY = key_path.read_text()
+        PRESTO_TLS_CERT = cert_path.read_text()
+    elif key_path.exists():
+        raise ConfigException(
+            f"PRESTO_TLS_CERT_PATH={cert_path}, but file does not exist"
+        )
+    elif cert_path.exists():
+        raise ConfigException(
+            f"PRESTO_TLS_KEY_PATH={key_path}, but file does not exist"
+        )
+    else:
+        raise ConfigException(
+            f"PRESTO_TLS_KEY_PATH={key_path} and PRESTO_TLS_CERT_PATH={cert_path} but the files does not exist"
+        )
 
 MAX_WORKERS = int(os.environ.get("MAX_WORKERS") or max(cpu_count() - 1, 1))
 

--- a/jobrunner/manage_jobs.py
+++ b/jobrunner/manage_jobs.py
@@ -81,6 +81,9 @@ def start_job(job):
             env["DATABASE_URL"] = config.DATABASE_URLS[job.database_name]
             if config.TEMP_DATABASE_NAME:
                 env["TEMP_DATABASE_NAME"] = config.TEMP_DATABASE_NAME
+            if config.PRESTO_TLS_KEY and config.PRESTO_TLS_CERT:
+                env["PRESTO_TLS_CERT"] = config.PRESTO_TLS_CERT
+                env["PRESTO_TLS_KEY"] = config.PRESTO_TLS_KEY
     # Prepend registry name
     image = action_args[0]
     full_image = f"{config.DOCKER_REGISTRY}/{image}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,73 @@
+import ast
+import subprocess
+import sys
+
+script = """
+from jobrunner import config;
+cfg = {k: str(v) for k, v in vars(config).items() if k.isupper()}
+print(repr(cfg))
+"""
+
+
+def import_cfg(env, raises=None):
+    ps = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    if ps.returncode == 0:
+        print(ps.stdout)
+        return ast.literal_eval(ps.stdout), None
+    else:
+        return None, ps.stderr
+
+
+def test_config_imports_with_clean_env():
+    import_cfg({})
+
+
+def test_config_presto_paths(tmp_path):
+    key = tmp_path / "key"
+    key.write_text("key")
+    cert = tmp_path / "cert"
+    cert.write_text("cert")
+    cfg, err = import_cfg(
+        {"PRESTO_TLS_KEY_PATH": str(key), "PRESTO_TLS_CERT_PATH": str(cert)}
+    )
+    assert err is None
+    assert cfg["PRESTO_TLS_KEY"] == "key"
+    assert cfg["PRESTO_TLS_CERT"] == "cert"
+
+
+def test_config_presto_paths_not_exist(tmp_path):
+    _, err = import_cfg(
+        {
+            "PRESTO_TLS_KEY_PATH": "key.notexists",
+            "PRESTO_TLS_CERT_PATH": "cert.notexists",
+        }
+    )
+    assert "PRESTO_TLS_KEY_PATH=key.notexists" in err
+    assert "PRESTO_TLS_CERT_PATH=cert.notexists" in err
+
+    key = tmp_path / "key"
+    key.write_text("key")
+    _, err = import_cfg(
+        {
+            "PRESTO_TLS_KEY_PATH": str(key),
+            "PRESTO_TLS_CERT_PATH": "cert.notexists",
+        }
+    )
+    assert "PRESTO_TLS_KEY_PATH=key.notexists" not in err
+    assert "PRESTO_TLS_CERT_PATH=cert.notexists" in err
+
+    cert = tmp_path / "cert"
+    cert.write_text("cert")
+    _, err = import_cfg(
+        {
+            "PRESTO_TLS_KEY_PATH": "key.notexists",
+            "PRESTO_TLS_CERT_PATH": str(cert),
+        }
+    )
+    assert "PRESTO_TLS_KEY_PATH=key.notexists" in err
+    assert "PRESTO_TLS_CERT_PATH=cert.notexists" not in err

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,33 +41,31 @@ def test_config_presto_paths(tmp_path):
 
 
 def test_config_presto_paths_not_exist(tmp_path):
-    _, err = import_cfg(
-        {
-            "PRESTO_TLS_KEY_PATH": "key.notexists",
-            "PRESTO_TLS_CERT_PATH": "cert.notexists",
-        }
-    )
-    assert "PRESTO_TLS_KEY_PATH=key.notexists" in err
-    assert "PRESTO_TLS_CERT_PATH=cert.notexists" in err
 
     key = tmp_path / "key"
     key.write_text("key")
-    _, err = import_cfg(
-        {
-            "PRESTO_TLS_KEY_PATH": str(key),
-            "PRESTO_TLS_CERT_PATH": "cert.notexists",
-        }
-    )
-    assert "PRESTO_TLS_KEY_PATH=key.notexists" not in err
-    assert "PRESTO_TLS_CERT_PATH=cert.notexists" in err
-
     cert = tmp_path / "cert"
     cert.write_text("cert")
-    _, err = import_cfg(
-        {
-            "PRESTO_TLS_KEY_PATH": "key.notexists",
-            "PRESTO_TLS_CERT_PATH": str(cert),
-        }
-    )
+
+    cfg, err = import_cfg({
+        "PRESTO_TLS_KEY_PATH": str(key),
+        "PRESTO_TLS_CERT_PATH": str(cert),
+    })
+    assert cfg['PRESTO_TLS_KEY'] == "key"
+    assert cfg['PRESTO_TLS_CERT'] == "cert"
+
+    # only one
+    _, err = import_cfg({ "PRESTO_TLS_KEY_PATH": "foo"})
+    assert "Both PRESTO_TLS_KEY_PATH and PRESTO_TLS_CERT_PATH must be defined" in err
+ 
+    cfg, err = import_cfg({
+        "PRESTO_TLS_KEY_PATH": "key.notexists",
+        "PRESTO_TLS_CERT_PATH": str(cert),
+    })
     assert "PRESTO_TLS_KEY_PATH=key.notexists" in err
-    assert "PRESTO_TLS_CERT_PATH=cert.notexists" not in err
+
+    cfg, err = import_cfg({
+        "PRESTO_TLS_KEY_PATH": str(key),
+        "PRESTO_TLS_CERT_PATH": "cert.notexists",
+    })
+    assert "PRESTO_TLS_CERT_PATH=cert.notexists" in err


### PR DESCRIPTION
PRESTO_TLS_KEY_PATH and PRESTO_TLS_CERT_PATH contain paths to the
relevant files, and we load them into PRESTO_TLS_KEY and PRESTO_TLS_CERT
respectively. If present, these values are passed to the cohortextractor
invocation.

This involved some error handing with in config.py that I wanted to
test, so I wrote a stupid subprocess test harness to do so.