### PR TITLE
chore: Set working directory to /workspace

### DIFF
--- a/scripts/mount-job-volume.sh
+++ b/scripts/mount-job-volume.sh
@@ -63,6 +63,8 @@ else
 
 fi
 
-exec docker run --rm -it --privileged --pid=host \
+exec docker run --rm -it \
+  --privileged --pid=host \
+  --workdir //workspace \
   -v "$selected_volume:/workspace" \
   ghcr.io/opensafely-core/tools


### PR DESCRIPTION
It's slightly more convenient to be dumped straight into the directory
you're going to be interested in.

(Double leading slash for the benefit of git-bash.)