### PR TITLE
fix: Fix logging and status messages for job cancellation

### DIFF
--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -97,6 +97,7 @@ def handle_pending_job(job):
 
 def handle_running_job(job):
     if job.cancelled:
+        log.info("Cancellation requested, killing job")
         kill_job(job)
 
     if job_still_running(job):
@@ -155,6 +156,9 @@ def mark_job_as_completed(job):
     # database exactly as is with the exception of setting the completed at
     # timestamp
     assert job.state in [State.SUCCEEDED, State.FAILED]
+    if job.state == State.FAILED and job.cancelled:
+        job.status_message = "Cancelled by user"
+        job.status_code = StatusCode.CANCELLED_BY_USER
     job.completed_at = int(time.time())
     update(job)
     log.info(job.status_message, extra={"status_code": job.status_code})


### PR DESCRIPTION
It turns out there are two seperate paths a failed job can go through
depending on exactly how it failed. This is because the once simple code
has splurged slightly and needs a bit of refactoring. Shouldn't be a
huge job but don't want to do it right now.