### PR TITLE
feat: use the github proxy to clone study repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ venv/ready: requirements.dev.txt requirements.txt
 	touch $@
 
 test: venv/ready
-	$(PYTHON) -m pytest
+	venv/bin/python -m pytest tests
 
 test-fast: venv/ready
-	$(PYTHON) -m pytest -m "not slow_test"
+	venv/bin/python -m pytest tests -m "not slow_test"
 
 test-verbose: venv/ready
-	$(PYTHON) -m pytest tests/test_integration.py -o log_cli=true -o log_cli_level=INFO
+	venv/bin/python -m pytest tests/test_integration.py -o log_cli=true -o log_cli_level=INFO
 
 run: venv/ready
 	venv/bin/add_job $(REPO) $(ACTION)
@@ -37,6 +37,6 @@ update-wheels: venv/ready requirements.txt requirements.tools.txt | lib
 # test the license shenanigins work when run from a console
 test-stata: venv/ready
 	rm -f tests/fixtures/stata_project/output/env.txt
-	$(PYTHON) -c 'from jobrunner.local_run import main; main("tests/fixtures/stata_project", ["stata"])'
+	venv/bin/python -c 'from jobrunner.local_run import main; main("tests/fixtures/stata_project", ["stata"])'
 	cat tests/fixtures/stata_project/output/env.txt
 	echo

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -100,7 +100,7 @@ ENABLE_PERMISSIONS_WORKAROUND = bool(os.environ.get("ENABLE_PERMISSIONS_WORKAROU
 STATA_LICENSE = os.environ.get("STATA_LICENSE")
 STATA_LICENSE_REPO = os.environ.get(
     "STATA_LICENSE_REPO",
-    "https://github.com/opensafely/server-instructions.git",
+    "https://github-proxy.opensafely.org/opensafely/server-instructions.git",
 )
 
 

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -110,7 +110,7 @@ ALLOWED_GITHUB_ORGS = (
 
 # we hardcode this for now, as from a security perspective, we do not want it
 # to be run time configurable.
-GIT_PROXY_URL = "https://github-proxy.opensafely.org/"
+GIT_PROXY_DOMAIN = "github-proxy.opensafely.org"
 
 
 def parse_job_resource_weights(config_file):

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -100,13 +100,17 @@ ENABLE_PERMISSIONS_WORKAROUND = bool(os.environ.get("ENABLE_PERMISSIONS_WORKAROU
 STATA_LICENSE = os.environ.get("STATA_LICENSE")
 STATA_LICENSE_REPO = os.environ.get(
     "STATA_LICENSE_REPO",
-    "https://github-proxy.opensafely.org/opensafely/server-instructions.git",
+    "https://github.com/opensafely/server-instructions.git",
 )
 
 
 ALLOWED_GITHUB_ORGS = (
     os.environ.get("ALLOWED_GITHUB_ORGS", "opensafely").strip().split(",")
 )
+
+# we hardcode this for now, as from a security perspective, we do not want it
+# to be run time configurable.
+GIT_PROXY_URL = "https://github-proxy.opensafely.org/"
 
 
 def parse_job_resource_weights(config_file):

--- a/jobrunner/git.py
+++ b/jobrunner/git.py
@@ -196,7 +196,7 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
     sleep = 4
     attempt = 1
     # we've already validated that the repo url starts with https://github.com
-    proxied_url = repo_url.replace('https://github.com/', config.GIT_PROXY_URL)
+    proxied_url = repo_url.replace('github.com', config.GIT_PROXY_DOMAIN)
     authenticated_url = add_access_token(proxied_url)
     while True:
         try:
@@ -254,7 +254,7 @@ def add_access_token(repo_url):
         return repo_url
     # Ensure we only ever send our token to github.com over https
     parsed = urlparse(repo_url)
-    if parsed.hostname != "github-proxy.opensafely.org" or parsed.scheme != "https":
+    if parsed.hostname != config.GIT_PROXY_DOMAIN or parsed.scheme != "https":
         return repo_url
     # Don't overwrite existing auth details (not sure why they'd be there but
     # seems polite)

--- a/jobrunner/git.py
+++ b/jobrunner/git.py
@@ -194,6 +194,9 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
     max_retries = 5
     sleep = 4
     attempt = 1
+    # we've already validated that the repo url starts with https://github.com
+    proxied_url = repo_url.replace('https://github.com/', 'https://github-proxy.opensafely.org/')
+    authenticated_url = add_access_token(proxied_url)
     while True:
         try:
             subprocess_run(
@@ -203,7 +206,7 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
                     "--force",
                     "--depth",
                     str(depth),
-                    add_access_token(repo_url),
+                    authenticated_url,
                     commit_sha,
                 ],
                 check=True,
@@ -214,7 +217,7 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
         except subprocess.SubprocessError as e:
             redact_token_from_exception(e)
             log.exception(
-                f"Error fetching commit {commit_sha} from {repo_url}"
+                f"Error fetching commit {commit_sha} from {proxied_url}"
                 f" (attempt {attempt}/{max_retries})"
             )
             if b"GnuTLS recv error" in e.stderr:
@@ -229,7 +232,7 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
                     time.sleep(sleep)
                     sleep *= 2
             else:
-                raise GitError(f"Error fetching commit {commit_sha} from {repo_url}")
+                raise GitError(f"Error fetching commit {commit_sha} from {proxied_url}")
 
 
 def commit_is_ancestor(repo_dir, ancestor_sha, descendant_sha):
@@ -250,7 +253,7 @@ def add_access_token(repo_url):
         return repo_url
     # Ensure we only ever send our token to github.com over https
     parsed = urlparse(repo_url)
-    if parsed.hostname != "github.com" or parsed.scheme != "https":
+    if parsed.hostname != "github-proxy.opensafely.org" or parsed.scheme != "https":
         return repo_url
     # Don't overwrite existing auth details (not sure why they'd be there but
     # seems polite)

--- a/jobrunner/git.py
+++ b/jobrunner/git.py
@@ -16,6 +16,7 @@ from .subprocess_utils import subprocess_run
 log = logging.getLogger(__name__)
 
 
+
 class GitError(Exception):
     pass
 
@@ -195,7 +196,7 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
     sleep = 4
     attempt = 1
     # we've already validated that the repo url starts with https://github.com
-    proxied_url = repo_url.replace('https://github.com/', 'https://github-proxy.opensafely.org/')
+    proxied_url = repo_url.replace('https://github.com/', config.GIT_PROXY_URL)
     authenticated_url = add_access_token(proxied_url)
     while True:
         try:


### PR DESCRIPTION
This will allow us to drop github access for job-runner.

Note: I verified the changed code is under tests, as tests fail if I break it
deliberately. But there's no easy way to test this change in isolation,
so have relied on current test paths.