### PR TITLE
Support config file giving job "resource weightings"

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -1,5 +1,7 @@
+import configparser
 import os
 from pathlib import Path
+import re
 from multiprocessing import cpu_count
 
 
@@ -100,3 +102,35 @@ STATA_LICENSE_REPO = os.environ.get(
     "STATA_LICENSE_REPO",
     "https://github.com/opensafely/server-instructions.git",
 )
+
+
+def parse_job_resource_weights(config_file):
+    """
+    Parse a simple ini file which looks like this:
+
+        [some-workspace-name]
+        my-ram-hungry-action = 4
+        other-actions.* = 1.5
+
+        [other-workspace-name]
+        ...
+
+    Any jobs in the specified workspace will have their action names matched
+    against the regex patterns specified in the config file and will be
+    assigned the weight of the first matching pattern. All other jobs are
+    assigned a weight of 1.
+    """
+    config_file = Path(config_file)
+    weights = {}
+    if config_file.exists():
+        config = configparser.ConfigParser()
+        config.read_string(config_file.read_text(), source=str(config_file))
+        for workspace in config.sections():
+            weights[workspace] = {
+                re.compile(pattern): float(weight)
+                for (pattern, weight) in config.items(workspace)
+            }
+    return weights
+
+
+JOB_RESOURCE_WEIGHTS = parse_job_resource_weights("job-resource-weights.ini")

--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -256,7 +256,11 @@ def create_and_run_jobs(
 
     # Run everything
     try:
-        run_main(exit_when_done=True, raise_on_failure=not continue_on_error)
+        run_main(
+            exit_when_done=True,
+            shuffle_jobs=False,
+            raise_on_failure=not continue_on_error,
+        )
     except (JobError, KeyboardInterrupt):
         pass
 

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -204,8 +204,16 @@ def get_reason_job_not_started(job):
             return "Waiting on available workers"
 
 
-def get_job_resource_weight(job):
-    # Hardcoded for now until we support a config file
+def get_job_resource_weight(job, weights=config.JOB_RESOURCE_WEIGHTS):
+    """
+    Get the job's resource weight by checking its workspace and action against
+    the config file, default to 1 otherwise
+    """
+    action_patterns = weights.get(job.workspace)
+    if action_patterns:
+        for pattern, weight in action_patterns.items():
+            if pattern.fullmatch(job.action):
+                return weight
     return 1
 
 

--- a/tests/test_job_resource_weights.py
+++ b/tests/test_job_resource_weights.py
@@ -1,0 +1,26 @@
+import textwrap
+
+from jobrunner.config import parse_job_resource_weights
+from jobrunner.models import Job
+from jobrunner.run import get_job_resource_weight
+
+
+def test_job_resource_weights(tmp_path):
+    config = textwrap.dedent(
+        """
+        [my-workspace]
+        some_action = 2.5
+        pattern[\d]+ = 4
+        """
+    )
+    config_file = tmp_path / "config.ini"
+    config_file.write_text(config)
+    weights = parse_job_resource_weights(config_file)
+    job = Job(workspace="foo", action="bar")
+    assert get_job_resource_weight(job, weights=weights) == 1
+    job = Job(workspace="my-workspace", action="some_action")
+    assert get_job_resource_weight(job, weights=weights) == 2.5
+    job = Job(workspace="my-workspace", action="pattern315")
+    assert get_job_resource_weight(job, weights=weights) == 4
+    job = Job(workspace="my-workspace", action="pattern000no_match")
+    assert get_job_resource_weight(job, weights=weights) == 1


### PR DESCRIPTION
This gives us a very crude mechanism for controlling how many of what
type of jobs are running together.

The config file itself should be placed at `job-resource-weights.ini`
in the job-runner working directory.

It is structured as:
```ini

[some-workspace-name]
my-ram-hungry-action = 4
other-actions.* = 1.5

[other-workspace-name]
...
```

Any jobs in the specified workspace will have their action names matched
against the regex patterns specified in the config file and will be
assigned the weight of the first matching pattern. All other jobs are
assigned a weight of 1.

We also take this opportunity to randomly shuffle the jobs list before each
processing loop so as to prevent a single set of jobs hogging all available
resources.