### PR TITLE
Validate that commits belong to OpenSAEFLY repos

### DIFF
--- a/jobrunner/add_job.py
+++ b/jobrunner/add_job.py
@@ -16,6 +16,7 @@ from .sync import job_request_from_remote_format
 from .database import find_where
 from .models import Job
 from .create_or_update_jobs import create_or_update_jobs
+from .git import get_sha_from_remote_ref
 
 
 def main(
@@ -27,6 +28,8 @@ def main(
         path = Path(parsed.path).resolve()
         # In case we're on Windows
         repo_url = str(path).replace("\\", "/")
+    if not commit:
+        commit = get_sha_from_remote_ref(repo_url, branch)
     job_request = job_request_from_remote_format(
         dict(
             identifier=random_id(),
@@ -34,6 +37,7 @@ def main(
             workspace=dict(name=workspace, repo=repo_url, branch=branch, db=database),
             requested_actions=actions,
             force_run_dependencies=force_run_dependencies,
+            cancelled_actions=[],
         )
     )
     print("Submitting JobRequest:\n")

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -104,6 +104,11 @@ STATA_LICENSE_REPO = os.environ.get(
 )
 
 
+ALLOWED_GITHUB_ORGS = (
+    os.environ.get("ALLOWED_GITHUB_ORGS", "opensafely").strip().split(",")
+)
+
+
 def parse_job_resource_weights(config_file):
     """
     Parse a simple ini file which looks like this:

--- a/tests/test_create_or_update_jobs.py
+++ b/tests/test_create_or_update_jobs.py
@@ -1,12 +1,19 @@
 from pathlib import Path
 import uuid
 
+import pytest
+
 from jobrunner.database import find_where
 from jobrunner.models import JobRequest, Job, State
 from jobrunner.create_or_update_jobs import (
     create_or_update_jobs,
     create_jobs_with_project_file,
 )
+
+
+@pytest.fixture(autouse=True)
+def disable_github_org_checking(monkeypatch):
+    monkeypatch.setattr("jobrunner.config.ALLOWED_GITHUB_ORGS", None)
 
 
 # Basic smoketest to test the full execution path

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3,7 +3,12 @@ from pathlib import Path
 
 import pytest
 
-from jobrunner.git import read_file_from_repo, checkout_commit, get_sha_from_remote_ref
+from jobrunner.git import (
+    read_file_from_repo,
+    checkout_commit,
+    get_sha_from_remote_ref,
+    commit_reachable_from_ref,
+)
 
 
 REPO_FIXTURE = str(Path(__file__).parent.resolve() / "fixtures/git-repo")
@@ -52,6 +57,22 @@ def test_read_file_from_private_repo(tmp_work_dir):
         "README.md",
     )
     assert output == b"# test-repository\nTesting GH permssions model\n"
+
+
+@pytest.mark.slow_test
+def test_commit_reachable_from_ref(tmp_work_dir):
+    is_reachable_good = commit_reachable_from_ref(
+        "https://github.com/opensafely/documentation",
+        "2170fadfeca7baf04f50376677253513e0a12bb1",
+        "1.6.0",
+    )
+    assert is_reachable_good
+    is_reachable_bad = commit_reachable_from_ref(
+        "https://github.com/opensafely/documentation",
+        "afaee06237df52d78aa85920248572d5803379a3",
+        "1.6.0",
+    )
+    assert not is_reachable_bad
 
 
 # The below tests use a local git repo fixture rather than accessing GitHub

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,6 +22,7 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
     monkeypatch.setattr(
         "jobrunner.config.JOB_SERVER_ENDPOINT", "http://testserver/api/v2/"
     )
+    monkeypatch.setattr("jobrunner.config.ALLOWED_GITHUB_ORGS", None)
 
     ensure_docker_images_present("cohortextractor", "python")
     project_fixture = str(Path(__file__).parent.resolve() / "fixtures/full_project")

--- a/tests/test_manage_jobs.py
+++ b/tests/test_manage_jobs.py
@@ -1,0 +1,13 @@
+import os
+
+from jobrunner.manage_jobs import delete_files
+
+
+def test_delete_files(tmp_path):
+    (tmp_path / "foo1").touch()
+    (tmp_path / "foo2").touch()
+    (tmp_path / "foo3").touch()
+    delete_files(tmp_path, ["foo1", "foo2", "foo3"], files_to_keep=["FOO1", "foo2"])
+    filenames = [f.name for f in tmp_path.iterdir()]
+    expected = ["foo1", "foo2"] if os.name == "nt" else ["foo2"]
+    assert filenames == expected


### PR DESCRIPTION
This is already enforced by the job-server but this means that even if
job-server is compromised it's impossible to run code unless you have
commit access to an OpenSAFELY repo.