### PR TITLE
Add crude service to log system stats to a SQLite file

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -134,3 +134,10 @@ def parse_job_resource_weights(config_file):
 
 
 JOB_RESOURCE_WEIGHTS = parse_job_resource_weights("job-resource-weights.ini")
+
+
+STATS_DATABASE_FILE = os.environ.get("STATS_DATABASE_FILE")
+if STATS_DATABASE_FILE:
+    STATS_DATABASE_FILE = Path(STATS_DATABASE_FILE)
+
+STATS_POLL_INTERVAL = float(os.environ.get("STATS_POLL_INTERVAL", "10"))

--- a/jobrunner/docker_stats.py
+++ b/jobrunner/docker_stats.py
@@ -1,0 +1,52 @@
+import json
+
+from .subprocess_utils import subprocess_run
+
+
+def get_volume_and_container_sizes():
+    response = subprocess_run(
+        ["docker", "system", "df", "--verbose", "--format", "{{json .}}"],
+        capture_output=True,
+        check=True,
+    )
+    data = json.loads(response.stdout)
+    volumes = {row["Name"]: _parse_size(row["Size"]) for row in data["Volumes"]}
+    containers = {row["Names"]: _parse_size(row["Size"]) for row in data["Containers"]}
+    return volumes, containers
+
+
+def get_container_stats():
+    response = subprocess_run(
+        ["docker", "stats", "--no-stream", "--format", "{{json .}}"],
+        capture_output=True,
+        check=True,
+    )
+    data = [json.loads(line) for line in response.stdout.splitlines()]
+    return {
+        row["Name"]: {
+            "cpu_percentage": float(row["CPUPerc"].rstrip("%")),
+            "memory_used": _parse_size(row["MemUsage"].split()[0]),
+        }
+        for row in data
+    }
+
+
+CONVERSIONS = {
+    "B": 1,
+    "KB": 10 ** 3,
+    # Is this correct?
+    "kB": 10 ** 3,
+    "KiB": 2 ** 10,
+    "MB": 10 ** 6,
+    "MiB": 2 ** 20,
+    "GB": 10 ** 9,
+    "GiB": 2 ** 30,
+    "TB": 10 ** 12,
+    "TiB": 2 ** 40,
+}
+
+
+def _parse_size(size):
+    units = size.lstrip("0123456789.")
+    value = float(size[: -len(units)])
+    return int(value * CONVERSIONS[units])

--- a/jobrunner/record_stats.py
+++ b/jobrunner/record_stats.py
@@ -1,0 +1,80 @@
+"""
+Super crude docker/system stats logger
+"""
+import datetime
+import json
+import logging
+import sqlite3
+import sys
+import time
+
+from . import config
+from .docker_stats import get_container_stats, get_volume_and_container_sizes
+from .system_stats import get_system_stats
+from .log_utils import configure_logging
+
+
+SCHEMA_SQL = """
+CREATE TABLE stats (
+    timestamp TEXT,
+    data TEXT
+);
+"""
+
+
+log = logging.getLogger(__name__)
+
+
+def main():
+    database_file = config.STATS_DATABASE_FILE
+    if not database_file:
+        log.info("STATS_DATABASE_FILE not set; not polling for system stats")
+        return
+    log.info(f"Logging system stats to: {database_file}")
+    connection = get_database_connection(database_file)
+    while True:
+        log_stats(connection)
+        time.sleep(config.STATS_POLL_INTERVAL)
+
+
+def get_database_connection(filename):
+    filename.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(filename)
+    # Enable autocommit
+    conn.isolation_level = None
+    schema_count = list(conn.execute("SELECT COUNT(*) FROM sqlite_master"))[0][0]
+    if schema_count == 0:
+        conn.executescript(SCHEMA_SQL)
+    return conn
+
+
+def log_stats(connection):
+    stats = get_all_stats()
+    # If no containers are running then don't log anything
+    if not stats["containers"]:
+        return
+    timestamp = datetime.datetime.utcnow().isoformat()
+    connection.execute(
+        "INSERT INTO stats (timestamp, data) VALUES (?, ?)",
+        [timestamp, json.dumps(stats)],
+    )
+
+
+def get_all_stats():
+    stats = get_system_stats()
+    volume_sizes, container_sizes = get_volume_and_container_sizes()
+    containers = get_container_stats()
+    for name, container in containers.items():
+        container["disk_used"] = container_sizes.get(name)
+    stats["containers"] = containers
+    stats["volumes"] = volume_sizes
+    return stats
+
+
+if __name__ == "__main__":
+    configure_logging()
+
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -60,6 +60,9 @@ def record_stats_wrapper():
     while True:
         try:
             record_stats.main()
+            # `main()` should loop forever, if it exits cleanly that means it
+            # wasn't configured to run so we should exit the thread rather than
+            # looping
             return
         except Exception:
             log.exception("Exception in record_stats thread")

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -9,6 +9,7 @@ from . import config
 from .log_utils import configure_logging
 from . import run
 from . import sync
+from . import record_stats
 
 
 log = logging.getLogger(__name__)
@@ -27,6 +28,10 @@ def main():
         # process exits
         thread = threading.Thread(target=sync_wrapper, daemon=True)
         thread.name = "sync"
+        thread.start()
+        # Stat the `record_stats` thread
+        thread = threading.Thread(target=record_stats_wrapper, daemon=True)
+        thread.name = "stat"
         thread.start()
         run.main()
     except KeyboardInterrupt:
@@ -48,6 +53,17 @@ def sync_wrapper():
         except Exception:
             log.exception("Exception in sync thread")
             time.sleep(sleep_after_error)
+
+
+def record_stats_wrapper():
+    """Wrap the record_stats call with logging context and an exception handler."""
+    while True:
+        try:
+            record_stats.main()
+            return
+        except Exception:
+            log.exception("Exception in record_stats thread")
+            time.sleep(config.STATS_POLL_INTERVAL)
 
 
 if __name__ == "__main__":

--- a/jobrunner/system_stats.py
+++ b/jobrunner/system_stats.py
@@ -1,0 +1,111 @@
+from .docker import MANAGEMENT_CONTAINER_IMAGE
+from .subprocess_utils import subprocess_run
+
+
+# Populated by calls to `register_command` below
+COMMANDS = []
+PARSERS = []
+
+
+def get_system_stats():
+    separator = "____"
+    command = f" && echo {separator} && ".join(COMMANDS)
+    response = subprocess_run(
+        ["docker", "run", "--rm", MANAGEMENT_CONTAINER_IMAGE, "sh", "-c", command],
+        capture_output=True,
+        check=True,
+    )
+    output = response.stdout.decode("ascii", "ignore")
+    stats = {}
+    chunks = output.split(f"\n{separator}\n")
+    for parser, chunk in zip(PARSERS, chunks):
+        stats.update(parser(chunk))
+    return stats
+
+
+def register_command(command):
+    def register_parser(fn):
+        COMMANDS.append(command)
+        PARSERS.append(fn)
+        return fn
+
+    return register_parser
+
+
+# `-b`: output in bytes
+@register_command("free -b")
+def parse_output_from_free(output):
+    # Example:
+    #
+    #               total        used        free      shared  buff/cache   available
+    # Mem:    16640380928  6100041728   161775616  1044062208 10378563584  9152172032
+    # Swap:   17040404480  3095134208 13945270272
+
+    # Add a `type` header because the output doesn't include one
+    output = "type " + output.strip()
+    for row in _parse_table(output):
+        if row["type"] == "Mem:":
+            return {
+                "total_memory": int(row["total"]),
+                "available_memory": int(row["available"]),
+            }
+
+
+# `-k`: output in kilobytes
+# `-P`: output in POSIX format
+@register_command("df -kP /")
+def parse_output_from_df(output):
+    # Example:
+    #
+    # Filesystem           1024-blocks    Used Available Capacity Mounted on
+    # overlay              967482320 639067280 279246760  70% /
+
+    rows = _parse_table(output)
+    assert len(rows) == 1
+    data = rows[0]
+    assert data["Mounted"] == "/"
+    return {
+        "total_disk_space": int(data["1024-blocks"]) * 1024,
+        "available_disk_space": int(data["Available"]) * 1024,
+    }
+
+
+# `-P ALL`: show results for all processors
+# `1 1`: produce 1 report, after an interval of 1 second
+@register_command("mpstat -P ALL 1 1")
+def parse_output_from_mpstat(output):
+    # Example:
+    # Linux 5.4.0-66-generic (c30c70806105)	03/09/21	_x86_64_	(4 CPU)
+    #
+    # 11:02:35     CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest   %idle
+    # 11:02:36     all   22.31    0.25    7.27    1.50    0.00    1.75    0.00    0.00   66.92
+    # 11:02:36       0   14.29    0.00    3.06    1.02    0.00    1.02    0.00    0.00   80.61
+    # 11:02:36       1   20.62    0.00    7.22    5.15    0.00    0.00    0.00    0.00   67.01
+    # 11:02:36       2   16.49    0.00    5.15    0.00    0.00    6.19    0.00    0.00   72.16
+    # 11:02:36       3   36.27    0.00   12.75    0.00    0.00    0.00    0.00    0.00   50.98
+    #
+    # Average:     CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest   %idle
+    # Average:     all   22.31    0.25    7.27    1.50    0.00    1.75    0.00    0.00   66.92
+    # Average:       0   14.29    0.00    3.06    1.02    0.00    1.02    0.00    0.00   80.61
+    # Average:       1   20.62    0.00    7.22    5.15    0.00    0.00    0.00    0.00   67.01
+    # Average:       2   16.49    0.00    5.15    0.00    0.00    6.19    0.00    0.00   72.16
+    # Average:       3   36.27    0.00   12.75    0.00    0.00    0.00    0.00    0.00   50.98
+    prefix = "Average:"
+    output = "\n".join(
+        line[len(prefix) :] for line in output.splitlines() if line.startswith(prefix)
+    )
+    rows = _parse_table(output)
+    rows = [
+        {
+            key: float(value) if key.startswith("%") else value
+            for (key, value) in row.items()
+        }
+        for row in rows
+    ]
+    return {"mpstat": rows}
+
+
+def _parse_table(table_str):
+    table = [line.split() for line in table_str.strip().splitlines()]
+    header, rows = table[0], table[1:]
+    return [dict(zip(header, row)) for row in rows]

--- a/tests/test_docker_stats.py
+++ b/tests/test_docker_stats.py
@@ -1,0 +1,39 @@
+import time
+
+import pytest
+
+from jobrunner import docker
+from jobrunner.docker_stats import get_container_stats, get_volume_and_container_sizes
+
+
+@pytest.mark.needs_docker
+# This runs file locally but fails in CI, despite the retry logic added below.
+# Don't have time to diagnose this properly and this isn't core functionality
+# in any case
+@pytest.mark.xfail
+def test_get_container_stats(docker_cleanup):
+    docker.run("test_container1", [docker.MANAGEMENT_CONTAINER_IMAGE, "sh"])
+    # It can sometimes take a while before the container actually appears :(
+    for _ in range(10):
+        containers = get_container_stats()
+        if "test_container1" not in containers:
+            time.sleep(1)
+        else:
+            break
+    assert containers["test_container1"] == {"cpu_percentage": 0, "memory_used": 0}
+
+
+@pytest.mark.needs_docker
+def test_get_volume_and_container_sizes(tmp_path, docker_cleanup):
+    half_meg_file = tmp_path / "halfmeg"
+    half_meg_file.write_bytes(b"0" * 500000)
+    docker.create_volume("test_volume1")
+    docker.copy_to_volume("test_volume1", half_meg_file, "halfmeg")
+    docker.run(
+        "test_container2",
+        [docker.MANAGEMENT_CONTAINER_IMAGE, "cp", "/workspace/halfmeg", "/halfmeg"],
+        volume=("test_volume1", "/workspace"),
+    )
+    volumes, containers = get_volume_and_container_sizes()
+    assert volumes["test_volume1"] == 500000
+    assert containers["test_container2"] == 500000

--- a/tests/test_system_stats.py
+++ b/tests/test_system_stats.py
@@ -11,4 +11,4 @@ def test_get_system_stats():
         "available_disk_space",
         "total_memory",
         "available_memory",
-    } <= stats.keys()
+    }.issubset(stats.keys())

--- a/tests/test_system_stats.py
+++ b/tests/test_system_stats.py
@@ -1,0 +1,14 @@
+import pytest
+
+from jobrunner.system_stats import get_system_stats
+
+
+@pytest.mark.needs_docker
+def test_get_system_stats():
+    stats = get_system_stats()
+    assert {
+        "total_disk_space",
+        "available_disk_space",
+        "total_memory",
+        "available_memory",
+    } <= stats.keys()


### PR DESCRIPTION
This dumps the output of various docker and system load viewing commands as timestamped blobs of JSON in a SQLite file.

Configured using:

    STATS_DATABASE_FILE
    STATS_POLL_INTERVAL

Deliberately added as a new service rather than bundled up with `sync` so that we can back it out easily when we replace this with something better.