### PR TITLE
chore: Support master and main as release branches

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false
-          release_branches: master
+          release_branches: master,main
 
   build-and-publish-package:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We haven't renamed the default branch yet, but we want to make sure this
keeps working when we do.