### PR TITLE
feat: Support passing complex config from project.yaml to commands

### DIFF
--- a/tests/fixtures/full_project/analysis/count_lines.py
+++ b/tests/fixtures/full_project/analysis/count_lines.py
@@ -1,11 +1,16 @@
-import sys
+import argparse, json, sys
 
 if __name__ == "__main__":
-    output_file, *input_files = sys.argv[1:]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config")
+    parser.add_argument("output_file")
+    args = parser.parse_args()
+
+    config = json.loads(args.config)
     counts = {}
-    for input_file in input_files:
+    for input_file in config["files"]:
         with open(input_file) as f:
             counts[input_file] = len(f.readlines())
-    with open(output_file, "w") as f:
+    with open(args.output_file, "w") as f:
         for name, count in counts.items():
             f.write(f"{name}: {count}\n")

--- a/tests/fixtures/full_project/project.yaml
+++ b/tests/fixtures/full_project/project.yaml
@@ -24,9 +24,18 @@ actions:
       highly_sensitive:
         female_cohort: female.*
 
+  prepare_data_with_quote_in_filename:
+    run: python:latest python analysis/filter_by_sex.py F output/input.csv "qu'ote.csv"
+    needs: [generate_cohort]
+    outputs:
+      highly_sensitive:
+        quote_cohort: "qu'ote.*"
+
   analyse_data:
-    run: python:latest python analysis/count_lines.py counts.txt male.csv female.csv
-    needs: [prepare_data_m, prepare_data_f]
+    run: python:latest python analysis/count_lines.py counts.txt
+    config:
+      files: ["male.csv", "female.csv", "qu'ote.csv"]
+    needs: [prepare_data_m, prepare_data_f, prepare_data_with_quote_in_filename]
     outputs:
       moderately_sensitive:
         counts: counts.txt

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -50,9 +50,10 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
 
     # Run sync to grab the JobRequest from the mocked job-server
     jobrunner.sync.sync()
-    # Check that five pending jobs are created
+    # Check that six pending jobs are created
     jobs = get_posted_jobs(requests_mock)
     assert [job["status"] for job in jobs.values()] == [
+        "pending",
         "pending",
         "pending",
         "pending",
@@ -69,6 +70,9 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
         "Waiting on dependencies"
     )
     assert jobs["prepare_data_f"]["status_message"].startswith(
+        "Waiting on dependencies"
+    )
+    assert jobs["prepare_data_with_quote_in_filename"]["status_message"].startswith(
         "Waiting on dependencies"
     )
     assert jobs["analyse_data"]["status_message"].startswith("Waiting on dependencies")
@@ -101,6 +105,7 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
             "generate_cohort",
             "prepare_data_f",
             "prepare_data_m",
+            "prepare_data_with_quote_in_filename",
             "analyse_data",
         ]
     )
@@ -110,6 +115,7 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
             "counts.txt",
             "male.csv",
             "female.csv",
+            "qu'ote.csv",
             "output/input.csv",
         ]
     )
@@ -120,6 +126,7 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
     assert jobs["generate_cohort"]["status"] == "succeeded"
     assert jobs["prepare_data_m"]["status"] == "succeeded"
     assert jobs["prepare_data_f"]["status"] == "succeeded"
+    assert jobs["prepare_data_with_quote_in_filename"]["status"] == "succeeded"
     assert jobs["analyse_data"]["status"] == "succeeded"
     assert jobs["test_cancellation"]["status"] == "failed"
 


### PR DESCRIPTION
For commands that require complex config, users can supply a config key in
project.yaml.  We serialize this as JSON, and pass it to the command with the
--config flag.

Fixes #225