### PR TITLE
Reusable actions

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -109,6 +109,9 @@ STATA_LICENSE_REPO = os.environ.get(
 )
 
 
+ACTIONS_GITHUB_ORG = "opensafely-actions"
+ACTIONS_GITHUB_ORG_URL = f"https://github.com/{ACTIONS_GITHUB_ORG}"
+
 ALLOWED_GITHUB_ORGS = (
     os.environ.get("ALLOWED_GITHUB_ORGS", "opensafely").strip().split(",")
 )

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -91,7 +91,7 @@ def create_jobs(job_request):
     validate_job_request(job_request)
     # In future I expect the job-server to only ever supply commits and so this
     # branch resolution will be redundant
-    if not job_request.commit:
+    if not job_request.commit and not config.LOCAL_RUN_MODE:
         job_request.commit = get_sha_from_remote_ref(
             job_request.repo_url, job_request.branch
         )

--- a/jobrunner/manage_jobs.py
+++ b/jobrunner/manage_jobs.py
@@ -125,7 +125,7 @@ def create_and_populate_volume(job):
     # `docker cp` can't create parent directories for us so we make sure all
     # these directories get created when we copy in the code
     extra_dirs = set(Path(filename).parent for filename in input_files.keys())
-    if config.LOCAL_RUN_MODE:
+    if config.LOCAL_RUN_MODE and not job.commit:
         copy_local_workspace_to_volume(volume, workspace_dir, extra_dirs)
     else:
         copy_git_commit_to_volume(volume, job.repo_url, job.commit, extra_dirs)

--- a/tests/test_manage_jobs.py
+++ b/tests/test_manage_jobs.py
@@ -1,7 +1,11 @@
 import os
 import tempfile
+from unittest import mock
 
-from jobrunner.manage_jobs import delete_files
+import pytest
+
+from jobrunner import config, models
+from jobrunner.manage_jobs import create_and_populate_volume, delete_files
 
 
 def is_filesystem_case_sensitive():
@@ -21,3 +25,73 @@ def test_delete_files(tmp_path):
     filenames = [f.name for f in tmp_path.iterdir()]
     expected = ["foo1", "foo2"] if not is_filesystem_case_sensitive() else ["foo2"]
     assert filenames == expected
+
+
+@mock.patch.multiple(
+    "jobrunner.docker",
+    create_volume=mock.DEFAULT,
+    copy_to_volume=mock.DEFAULT,
+)
+@mock.patch.multiple(
+    "jobrunner.manage_jobs",
+    copy_local_workspace_to_volume=mock.DEFAULT,
+    copy_git_commit_to_volume=mock.DEFAULT,
+)
+class TestCreateAndPopulateVolume:
+    # We patch docker to speed up the tests; we patch manage_jobs to test that the
+    # expected path was followed.
+
+    @pytest.fixture
+    def action_job(self):
+        """Returns a minimal Job instance that represents an action."""
+        return models.Job(
+            repo_url=f"opensafely/my-study",
+            requires_outputs_from=[],
+            workspace="output",
+        )
+
+    @pytest.fixture
+    def reusable_action_job(self):
+        """Returns a minimal Job instance that represents a reusable action."""
+        return models.Job(
+            repo_url=f"opensafely-actions/my-reusable-action",
+            commit="the-sha-for-this-commit",
+            requires_outputs_from=[],
+            workspace="output",
+        )
+
+    @mock.patch.object(config, "LOCAL_RUN_MODE", True)
+    def test_is_local_run_not_reusable_action(self, *, action_job, **kwargs):
+        mocked_copy_local_workspace_to_volume = kwargs["copy_local_workspace_to_volume"]
+        mocked_copy_git_commit_to_volume = kwargs["copy_git_commit_to_volume"]
+
+        create_and_populate_volume(action_job)
+        mocked_copy_local_workspace_to_volume.assert_called_once()
+        mocked_copy_git_commit_to_volume.assert_not_called()
+
+    @mock.patch.object(config, "LOCAL_RUN_MODE", True)
+    def test_is_local_run_is_reusable_action(self, *, reusable_action_job, **kwargs):
+        mocked_copy_local_workspace_to_volume = kwargs["copy_local_workspace_to_volume"]
+        mocked_copy_git_commit_to_volume = kwargs["copy_git_commit_to_volume"]
+
+        create_and_populate_volume(reusable_action_job)
+        mocked_copy_local_workspace_to_volume.assert_not_called()
+        mocked_copy_git_commit_to_volume.assert_called_once()
+
+    @mock.patch.object(config, "LOCAL_RUN_MODE", False)
+    def test_not_local_run_not_reusable_action(self, *, action_job, **kwargs):
+        mocked_copy_local_workspace_to_volume = kwargs["copy_local_workspace_to_volume"]
+        mocked_copy_git_commit_to_volume = kwargs["copy_git_commit_to_volume"]
+
+        create_and_populate_volume(action_job)
+        mocked_copy_local_workspace_to_volume.assert_not_called()
+        mocked_copy_git_commit_to_volume.assert_called_once()
+
+    @mock.patch.object(config, "LOCAL_RUN_MODE", False)
+    def test_not_local_run_is_reusable_action(self, *, reusable_action_job, **kwargs):
+        mocked_copy_local_workspace_to_volume = kwargs["copy_local_workspace_to_volume"]
+        mocked_copy_git_commit_to_volume = kwargs["copy_git_commit_to_volume"]
+
+        create_and_populate_volume(reusable_action_job)
+        mocked_copy_local_workspace_to_volume.assert_not_called()
+        mocked_copy_git_commit_to_volume.assert_called_once()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,11 +1,138 @@
+from unittest import mock
+
 import pytest
 
+from jobrunner import create_or_update_jobs, git, project
 from jobrunner.project import (
     parse_and_validate_project_file,
     ProjectValidationError,
     assert_valid_glob_pattern,
     InvalidPatternError,
 )
+
+
+@mock.patch.multiple(
+    "jobrunner.git",
+    get_sha_from_remote_ref=mock.DEFAULT,
+    read_file_from_repo=mock.DEFAULT,
+)
+class TestHandleReusableAction:
+    def test_when_not_a_reusable_action(self, **kwargs):
+        # Happy path 1
+        action_in = {"run": "python:latest python analysis/my_action.py"}
+        action_out = project.handle_reusable_action("my_action", action_in)
+        assert action_in is action_out
+        kwargs["get_sha_from_remote_ref"].assert_not_called()
+        kwargs["read_file_from_repo"].assert_not_called()
+
+    @mock.patch(
+        "jobrunner.project.parse_yaml_file",
+        return_value={"run": "python:latest python reusable_action/main.py"},
+    )
+    def test_when_a_reusable_action(self, *args, **kwargs):
+        # Happy path 2
+        action_in = {"run": "reusable-action:latest --output-format=png"}
+        action_out = project.handle_reusable_action("my_action", action_in)
+        assert action_in is not action_out
+        assert (
+            action_out["run"]
+            == "python:latest python reusable_action/main.py --output-format=png"
+        )
+
+    def test_with_bad_run_command(self, **kwargs):
+        # We don't need to check the scheme, netloc, or org because we add those.
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action",
+                {"run": "../my-bad-org/reusable-action:latest"},
+            )
+
+    def test_with_bad_remote_ref(self, **kwargs):
+        kwargs["get_sha_from_remote_ref"].side_effect = git.GitError
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action", {"run": "reusable-action:latest"}
+            )
+
+    @mock.patch(
+        "jobrunner.create_or_update_jobs.validate_branch_and_commit",
+        side_effect=create_or_update_jobs.JobRequestError,
+    )
+    def test_with_bad_commit(self, *args, **kwargs):
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action",
+                {"run": "reusable-action:latest"},
+            )
+
+    def test_with_bad_file(self, **kwargs):
+        kwargs["read_file_from_repo"].side_effect = git.GitError
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action", {"run": "reusable-action:latest"}
+            )
+
+    @mock.patch(
+        "jobrunner.project.parse_yaml_file",
+        side_effect=project.ProjectYAMLError,
+    )
+    def test_with_bad_yaml(self, *args, **kwargs):
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action", {"run": "reusable-action:latest"}
+            )
+
+    @mock.patch("jobrunner.project.parse_yaml_file", return_value={})
+    def test_with_bad_action_config(self, *args, **kwargs):
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action", {"run": "reusable-action:latest"}
+            )
+
+
+class TestParseAndValidateProjectFile:
+    def test_with_action(self):
+        project_file = """
+        version: '3.0'
+        expectations:
+            population_size: 1000
+        actions:
+            my_action:
+                run: python:latest python analysis/my_action.py
+                outputs:
+                    moderately_sensitive:
+                        my_figure: output/my_figure.png
+        """
+        project = parse_and_validate_project_file(project_file)
+        obs_run = project["actions"]["my_action"]["run"]
+        exp_run = "python:latest python analysis/my_action.py"
+        assert obs_run == exp_run
+
+    @mock.patch.multiple(
+        "jobrunner.git",
+        get_sha_from_remote_ref=mock.DEFAULT,
+        read_file_from_repo=mock.DEFAULT,
+    )
+    def test_with_reusable_action(self, **kwargs):
+        project_file = """
+        version: '3.0'
+        expectations:
+            population_size: 1000
+        actions:
+            my_action:
+                run: reusable-action:latest --output-format=png
+                outputs:
+                    moderately_sensitive:
+                        my_figure: output/my_figure.png
+        """
+        action_file = """
+        run: python:latest python reusable_action/main.py
+        """
+        kwargs["read_file_from_repo"].return_value = action_file
+        project = parse_and_validate_project_file(project_file)
+        obs_run = project["actions"]["my_action"]["run"]
+        exp_run = "python:latest python reusable_action/main.py --output-format=png"
+        assert obs_run == exp_run
 
 
 def test_error_on_duplicate_keys():
@@ -35,3 +162,48 @@ def test_assert_valid_glob_pattern():
     for pattern in bad_patterns:
         with pytest.raises(InvalidPatternError):
             assert_valid_glob_pattern(pattern)
+
+
+def test_get_action_specification_with_unknown_action():
+    project_dict = {"actions": {"known_action": {}}}
+    action_id = "unknown_action"
+    with pytest.raises(project.UnknownActionError):
+        project.get_action_specification(project_dict, action_id)
+
+
+def test_get_action_specification_with_config():
+    project_dict = {
+        "actions": {
+            "my_action": {
+                "run": "python:latest python analysis/my_action.py",
+                "config": {"my_key": "my_value"},
+                "outputs": {
+                    "moderately_sensitive": {"my_figure": "output/my_figure.png"}
+                },
+            }
+        }
+    }
+    action_id = "my_action"
+    action_spec = project.get_action_specification(project_dict, action_id)
+    assert (
+        action_spec.run
+        == """python:latest python analysis/my_action.py --config '{"my_key": "my_value"}'"""
+    )
+
+
+def test_get_action_specification_for_cohortextractor_generate_cohort_action():
+    project_dict = {
+        "expectations": {"population_size": 1_000},
+        "actions": {
+            "generate_cohort": {
+                "run": "cohortextractor:latest generate_cohort",
+                "outputs": {"highly_sensitive": {"cohort": "output/input.csv"}},
+            }
+        },
+    }
+    action_id = "generate_cohort"
+    action_spec = project.get_action_specification(project_dict, action_id)
+    assert (
+        action_spec.run
+        == """cohortextractor:latest generate_cohort --expectations-population=1000 --output-dir=output"""
+    )


### PR DESCRIPTION
Behold, reusable actions! 🎉 

* This is part one; for part two, see #228.
* For a discussion of how actions are hosted in GitHub, see #229. (TL;DR we will host actions in a new GitHub organisation called `opensafely-actions`.)
* For more information about the nature of reusable actions, see https://github.com/opensafely-core/action-packager/issues/1#issuecomment-874200067.

What's in this PR?

* Two small commits that move code for parsing YAML and validating the project file (*project.yaml*)
* One small commit that parses and validates the action file (*action.yaml*). @iaindillingham needs to revisit this commit, as he needs to think about what to `raise`; if an action developer has created an invalid action file, then there's only so much a study developer can do 🤷🏻‍♂️ 
* One small commit that gets the "binary" for a reusable action, if a reusable action has a binary. Python reusable actions do (`python`); R and Stata reusable actions don't
* One big commit that handles reusable actions - rewriting the action specification before it's saved (in the sync loop), to take advantage of existing functionality that fetches a Git repository and copies it to a volume. There is a small change when running a job (in the run loop), which introduces a switch to ensure that reusable actions are fetched when running in local run mode.

Closes #227 