### PR TITLE
fix: Clean up jobs which fail to start correctly

### DIFF
--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -90,6 +90,7 @@ def handle_pending_job(job):
                 cleanup_job(job)
             except Exception:
                 mark_job_as_failed(job, "Internal error when starting job")
+                cleanup_job(job)
                 raise
             else:
                 mark_job_as_running(job)


### PR DESCRIPTION
I think I originally didn't do this to aid debugging. However, it leads
to a cascading failure state where a job fails to start because Docker
runs out of disk space while copying in input files, and then the volume
never gets cleaned up and we can't even extract outputs from completed
jobs to free up space because we can't start the container required to
do the copying.

The one case now when we still *don't* automatically clean up is when a
job completes but hits some unexpected internal error while finalising.
In this case it seems premature to discard the results of potentially
long-running job when often the condition is fixable and the
finalisation step can be successfully retried later.