### PR TITLE
docs: Update the help text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ pip-wheel-metadata/*
 /tests/fixtures/*/output/*
 /tests/fixtures/*/metadata
 service*.log
+tags

--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -61,7 +61,7 @@ def add_arguments(parser):
     parser.add_argument(
         "-f",
         "--force-run-dependencies",
-        help="Re-run from scratch without using existing outputs",
+        help="Force the dependencies of the action to run, whether or not their outputs exist",
         action="store_true",
     )
     parser.add_argument(


### PR DESCRIPTION
Update the help text for the --force-run-dependencies argument. This commit is in addition to opensafely/documentation#217, which updates the documentation.