### PR TITLE
feat: Add validation for outputs_for_publishing field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ venv/ready: requirements.dev.txt requirements.txt
 	touch $@
 
 test: venv/ready
-	$(PYTHON) -m pytest
+	venv/bin/python -m pytest
 
 test-fast: venv/ready
-	$(PYTHON) -m pytest -m "not slow_test"
+	venv/bin/python -m pytest -m "not slow_test"
 
 test-verbose: venv/ready
-	$(PYTHON) -m pytest tests/test_integration.py -o log_cli=true -o log_cli_level=INFO
+	venv/bin/python -m pytest tests/test_integration.py -o log_cli=true -o log_cli_level=INFO
 
 run: venv/ready
 	venv/bin/add_job $(REPO) $(ACTION)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -4,6 +4,7 @@ from jobrunner.project import (
     parse_and_validate_project_file,
     ProjectValidationError,
     assert_valid_glob_pattern,
+    assert_valid_published_output,
     InvalidPatternError,
 )
 
@@ -35,3 +36,31 @@ def test_assert_valid_glob_pattern():
     for pattern in bad_patterns:
         with pytest.raises(InvalidPatternError):
             assert_valid_glob_pattern(pattern)
+
+
+@pytest.mark.parametrize(
+    "info,msg",
+    [
+        ({}, "missing field 'type'"),
+        ({"type": "table"}, "missing field 'files'"),
+        ({"type": "table", "files": []}, "missing field 'description'"),
+        (
+            {"type": "INVALID", "files": [], "description": "description"},
+            "invalid type of 'INVALID'",
+        ),
+        (
+            {"type": "table", "files": ["highly.csv"], "description": "description"},
+            "file 'highly.csv' does not match a moderately_sensitive action output.",
+        ),
+        (
+            {"type": "notebook", "files": ["output.csv"], "description": "description"},
+            "file 'output.csv' has invalid extension for output type 'notebook'",
+        ),
+    ],
+)
+def test_assert_valid_published_output(info, msg):
+    moderate_outputs = {"output.csv"}
+    with pytest.raises(ProjectValidationError) as err:
+        assert_valid_published_output("name", info, moderate_outputs)
+
+    assert str(err.value).startswith("outputs_for_publication name: " + msg)


### PR DESCRIPTION
Proposed new field here: 

https://github.com/opensafely-core/roadmap/discussions/11

This simply validates the field, but it is optional, so should be
backwards compatible