### PR TITLE
fix: Safely handle case-insensitive filesystems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
             "kill_job=jobrunner.kill_job:run",
             "retry_job=jobrunner.retry_job:run",
         ],
-    )
+    ),
 )

--- a/tests/test_local_run.py
+++ b/tests/test_local_run.py
@@ -77,21 +77,19 @@ def test_get_stata_license_repo_error(systmpdir):
 def test_add_arguments():
     parser = argparse.ArgumentParser(description="test")
     parser = local_run.add_arguments(parser)
-    args = parser.parse_args([
-        "action",
-        "--force-run-dependencies",
-        "--project-dir=dir",
-        "--continue-on-error",
-        "--timestamps",
-        "--debug"
-    ])
+    args = parser.parse_args(
+        [
+            "action",
+            "--force-run-dependencies",
+            "--project-dir=dir",
+            "--continue-on-error",
+            "--timestamps",
+            "--debug",
+        ]
+    )
 
     assert args.actions == ["action"]
-    assert args.force_run_dependencies 
+    assert args.force_run_dependencies
     assert args.project_dir == "dir"
     assert args.timestamps
     assert args.debug
-
-
-
-


### PR DESCRIPTION
Previously, if the case of an output file changed we would end up
deleting it every time we copied it out :(

The WindowsPath object already contains some case-normalisation logic
for comparison/hashing, but we also need to run correctly on macOS we is
case-insensitive but uses PosixPath. Doing the comparisons directly with
inodes is a bit of blunt tool but should give us the correct behaviour
here.