### PR TITLE
fix: Apply github proxy when resolving remote refs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ name: Tests
 on: [push]
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PRIVATE_REPO_ACCESS_TOKEN: ${{ secrets.ACTIONS_PRIVATE_REPO_RO_TOKEN }}
 jobs:
   test_job:
     runs-on: ubuntu-latest

--- a/jobrunner/git.py
+++ b/jobrunner/git.py
@@ -128,7 +128,7 @@ def get_sha_from_remote_ref(repo_url, ref):
         output = response.stdout
     except subprocess.SubprocessError as exc:
         redact_token_from_exception(exc)
-        log.exception(f"Error resolving {ref} from {repo_url}")
+        log.exception("Error resolving remote git ref")
         output = ""
     results = _parse_ls_remote_output(output)
     if len(results) == 1:
@@ -261,10 +261,7 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
             break
         except subprocess.SubprocessError as e:
             redact_token_from_exception(e)
-            log.exception(
-                f"Error fetching commit {commit_sha} from {repo_url}"
-                f" (attempt {attempt}/{max_retries})"
-            )
+            log.exception(f"Error fetching commit (attempt {attempt}/{max_retries})")
             if (
                 b"GnuTLS recv error" in e.stderr
                 or b"SSL_read: Connection was reset" in e.stderr

--- a/jobrunner/git.py
+++ b/jobrunner/git.py
@@ -117,7 +117,7 @@ def get_sha_from_remote_ref(repo_url, ref):
                 "ls-remote",
                 "--quiet",
                 "--exit-code",
-                add_access_token(repo_url),
+                add_access_token_and_proxy(repo_url),
                 ref,
             ],
             check=True,
@@ -240,9 +240,7 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
     max_retries = 5
     sleep = 4
     attempt = 1
-    # we've already validated that the repo url starts with https://github.com
-    proxied_url = repo_url.replace("github.com", config.GIT_PROXY_DOMAIN)
-    authenticated_url = add_access_token(proxied_url)
+    authenticated_url = add_access_token_and_proxy(repo_url)
     while True:
         try:
             subprocess_run(
@@ -264,7 +262,7 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
         except subprocess.SubprocessError as e:
             redact_token_from_exception(e)
             log.exception(
-                f"Error fetching commit {commit_sha} from {proxied_url}"
+                f"Error fetching commit {commit_sha} from {repo_url}"
                 f" (attempt {attempt}/{max_retries})"
             )
             if (
@@ -282,7 +280,7 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
                     time.sleep(sleep)
                     sleep *= 2
             else:
-                raise GitError(f"Error fetching commit {commit_sha} from {proxied_url}")
+                raise GitError(f"Error fetching commit {commit_sha} from {repo_url}")
 
 
 def commit_is_ancestor(repo_dir, ancestor_sha, descendant_sha):
@@ -294,7 +292,9 @@ def commit_is_ancestor(repo_dir, ancestor_sha, descendant_sha):
     return response.returncode == 0
 
 
-def add_access_token(repo_url):
+def add_access_token_and_proxy(repo_url):
+    # We've already validated that the repo url starts with https://github.com
+    repo_url = repo_url.replace("github.com", config.GIT_PROXY_DOMAIN)
     # We previously did a complicated thing involving the GIT_ASKPASS
     # executable which worked OK on Linux but not on Windows or macOS, so we're
     # doing the more reliable thing of just sticking the token in the URL

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -46,22 +46,6 @@ def test_get_sha_from_remote_ref(tmp_work_dir):
     assert sha == "d78522cce38e6f431353e9e96de62d49b7ee86ea"
 
 
-# This test makes a request to an actual private GitHub repo and so will only
-# work if there's an appropriate access token in the environment
-@pytest.mark.skipif(
-    not os.environ.get("PRIVATE_REPO_ACCESS_TOKEN"),
-    reason="No access token in environment",
-)
-@pytest.mark.slow_test
-def test_read_file_from_private_repo(tmp_work_dir):
-    output = read_file_from_repo(
-        "https://github.com/opensafely/test-repository.git",
-        "d7fe87ab5d6dc97222c4a9dbf7c0fe40fc108c8f",
-        "README.md",
-    )
-    assert output == b"# test-repository\nTesting GH permssions model\n"
-
-
 @pytest.mark.slow_test
 def test_commit_reachable_from_ref(tmp_work_dir):
     is_reachable_good = commit_reachable_from_ref(
@@ -76,6 +60,36 @@ def test_commit_reachable_from_ref(tmp_work_dir):
         "1.6.0",
     )
     assert not is_reachable_bad
+
+
+# These tests makes request to an actual private GitHub repo and so will only
+# work if there's an appropriate access token in the environment
+
+
+@pytest.mark.skipif(
+    not os.environ.get("PRIVATE_REPO_ACCESS_TOKEN"),
+    reason="No access token in environment",
+)
+@pytest.mark.slow_test
+def test_read_file_from_private_repo(tmp_work_dir):
+    output = read_file_from_repo(
+        "https://github.com/opensafely/test-repository.git",
+        "d7fe87ab5d6dc97222c4a9dbf7c0fe40fc108c8f",
+        "README.md",
+    )
+    assert output == b"# test-repository\nTesting GH permssions model\n"
+
+
+@pytest.mark.skipif(
+    not os.environ.get("PRIVATE_REPO_ACCESS_TOKEN"),
+    reason="No access token in environment",
+)
+@pytest.mark.slow_test
+def test_get_sha_from_remote_ref_private(tmp_work_dir):
+    sha = get_sha_from_remote_ref(
+        "https://github.com/opensafely/test-repository", "v1.0"
+    )
+    assert sha == "981ac62ec5620df90556bc18784f06b6e7db7e4d"
 
 
 # The below tests use a local git repo fixture rather than accessing GitHub


### PR DESCRIPTION
After all the bikeshedding over configuration I missed the fact that
there's another function which talks to Github which didn't have the
proxy transformation applied! By moving this in with the auth stuff it's
now impossible to accidentally miss this.