### PR TITLE
feat: Handle reusable actions

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -109,6 +109,9 @@ STATA_LICENSE_REPO = os.environ.get(
 )
 
 
+ACTIONS_GITHUB_ORG = "opensafely-actions"
+ACTIONS_GITHUB_ORG_URL = f"https://github.com/{ACTIONS_GITHUB_ORG}"
+
 ALLOWED_GITHUB_ORGS = (
     os.environ.get("ALLOWED_GITHUB_ORGS", "opensafely").strip().split(",")
 )

--- a/jobrunner/manage_jobs.py
+++ b/jobrunner/manage_jobs.py
@@ -66,6 +66,11 @@ class MissingOutputError(JobError):
 
 
 def start_job(job):
+    """Start the given job.
+
+    Args:
+        job: An instance of Job.
+    """
     # If we already created the job but were killed before we updated the state
     # then there's nothing further to do
     if docker.container_exists(container_name(job)):
@@ -125,7 +130,9 @@ def create_and_populate_volume(job):
     # `docker cp` can't create parent directories for us so we make sure all
     # these directories get created when we copy in the code
     extra_dirs = set(Path(filename).parent for filename in input_files.keys())
-    if config.LOCAL_RUN_MODE:
+    # If job represents a reusable action, then job.commit will be non-None and we need
+    # to copy it to the volume whether or not we're in local development mode.
+    if config.LOCAL_RUN_MODE and not job.commit:
         copy_local_workspace_to_volume(volume, workspace_dir, extra_dirs)
     else:
         copy_git_commit_to_volume(volume, job.repo_url, job.commit, extra_dirs)

--- a/jobrunner/project.py
+++ b/jobrunner/project.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError, YAMLStreamError, YAMLWarning, YAMLFutureWarning
 
-from . import config
+from . import config, git
 
 
 # The magic action name which means "run every action"
@@ -47,27 +47,129 @@ class InvalidPatternError(ProjectValidationError):
     pass
 
 
+class ReusableActionError(Exception):
+    """Represents a study developer-friendly reusable action error.
+
+    We raise this in preference to other, lower-level, errors because there's only so
+    much a study developer can do when there's an error with a reusable action.
+    """
+
+
 # Tiny dataclass to capture the specification of a project action
 @dataclasses.dataclass
 class ActionSpecifiction:
     run: str
     needs: list
     outputs: dict
+    repo_url: str
+    commit: str
 
 
-def parse_and_validate_project_file(project_file):
+def parse_yaml_file(yaml_file):
     try:
         # We're using the pure-Python version here as we don't care about speed
         # and this gives better error messages (and consistent behaviour
         # cross-platform)
-        project = YAML(typ="safe", pure=True).load(project_file)
+        return YAML(typ="safe", pure=True).load(yaml_file)
         # ruamel doesn't have a nice exception hierarchy so we have to catch
         # these four separate base classes
     except (YAMLError, YAMLStreamError, YAMLWarning, YAMLFutureWarning) as e:
         e = make_yaml_error_more_helpful(e)
         raise ProjectYAMLError(f"{type(e).__name__} {e}")
+
+
+def parse_and_validate_project_file(project_file):
+    """Parse and validate the project file, handling reusable actions.
+
+    Args:
+        project_file: The contents of the project file as an immutable array of bytes.
+
+    Returns:
+        A dict representing the project.
+
+    Raises:
+        ProjectYAMLError: The contents of the project file could not be parsed.
+    """
+    project = parse_yaml_file(project_file)
+    actions = project["actions"]
+    for action_id, action in actions.items():
+        actions[action_id] = handle_reusable_action(action_id, action)
     project = validate_project_and_set_defaults(project)
     return project
+
+
+def handle_reusable_action(action_id, action):
+    """If `action` is reusable, then handle it. If not, then return it unchanged.
+
+    Args:
+        action_id: The action's ID as a string. This is the action's key in
+            project.yaml. It is used to raise errors with more informative messages.
+        action: The action's representation as a dict. This is the action's value in
+            project.yaml.
+
+    Returns:
+        The action's representation as a dict. If `action` resolves to a reusable
+        action, then it is rewritten to point to the reusable action and a copy is
+        returned. If not, then `action` is returned unchanged.
+
+    Raises:
+        ReusableActionError: An error occurred when accessing the reusable action.
+    """
+    # This avoids a circular import and is much less invasive than either moving the
+    # imports or importing `project` within `create_or_update_jobs`.
+    from .create_or_update_jobs import (
+        JobRequestError,
+        validate_branch_and_commit,
+        validate_repo_url,
+    )
+
+    run_args = shlex.split(action["run"])
+    image, tag = run_args[0].split(":")
+
+    if image in config.ALLOWED_IMAGES:
+        # This isn't a reusable action.
+        return action
+
+    # This is a reusable action.
+    repo_url = f"{config.ACTIONS_GITHUB_ORG_URL}/{image}"
+    try:
+        validate_repo_url(repo_url, [config.ACTIONS_GITHUB_ORG])
+    except JobRequestError as e:
+        raise ReusableActionError(*e.args)  # This keeps the function signature clean
+
+    try:
+        # If there's a problem, then it relates to the repository. Maybe the study
+        # developer made an error; maybe the reusable action developer made an error.
+        commit_sha = git.get_sha_from_remote_ref(repo_url, tag)
+    except git.GitError:
+        raise ReusableActionError(
+            f"Cannot resolve '{action_id}' to a repository at '{repo_url}'"
+        )
+
+    try:
+        validate_branch_and_commit(repo_url, commit_sha, "main")
+    except JobRequestError as e:
+        raise ReusableActionError(*e.args)
+
+    try:
+        # If there's a problem, then it relates to the reusable action. The study
+        # developer didn't make an error; the reusable action developer did.
+        action_file = git.read_file_from_repo(repo_url, commit_sha, "action.yaml")
+        action_config = parse_yaml_file(action_file)
+        assert "run" in action_config
+    except (git.GitError, ProjectYAMLError, AssertionError):
+        raise ReusableActionError(
+            f"There is a problem with the reusable action required by '{action_id}'"
+        )
+
+    # ["action:tag", "arg", ...] -> ["runtime:tag binary entrypoint", "arg", ...]
+    run_args[0] = action_config["run"]
+
+    new_action = action.copy()
+    new_action["run"] = " ".join(run_args)
+    new_action["repo_url"] = repo_url
+    new_action["commit"] = commit_sha
+    return new_action
 
 
 def make_yaml_error_more_helpful(exc):
@@ -187,9 +289,18 @@ def validate_project_and_set_defaults(project):
 
 
 def get_action_specification(project, action_id):
-    """
-    Given a project and action, return an ActionSpecification which contains
-    everything the job-runner needs to run this action
+    """Get a specification for the action from the project.
+
+    Args:
+        project: A dict representing the project.
+        action_id: The string ID of the action.
+
+    Returns:
+        An instance of ActionSpecification.
+
+    Raises:
+        UnknownActionError: The action was not found in the project.
+        ProjectValidationError: The project was not valid.
     """
     try:
         action_spec = project["actions"][action_id]
@@ -201,6 +312,7 @@ def get_action_specification(project, action_id):
     if "config" in action_spec:
         run_command = add_config_to_run_command(run_command, action_spec["config"])
     run_args = shlex.split(run_command)
+
     # Specical case handling for the `cohortextractor generate_cohort` command
     if is_generate_cohort_command(run_args):
         # Set the size of the dummy data population, if that's what were
@@ -232,6 +344,10 @@ def get_action_specification(project, action_id):
         run=run_command,
         needs=action_spec.get("needs", []),
         outputs=action_spec["outputs"],
+        # If action_spec (a dict) represents a reusable action, then it will have the
+        # following keys. If not, then it won't.
+        repo_url=action_spec.get("repo_url"),
+        commit=action_spec.get("commit"),
     )
 
 

--- a/tests/test_manage_jobs.py
+++ b/tests/test_manage_jobs.py
@@ -1,7 +1,11 @@
 import os
 import tempfile
+from unittest import mock
 
-from jobrunner.manage_jobs import delete_files
+import pytest
+
+from jobrunner import config, models
+from jobrunner.manage_jobs import create_and_populate_volume, delete_files
 
 
 def is_filesystem_case_sensitive():
@@ -21,3 +25,73 @@ def test_delete_files(tmp_path):
     filenames = [f.name for f in tmp_path.iterdir()]
     expected = ["foo1", "foo2"] if not is_filesystem_case_sensitive() else ["foo2"]
     assert filenames == expected
+
+
+@mock.patch.multiple(
+    "jobrunner.docker",
+    create_volume=mock.DEFAULT,
+    copy_to_volume=mock.DEFAULT,
+)
+@mock.patch.multiple(
+    "jobrunner.manage_jobs",
+    copy_local_workspace_to_volume=mock.DEFAULT,
+    copy_git_commit_to_volume=mock.DEFAULT,
+)
+class TestCreateAndPopulateVolume:
+    # We patch docker to speed up the tests; we patch manage_jobs to test that the
+    # expected path was followed.
+
+    @pytest.fixture
+    def action_job(self):
+        """Returns a minimal Job instance that represents an action."""
+        return models.Job(
+            repo_url=f"opensafely/my-study",
+            requires_outputs_from=[],
+            workspace="output",
+        )
+
+    @pytest.fixture
+    def reusable_action_job(self):
+        """Returns a minimal Job instance that represents a reusable action."""
+        return models.Job(
+            repo_url=f"opensafely-actions/my-reusable-action",
+            commit="the-sha-for-this-commit",
+            requires_outputs_from=[],
+            workspace="output",
+        )
+
+    @mock.patch.object(config, "LOCAL_RUN_MODE", True)
+    def test_is_local_run_not_reusable_action(self, *, action_job, **kwargs):
+        mocked_copy_local_workspace_to_volume = kwargs["copy_local_workspace_to_volume"]
+        mocked_copy_git_commit_to_volume = kwargs["copy_git_commit_to_volume"]
+
+        create_and_populate_volume(action_job)
+        mocked_copy_local_workspace_to_volume.assert_called_once()
+        mocked_copy_git_commit_to_volume.assert_not_called()
+
+    @mock.patch.object(config, "LOCAL_RUN_MODE", True)
+    def test_is_local_run_is_reusable_action(self, *, reusable_action_job, **kwargs):
+        mocked_copy_local_workspace_to_volume = kwargs["copy_local_workspace_to_volume"]
+        mocked_copy_git_commit_to_volume = kwargs["copy_git_commit_to_volume"]
+
+        create_and_populate_volume(reusable_action_job)
+        mocked_copy_local_workspace_to_volume.assert_not_called()
+        mocked_copy_git_commit_to_volume.assert_called_once()
+
+    @mock.patch.object(config, "LOCAL_RUN_MODE", False)
+    def test_not_local_run_not_reusable_action(self, *, action_job, **kwargs):
+        mocked_copy_local_workspace_to_volume = kwargs["copy_local_workspace_to_volume"]
+        mocked_copy_git_commit_to_volume = kwargs["copy_git_commit_to_volume"]
+
+        create_and_populate_volume(action_job)
+        mocked_copy_local_workspace_to_volume.assert_not_called()
+        mocked_copy_git_commit_to_volume.assert_called_once()
+
+    @mock.patch.object(config, "LOCAL_RUN_MODE", False)
+    def test_not_local_run_is_reusable_action(self, *, reusable_action_job, **kwargs):
+        mocked_copy_local_workspace_to_volume = kwargs["copy_local_workspace_to_volume"]
+        mocked_copy_git_commit_to_volume = kwargs["copy_git_commit_to_volume"]
+
+        create_and_populate_volume(reusable_action_job)
+        mocked_copy_local_workspace_to_volume.assert_not_called()
+        mocked_copy_git_commit_to_volume.assert_called_once()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,11 +1,138 @@
+from unittest import mock
+
 import pytest
 
+from jobrunner import create_or_update_jobs, git, project
 from jobrunner.project import (
     parse_and_validate_project_file,
     ProjectValidationError,
     assert_valid_glob_pattern,
     InvalidPatternError,
 )
+
+
+@mock.patch.multiple(
+    "jobrunner.git",
+    get_sha_from_remote_ref=mock.DEFAULT,
+    read_file_from_repo=mock.DEFAULT,
+)
+class TestHandleReusableAction:
+    def test_when_not_a_reusable_action(self, **kwargs):
+        # Happy path 1
+        action_in = {"run": "python:latest python analysis/my_action.py"}
+        action_out = project.handle_reusable_action("my_action", action_in)
+        assert action_in is action_out
+        kwargs["get_sha_from_remote_ref"].assert_not_called()
+        kwargs["read_file_from_repo"].assert_not_called()
+
+    @mock.patch(
+        "jobrunner.project.parse_yaml_file",
+        return_value={"run": "python:latest python reusable_action/main.py"},
+    )
+    def test_when_a_reusable_action(self, *args, **kwargs):
+        # Happy path 2
+        action_in = {"run": "reusable-action:latest --output-format=png"}
+        action_out = project.handle_reusable_action("my_action", action_in)
+        assert action_in is not action_out
+        assert (
+            action_out["run"]
+            == "python:latest python reusable_action/main.py --output-format=png"
+        )
+
+    def test_with_bad_run_command(self, **kwargs):
+        # We don't need to check the scheme, netloc, or org because we add those.
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action",
+                {"run": "../my-bad-org/reusable-action:latest"},
+            )
+
+    def test_with_bad_remote_ref(self, **kwargs):
+        kwargs["get_sha_from_remote_ref"].side_effect = git.GitError
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action", {"run": "reusable-action:latest"}
+            )
+
+    @mock.patch(
+        "jobrunner.create_or_update_jobs.validate_branch_and_commit",
+        side_effect=create_or_update_jobs.JobRequestError,
+    )
+    def test_with_bad_commit(self, *args, **kwargs):
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action",
+                {"run": "reusable-action:latest"},
+            )
+
+    def test_with_bad_file(self, **kwargs):
+        kwargs["read_file_from_repo"].side_effect = git.GitError
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action", {"run": "reusable-action:latest"}
+            )
+
+    @mock.patch(
+        "jobrunner.project.parse_yaml_file",
+        side_effect=project.ProjectYAMLError,
+    )
+    def test_with_bad_yaml(self, *args, **kwargs):
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action", {"run": "reusable-action:latest"}
+            )
+
+    @mock.patch("jobrunner.project.parse_yaml_file", return_value={})
+    def test_with_bad_action_config(self, *args, **kwargs):
+        with pytest.raises(project.ReusableActionError):
+            project.handle_reusable_action(
+                "my_action", {"run": "reusable-action:latest"}
+            )
+
+
+class TestParseAndValidateProjectFile:
+    def test_with_action(self):
+        project_file = """
+        version: '3.0'
+        expectations:
+            population_size: 1000
+        actions:
+            my_action:
+                run: python:latest python analysis/my_action.py
+                outputs:
+                    moderately_sensitive:
+                        my_figure: output/my_figure.png
+        """
+        project = parse_and_validate_project_file(project_file)
+        obs_run = project["actions"]["my_action"]["run"]
+        exp_run = "python:latest python analysis/my_action.py"
+        assert obs_run == exp_run
+
+    @mock.patch.multiple(
+        "jobrunner.git",
+        get_sha_from_remote_ref=mock.DEFAULT,
+        read_file_from_repo=mock.DEFAULT,
+    )
+    def test_with_reusable_action(self, **kwargs):
+        project_file = """
+        version: '3.0'
+        expectations:
+            population_size: 1000
+        actions:
+            my_action:
+                run: reusable-action:latest --output-format=png
+                outputs:
+                    moderately_sensitive:
+                        my_figure: output/my_figure.png
+        """
+        action_file = """
+        run: python:latest python reusable_action/main.py
+        """
+        kwargs["read_file_from_repo"].return_value = action_file
+        project = parse_and_validate_project_file(project_file)
+        obs_run = project["actions"]["my_action"]["run"]
+        exp_run = "python:latest python reusable_action/main.py --output-format=png"
+        assert obs_run == exp_run
 
 
 def test_error_on_duplicate_keys():
@@ -35,3 +162,48 @@ def test_assert_valid_glob_pattern():
     for pattern in bad_patterns:
         with pytest.raises(InvalidPatternError):
             assert_valid_glob_pattern(pattern)
+
+
+def test_get_action_specification_with_unknown_action():
+    project_dict = {"actions": {"known_action": {}}}
+    action_id = "unknown_action"
+    with pytest.raises(project.UnknownActionError):
+        project.get_action_specification(project_dict, action_id)
+
+
+def test_get_action_specification_with_config():
+    project_dict = {
+        "actions": {
+            "my_action": {
+                "run": "python:latest python analysis/my_action.py",
+                "config": {"my_key": "my_value"},
+                "outputs": {
+                    "moderately_sensitive": {"my_figure": "output/my_figure.png"}
+                },
+            }
+        }
+    }
+    action_id = "my_action"
+    action_spec = project.get_action_specification(project_dict, action_id)
+    assert (
+        action_spec.run
+        == """python:latest python analysis/my_action.py --config '{"my_key": "my_value"}'"""
+    )
+
+
+def test_get_action_specification_for_cohortextractor_generate_cohort_action():
+    project_dict = {
+        "expectations": {"population_size": 1_000},
+        "actions": {
+            "generate_cohort": {
+                "run": "cohortextractor:latest generate_cohort",
+                "outputs": {"highly_sensitive": {"cohort": "output/input.csv"}},
+            }
+        },
+    }
+    action_id = "generate_cohort"
+    action_spec = project.get_action_specification(project_dict, action_id)
+    assert (
+        action_spec.run
+        == """cohortextractor:latest generate_cohort --expectations-population=1000 --output-dir=output"""
+    )


### PR DESCRIPTION
Reusable Actions, Part Deux 🎉 

The best place to start is *jobrunner/project.py*. Here, `handle_reusable_action` rewrites actions that resolve to reusable actions. It's called within job-runner's sync loop, before a transaction is opened on the database.

A small change within *jobrunner/manage_jobs.py* to `create_and_populate_volume` ensures that reusable actions are handled correctly within job-runner's run loop.

Next steps...

- [ ] Address any changes requested following this PR
- [ ] Add a reusable action to the integration test (*tests/test_integration.py*)

This PR follows #232, which was closed after much squashing and force pushing.