### PR TITLE
Support cancelling jobs on user request

### DIFF
--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -181,6 +181,7 @@ def create_and_run_jobs(
         repo_url=str(project_dir),
         commit="none",
         requested_actions=actions,
+        cancelled_actions=[],
         workspace=project_dir.name,
         database_name="dummy",
         force_run_dependencies=force_run_dependencies,

--- a/jobrunner/manage_jobs.py
+++ b/jobrunner/manage_jobs.py
@@ -312,6 +312,10 @@ def cleanup_job(job):
         log.info("Leaving container and volume in place for debugging")
 
 
+def kill_job(job):
+    docker.kill(container_name(job))
+
+
 def get_container_metadata(job):
     metadata = docker.container_inspect(container_name(job), none_if_not_exists=True)
     if not metadata:

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -33,6 +33,7 @@ class StatusCode(Enum):
     DEPENDENCY_FAILED = "dependency_failed"
     WAITING_ON_WORKERS = "waiting_on_workers"
     NONZERO_EXIT = "nonzero_exit"
+    CANCELLED_BY_USER = "cancelled_by_user"
 
 
 # This is our internal representation of a JobRequest which we pass around but
@@ -43,6 +44,7 @@ class JobRequest:
     repo_url: str
     commit: str
     requested_actions: list
+    cancelled_actions: list
     workspace: str
     database_name: str
     force_run_dependencies: bool = False
@@ -106,6 +108,8 @@ class Job:
     status_message: str = None
     # Machine readable code representing the status_message above
     status_code: StatusCode = None
+    # Flag indicating that the user has cancelled this job
+    cancelled: bool = False
     # Times (stored as integer UNIX timestamps)
     created_at: int = None
     updated_at: int = None

--- a/jobrunner/schema.sql
+++ b/jobrunner/schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE job (
     unmatched_outputs TEXT,
     status_message TEXT,
     status_code TEXT,
+    cancelled BOOLEAN,
     created_at INT,
     updated_at INT,
     started_at INT,

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -103,6 +103,7 @@ def job_request_from_remote_format(job_request):
         commit=job_request.get("sha"),
         branch=job_request["workspace"]["branch"],
         requested_actions=job_request["requested_actions"],
+        cancelled_actions=job_request["cancelled_actions"],
         workspace=job_request["workspace"]["name"],
         database_name=job_request["workspace"]["db"],
         force_run_dependencies=job_request["force_run_dependencies"],

--- a/tests/fixtures/full_project/project.yaml
+++ b/tests/fixtures/full_project/project.yaml
@@ -30,3 +30,10 @@ actions:
     outputs:
       moderately_sensitive:
         counts: counts.txt
+
+  test_cancellation:
+    run: python:latest python analysis/filter_by_sex.py F output/input.csv somefile.csv
+    needs: [generate_cohort]
+    outputs:
+      highly_sensitive:
+        somefile: somefile.csv

--- a/tests/test_create_or_update_jobs.py
+++ b/tests/test_create_or_update_jobs.py
@@ -18,6 +18,7 @@ def test_create_or_update_jobs(tmp_work_dir):
         commit=None,
         branch="v1",
         requested_actions=["generate_cohort"],
+        cancelled_actions=[],
         workspace="1",
         database_name="dummy",
         original={},
@@ -55,6 +56,7 @@ def test_create_or_update_jobs_with_git_error(tmp_work_dir):
         commit=None,
         branch="no-such-branch",
         requested_actions=["generate_cohort"],
+        cancelled_actions=[],
         workspace="1",
         database_name="dummy",
         original={},
@@ -146,6 +148,7 @@ def make_job_request(action="generate_cohort", **kwargs):
         workspace="1",
         database_name="full",
         requested_actions=[action],
+        cancelled_actions=[],
         original={},
     )
     for key, value in kwargs.items():

--- a/tests/test_create_or_update_jobs.py
+++ b/tests/test_create_or_update_jobs.py
@@ -140,6 +140,21 @@ def test_existing_active_jobs_are_picked_up_when_checking_dependencies(tmp_work_
     assert prepare_2_job.wait_for_job_ids == [generate_job.id]
 
 
+def test_cancelled_jobs_are_flagged(tmp_work_dir):
+    job_request = make_job_request(action="analyse_data")
+    create_jobs_with_project_file(job_request, TEST_PROJECT)
+    job_request.cancelled_actions = ["prepare_data_1", "prepare_data_2"]
+    create_or_update_jobs(job_request)
+    analyse_job = find_where(Job, action="analyse_data")[0]
+    prepare_1_job = find_where(Job, action="prepare_data_1")[0]
+    prepare_2_job = find_where(Job, action="prepare_data_2")[0]
+    generate_job = find_where(Job, action="generate_cohort")[0]
+    assert analyse_job.cancelled == False
+    assert prepare_1_job.cancelled == True
+    assert prepare_2_job.cancelled == True
+    assert generate_job.cancelled == False
+
+
 def make_job_request(action="generate_cohort", **kwargs):
     job_request = JobRequest(
         id=str(uuid.uuid4()),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,6 +34,7 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
                 {
                     "identifier": 1,
                     "requested_actions": ["analyse_data"],
+                    "cancelled_actions": [],
                     "force_run_dependencies": False,
                     "workspace": {
                         "name": "testing",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,32 +27,32 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
     project_fixture = str(Path(__file__).parent.resolve() / "fixtures/full_project")
     repo_path = tmp_work_dir / "test-repo"
     commit_directory_contents(repo_path, project_fixture)
+    job_request = {
+        "identifier": 1,
+        "requested_actions": ["analyse_data", "test_cancellation"],
+        "cancelled_actions": [],
+        "force_run_dependencies": False,
+        "workspace": {
+            "name": "testing",
+            "repo": str(repo_path),
+            "branch": "HEAD",
+            "db": "dummy",
+        },
+    }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",
         json={
-            "results": [
-                {
-                    "identifier": 1,
-                    "requested_actions": ["analyse_data"],
-                    "cancelled_actions": [],
-                    "force_run_dependencies": False,
-                    "workspace": {
-                        "name": "testing",
-                        "repo": str(repo_path),
-                        "branch": "HEAD",
-                        "db": "dummy",
-                    },
-                }
-            ],
+            "results": [job_request],
         },
     )
     requests_mock.post("http://testserver/api/v2/jobs/", json={})
 
     # Run sync to grab the JobRequest from the mocked job-server
     jobrunner.sync.sync()
-    # Check that three pending jobs are created
+    # Check that five pending jobs are created
     jobs = get_posted_jobs(requests_mock)
     assert [job["status"] for job in jobs.values()] == [
+        "pending",
         "pending",
         "pending",
         "pending",
@@ -71,6 +71,17 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
         "Waiting on dependencies"
     )
     assert jobs["analyse_data"]["status_message"].startswith("Waiting on dependencies")
+
+    # Request a job to be cancelled and then sync
+    job_request["cancelled_actions"] = ["test_cancellation"]
+    requests_mock.get(
+        "http://testserver/api/v2/job-requests/?backend=expectations",
+        json={
+            "results": [job_request],
+        },
+    )
+    jobrunner.sync.sync()
+
     # Run the main loop to completion and then sync
     jobrunner.run.main(exit_when_done=True)
 
@@ -103,12 +114,13 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
     )
 
     jobrunner.sync.sync()
-    # All jobs should now have succeeded
+    # All jobs should now have succeeded apart from the cancelled one
     jobs = get_posted_jobs(requests_mock)
     assert jobs["generate_cohort"]["status"] == "succeeded"
     assert jobs["prepare_data_m"]["status"] == "succeeded"
     assert jobs["prepare_data_f"]["status"] == "succeeded"
     assert jobs["analyse_data"]["status"] == "succeeded"
+    assert jobs["test_cancellation"]["status"] == "failed"
 
 
 def commit_directory_contents(repo_path, directory):

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -2,8 +2,6 @@ from datetime import datetime
 import logging
 import time
 
-import pytest
-
 from jobrunner.models import Job, JobRequest
 from jobrunner import log_utils, local_run
 
@@ -19,6 +17,7 @@ test_request = JobRequest(
     workspace="workspace",
     commit="commit",
     requested_actions=["action"],
+    cancelled_actions=[],
     database_name="dummy",
 )
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -12,6 +12,7 @@ def test_job_request_from_remote_format():
             "db": "full",
         },
         "requested_actions": ["generate_cohort"],
+        "cancelled_actions": ["analyse"],
         "force_run_dependencies": True,
     }
     expected = JobRequest(
@@ -22,6 +23,7 @@ def test_job_request_from_remote_format():
         workspace="testing",
         database_name="full",
         requested_actions=["generate_cohort"],
+        cancelled_actions=["analyse"],
         force_run_dependencies=True,
         original=remote_job_request,
     )


### PR DESCRIPTION
The UI for this has already been added but only enabled for admin users:
opensafely-core/job-server#382

This requires a database migration which needs to be done by hand for now:

1. Stop the runner and update:
    ```sh
    /c/nssm-2.24/win64/nssm stop opensafely
    git pull
    ```

2. Open a python shell:
    ```sh
    bash scripts/run.sh
    ```

3. Add the column:
    ```py
    from jobrunner.database import get_connection
    get_connection().execute("ALTER TABLE job ADD cancelled BOOLEAN")
    ```

1. Restart the runner:
    ```sh
    /c/nssm-2.24/win64/nssm start opensafely
    ```