### PR TITLE
Attempt to fix git reliability issues

### DIFF
--- a/jobrunner/git.py
+++ b/jobrunner/git.py
@@ -196,7 +196,7 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
     sleep = 4
     attempt = 1
     # we've already validated that the repo url starts with https://github.com
-    proxied_url = repo_url.replace('github.com', config.GIT_PROXY_DOMAIN)
+    proxied_url = repo_url.replace("github.com", config.GIT_PROXY_DOMAIN)
     authenticated_url = add_access_token(proxied_url)
     while True:
         try:

--- a/jobrunner/git.py
+++ b/jobrunner/git.py
@@ -267,7 +267,10 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
                 f"Error fetching commit {commit_sha} from {proxied_url}"
                 f" (attempt {attempt}/{max_retries})"
             )
-            if b"GnuTLS recv error" in e.stderr:
+            if (
+                b"GnuTLS recv error" in e.stderr
+                or b"SSL_read: Connection was reset" in e.stderr
+            ):
                 attempt += 1
                 if attempt > max_retries:
                     raise GitError(

--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -461,7 +461,7 @@ def get_stata_license(repo=config.STATA_LICENSE_REPO):
     if cached.exists():
         mtime = datetime.fromtimestamp(cached.stat().st_mtime)
         if datetime.utcnow() - mtime > license_timeout:
-            fetch=True
+            fetch = True
     else:
         fetch = True
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -8,6 +8,9 @@ from jobrunner.git import (
     checkout_commit,
     get_sha_from_remote_ref,
     commit_reachable_from_ref,
+    ensure_git_init,
+    fetch_commit,
+    commit_already_fetched,
 )
 
 
@@ -101,3 +104,12 @@ def test_checkout_commit_local(tmp_work_dir, tmp_path):
 def test_get_sha_from_remote_ref_local(tmp_work_dir):
     sha = get_sha_from_remote_ref(REPO_FIXTURE, "v1")
     assert sha == "d1e88b31cbe8f67c58f938adb5ee500d54a69764"
+
+
+def test_commit_already_fetched(tmp_path):
+    commit_sha = "d1e88b31cbe8f67c58f938adb5ee500d54a69764"
+    repo_dir = tmp_path / "repo"
+    ensure_git_init(repo_dir)
+    assert not commit_already_fetched(repo_dir, commit_sha)
+    fetch_commit(repo_dir, REPO_FIXTURE, commit_sha)
+    assert commit_already_fetched(repo_dir, commit_sha)

--- a/tests/test_local_run.py
+++ b/tests/test_local_run.py
@@ -59,7 +59,7 @@ def license_repo(tmp_path):
     subprocess_run(git + ["add", "stata.lic"], cwd=repo_path)
     subprocess_run(git + ["commit", "-m", "test"], cwd=repo_path)
     return repo_path
- 
+
 
 def test_get_stata_license_cache_recent(systmpdir, monkeypatch, tmp_path):
     def fail(*a, **kwargs):


### PR DESCRIPTION
This PR contains two changes: one to ensure that our use of git-fetch is atomic and prevent the problems caused by partially fetched commits; and another to expand the class of errors on which we automatically retry fetches.