### PR TITLE
Test filesystem for case sensitivity

### DIFF
--- a/tests/test_manage_jobs.py
+++ b/tests/test_manage_jobs.py
@@ -1,6 +1,16 @@
 import os
+import tempfile
 
 from jobrunner.manage_jobs import delete_files
+
+
+def is_filesystem_case_sensitive():
+    """Returns True if the filesystem is case sensitive; otherwise returns False."""
+    # Return a file-like object with some upper-case letters in its name that is deleted
+    # as soon as it is closed.
+    with tempfile.NamedTemporaryFile(prefix="TEMPORARY_FILE_") as temporary_file:
+        # The name property contains the path to the file.
+        return not os.path.exists(temporary_file.name.lower())
 
 
 def test_delete_files(tmp_path):
@@ -9,5 +19,5 @@ def test_delete_files(tmp_path):
     (tmp_path / "foo3").touch()
     delete_files(tmp_path, ["foo1", "foo2", "foo3"], files_to_keep=["FOO1", "foo2"])
     filenames = [f.name for f in tmp_path.iterdir()]
-    expected = ["foo1", "foo2"] if os.name == "nt" else ["foo2"]
+    expected = ["foo1", "foo2"] if not is_filesystem_case_sensitive() else ["foo2"]
     assert filenames == expected


### PR DESCRIPTION
Previously, we tested the operating system for case sensitivity. However, this fails on some macOS installs because whilst macOS is POSIX-compatible, by default APFS (Apple File System) is case insensitive. Python's standard library doesn't have a function for testing the filesystem; seemingly the best way is to write/read a temporary file. Finally, because this function is specific to the test, rather than the application code, it's next to the test.