### PR TITLE
Include full log files in Github Actions output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PRIVATE_REPO_ACCESS_TOKEN: ${{ secrets.ACTIONS_PRIVATE_REPO_RO_TOKEN }}
 jobs:
-  test_job:
+  test-job:
     runs-on: ubuntu-latest
     name: Run test suite
     steps:
@@ -23,7 +23,7 @@ jobs:
       run: python -m pytest
 
   # A bit of inelegant copy/paste here, just to see if this works
-  test_job_windows:
+  test-job-windows:
     runs-on: windows-2019
     name: "Run test suite on Windows"
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,3 +77,26 @@ jobs:
       uses: actions/checkout@v1
     - name: Build image
       run: docker build . --file Dockerfile --build-arg=pythonversion=3.8.3
+
+  test-github-workflow-output:
+    runs-on: ubuntu-latest
+    name: Inspect test runner output in the context of a Github Workflow
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run equivalent command used by test runner
+      # We don't care if this command succeeds or not, we just want to be able
+      # to look at the output
+      run: |
+        python -m jobrunner.local_run run_all \
+          --project-dir=tests/fixtures/full_project \
+          --continue-on-error --timestamps \
+          || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,5 +98,5 @@ jobs:
       run: |
         python -m jobrunner.local_run run_all \
           --project-dir=tests/fixtures/full_project \
-          --continue-on-error --timestamps \
+          --continue-on-error --timestamps --format-output-for-github \
           || true

--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -57,6 +57,16 @@ DESCRIPTION = __doc__.partition("\n\n")[0]
 LOCAL_RUN_FORMAT = "{action}{message}"
 
 
+# Super-crude support for colourised/formatted output inside Github Actions. It
+# would be good to support formatted output in the CLI more generally, but we
+# should use a decent library for that to handle the various cross-platform
+# issues.
+class ANSI:
+    Reset = "\u001b[0m"
+    Bold = "\u001b[1m"
+    Grey = "\u001b[38;5;248m"
+
+
 def add_arguments(parser):
     parser.add_argument("actions", nargs="*", help="Name of project action to run")
     parser.add_argument(
@@ -283,7 +293,7 @@ def create_and_run_jobs(
     # Wrap all the log output inside an expandable block when running inside
     # Github Actions
     if format_output_for_github:
-        print("::group::Job Runner Logs (click to view)")
+        print(f"::group::Job Runner Logs {ANSI.Grey}(click to view){ANSI.Reset}")
     # Run everything
     try:
         run_main(
@@ -319,7 +329,10 @@ def create_and_run_jobs(
             and job.status_code == StatusCode.DEPENDENCY_FAILED
         ):
             continue
-        print(f"=> {job.action}")
+        if format_output_for_github:
+            print(f"{ANSI.Bold}=> {job.action}{ANSI.Reset}")
+        else:
+            print(f"=> {job.action}")
         print(textwrap.indent(job.status_message, "   "))
         # Where a job failed because expected outputs weren't found we show a
         # list of other outputs which were generated
@@ -332,8 +345,13 @@ def create_and_run_jobs(
         # Output the entire log file inside an expandable block when running
         # inside Github Actions
         if format_output_for_github:
-            print(f"::group:: log file: {log_file} (click to view)")
+            print(
+                f"::group:: log file: {log_file} {ANSI.Grey}(click to view){ANSI.Reset}"
+            )
+            long_grey_line = ANSI.Grey + ("\u2015" * 80) + ANSI.Reset
+            print(long_grey_line)
             print((project_dir / log_file).read_text())
+            print(long_grey_line)
             print("::endgroup::")
         else:
             print(f"   log file: {log_file}")


### PR DESCRIPTION
Github Actions supports various [magic strings][1] for formatting
output. In particular, it allows you to hide output behind an expandable
toggle. We exploit this to embed the full log file from each action run
in the test output. We also add some very basic text formatting to
improve readability of the test output.

Example of collapsed output:

![github com_opensafely-core_job-runner_runs_2630948131_check_suite_focus=true](https://user-images.githubusercontent.com/19630/118996549-e7732400-b97f-11eb-951a-fdf00de021e7.png)


Example of expanded output:

![github com_opensafely-core_job-runner_runs_2630948131_check_suite_focus=true (1)](https://user-images.githubusercontent.com/19630/118996882-22755780-b980-11eb-91c9-40ca63c54ea4.png)

Addresses https://github.com/opensafely-core/research-action/issues/6

[1]: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#grouping-log-lines