### PR TITLE
fix: Slightly better behaviour for cancelled jobs

### DIFF
--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -60,12 +60,14 @@ def handle_jobs(raise_on_failure=False, shuffle_jobs=True):
 
 def handle_pending_job(job):
     if job.cancelled:
-        # Mark the job as running and let `handle_running_job` deal with
-        # cancelling it on the next loop iteration. This allows us to keep all
-        # the kill/cleanup code together and it means that there aren't edge
-        # cases where we could lose track of jobs completely after losing
-        # database state
+        # Mark the job as running and then immediately invoke
+        # `handle_running_job` to deal with the cancellation. This slightly
+        # counterintuitive appraoch allows us to keep a simple, consistent set
+        # of state transitions and to consolidate all the kill/cleanup code
+        # together. It also means that there aren't edge cases where we could
+        # lose track of jobs completely after losing database state
         mark_job_as_running(job)
+        handle_running_job(job)
         return
 
     awaited_states = get_states_of_awaited_jobs(job)


### PR DESCRIPTION
Rather than marking jobs as running and then waiting for the next loop
iteration to actually cancel them, we now immediately invoke
`handle_running_job` to do the cancellation. This gives us the same
structural advantages as we had previously, but it makes cancellation
faster and means we no longer misleadingly report cancelled jobs as
having a non-zero runtime.