### PR TITLE
fix: Fix non-deterministic integration test

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -93,6 +93,12 @@ if PRESTO_TLS_CERT_PATH:
 
 MAX_WORKERS = int(os.environ.get("MAX_WORKERS") or max(cpu_count() - 1, 1))
 
+# This is a crude mechanism for preventing a single large JobRequest with lots
+# of associated Jobs from hogging all the resources. We want this configurable
+# because it's useful to be able to disable this during tests and when running
+# locally
+RANDOMISE_JOB_ORDER = True
+
 # See `local_run.py` for more detail
 LOCAL_RUN_MODE = False
 

--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -196,6 +196,8 @@ def create_and_run_jobs(
     # Configure
     docker.LABEL = docker_label
     config.LOCAL_RUN_MODE = True
+    # It's more helpful in this context to have things consistent
+    config.RANDOMISE_JOB_ORDER = False
     config.HIGH_PRIVACY_WORKSPACES_DIR = project_dir.parent
     # Append a random value so that multiple runs in the same process will each
     # get their own unique in-memory database. This is only really relevant
@@ -302,7 +304,6 @@ def create_and_run_jobs(
     try:
         run_main(
             exit_when_done=True,
-            shuffle_jobs=False,
             raise_on_failure=not continue_on_error,
         )
     except (JobError, KeyboardInterrupt):

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -26,18 +26,16 @@ from .manage_jobs import (
 log = logging.getLogger(__name__)
 
 
-def main(exit_when_done=False, raise_on_failure=False):
+def main(exit_callback=lambda _: False):
     log.info("jobrunner.run loop started")
     while True:
-        active_jobs = handle_jobs(
-            raise_on_failure=raise_on_failure
-        )
-        if exit_when_done and len(active_jobs) == 0:
+        active_jobs = handle_jobs()
+        if exit_callback(active_jobs):
             break
         time.sleep(config.JOB_LOOP_INTERVAL)
 
 
-def handle_jobs(raise_on_failure=False):
+def handle_jobs():
     active_jobs = find_where(Job, state__in=[State.PENDING, State.RUNNING])
     # Randomising the job order is a crude but effective way to ensure that a
     # single large job request doesn't hog all the workers. We make this
@@ -53,8 +51,6 @@ def handle_jobs(raise_on_failure=False):
                 handle_pending_job(job)
             elif job.state == State.RUNNING:
                 handle_running_job(job)
-        if raise_on_failure and job.state == State.FAILED:
-            raise JobError("Job failed")
     return active_jobs
 
 

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -26,24 +26,24 @@ from .manage_jobs import (
 log = logging.getLogger(__name__)
 
 
-def main(exit_when_done=False, raise_on_failure=False, shuffle_jobs=True):
+def main(exit_when_done=False, raise_on_failure=False):
     log.info("jobrunner.run loop started")
     while True:
         active_jobs = handle_jobs(
-            raise_on_failure=raise_on_failure, shuffle_jobs=shuffle_jobs
+            raise_on_failure=raise_on_failure
         )
         if exit_when_done and len(active_jobs) == 0:
             break
         time.sleep(config.JOB_LOOP_INTERVAL)
 
 
-def handle_jobs(raise_on_failure=False, shuffle_jobs=True):
+def handle_jobs(raise_on_failure=False):
     active_jobs = find_where(Job, state__in=[State.PENDING, State.RUNNING])
     # Randomising the job order is a crude but effective way to ensure that a
     # single large job request doesn't hog all the workers. We make this
     # optional as, when running locally, having jobs run in a predictable order
     # is preferable
-    if shuffle_jobs:
+    if config.RANDOMISE_JOB_ORDER:
         random.shuffle(active_jobs)
     for job in active_jobs:
         # `set_log_context` ensures that all log messages triggered anywhere

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -102,8 +102,8 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
     )
     jobrunner.sync.sync()
 
-    # Run the main loop to completion and then sync
-    jobrunner.run.main(exit_when_done=True)
+    # Run the main loop until there are no jobs left and then sync
+    jobrunner.run.main(exit_callback=lambda active_jobs: len(active_jobs) == 0)
     jobrunner.sync.sync()
 
     # All jobs should now have succeeded apart from the cancelled one

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,16 +23,18 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
         "jobrunner.config.JOB_SERVER_ENDPOINT", "http://testserver/api/v2/"
     )
     monkeypatch.setattr("jobrunner.config.ALLOWED_GITHUB_ORGS", None)
-
     ensure_docker_images_present("cohortextractor", "python")
+
+    # Take our test project fixture and commit it to a temporary git repo
     project_fixture = str(Path(__file__).parent.resolve() / "fixtures/full_project")
     repo_path = tmp_work_dir / "test-repo"
     commit_directory_contents(repo_path, project_fixture)
-    job_request = {
+
+    # Set up a mock job-server with a single job request
+    job_request_1 = {
         "identifier": 1,
         "requested_actions": [
             "analyse_data",
-            "generate_cohort_with_dummy_data",
             "test_cancellation",
         ],
         "cancelled_actions": [],
@@ -47,46 +49,71 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",
         json={
-            "results": [job_request],
+            "results": [job_request_1],
         },
     )
     requests_mock.post("http://testserver/api/v2/jobs/", json={})
 
     # Run sync to grab the JobRequest from the mocked job-server
     jobrunner.sync.sync()
-    # Check that seven pending jobs are created
+    # Check that six pending jobs are created
     jobs = get_posted_jobs(requests_mock)
-    assert [job["status"] for job in jobs.values()] == ["pending"] * 7
+    assert [job["status"] for job in jobs.values()] == ["pending"] * 6
     # Exectue one tick of the run loop and then sync
     jobrunner.run.handle_jobs()
     jobrunner.sync.sync()
-    # We should now have one running job and two waiting on dependencies
+    # We should now have one running job and five waiting on dependencies
     jobs = get_posted_jobs(requests_mock)
     assert jobs["generate_cohort"]["status"] == "running"
-    assert jobs["prepare_data_m"]["status_message"].startswith(
-        "Waiting on dependencies"
-    )
-    assert jobs["prepare_data_f"]["status_message"].startswith(
-        "Waiting on dependencies"
-    )
-    assert jobs["prepare_data_with_quote_in_filename"]["status_message"].startswith(
-        "Waiting on dependencies"
-    )
-    assert jobs["analyse_data"]["status_message"].startswith("Waiting on dependencies")
+    for action in [
+        "prepare_data_m",
+        "prepare_data_f",
+        "prepare_data_with_quote_in_filename",
+        "analyse_data",
+        "test_cancellation",
+    ]:
+        assert jobs[action]["status_message"].startswith("Waiting on dependencies")
 
-    # Request a job to be cancelled and then sync
-    job_request["cancelled_actions"] = ["test_cancellation"]
+    # Update the existing job request to mark a job as cancelled, add a new job
+    # request to be run and then sync
+    job_request_1["cancelled_actions"] = ["test_cancellation"]
+    job_request_2 = {
+        "identifier": 2,
+        "requested_actions": [
+            "generate_cohort_with_dummy_data",
+        ],
+        "cancelled_actions": [],
+        "force_run_dependencies": False,
+        "workspace": {
+            "name": "testing",
+            "repo": str(repo_path),
+            "branch": "HEAD",
+            "db": "dummy",
+        },
+    }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",
         json={
-            "results": [job_request],
+            "results": [job_request_1, job_request_2],
         },
     )
     jobrunner.sync.sync()
 
     # Run the main loop to completion and then sync
     jobrunner.run.main(exit_when_done=True)
+    jobrunner.sync.sync()
 
+    # All jobs should now have succeeded apart from the cancelled one
+    jobs = get_posted_jobs(requests_mock)
+    assert jobs["generate_cohort"]["status"] == "succeeded"
+    assert jobs["generate_cohort_with_dummy_data"]["status"] == "succeeded"
+    assert jobs["prepare_data_m"]["status"] == "succeeded"
+    assert jobs["prepare_data_f"]["status"] == "succeeded"
+    assert jobs["prepare_data_with_quote_in_filename"]["status"] == "succeeded"
+    assert jobs["analyse_data"]["status"] == "succeeded"
+    assert jobs["test_cancellation"]["status"] == "failed"
+
+    # Check that the manfiest contains what we expect
     manifest_file = (
         tmp_work_dir
         / "medium_privacy_workspaces_dir"
@@ -118,17 +145,6 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
             "output/extra/input.csv",
         ]
     )
-
-    jobrunner.sync.sync()
-    # All jobs should now have succeeded apart from the cancelled one
-    jobs = get_posted_jobs(requests_mock)
-    assert jobs["generate_cohort"]["status"] == "succeeded"
-    assert jobs["generate_cohort_with_dummy_data"]["status"] == "succeeded"
-    assert jobs["prepare_data_m"]["status"] == "succeeded"
-    assert jobs["prepare_data_f"]["status"] == "succeeded"
-    assert jobs["prepare_data_with_quote_in_filename"]["status"] == "succeeded"
-    assert jobs["analyse_data"]["status"] == "succeeded"
-    assert jobs["test_cancellation"]["status"] == "failed"
 
 
 def commit_directory_contents(repo_path, directory):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -60,7 +60,7 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
     jobs = get_posted_jobs(requests_mock)
     assert [job["status"] for job in jobs.values()] == ["pending"] * 6
     # Exectue one tick of the run loop and then sync
-    jobrunner.run.handle_jobs()
+    jobrunner.run.handle_jobs(shuffle_jobs=False)
     jobrunner.sync.sync()
     # We should now have one running job and five waiting on dependencies
     jobs = get_posted_jobs(requests_mock)
@@ -100,7 +100,7 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
     jobrunner.sync.sync()
 
     # Run the main loop to completion and then sync
-    jobrunner.run.main(exit_when_done=True)
+    jobrunner.run.main(exit_when_done=True, shuffle_jobs=False)
     jobrunner.sync.sync()
 
     # All jobs should now have succeeded apart from the cancelled one


### PR DESCRIPTION
The addition of the `generate_cohort_with_dummy_data` action made the dependency graph no longer have a single root. Combined with the job order randomisation that we apply this made it non-deterministic which job was started first which made the test intermittently fail.

This PR disables job order randomisation during the test and slightly refactors how the behaviour of the main `run` loop is configured.

It also re-organises the test to restore the single graph root and hopefully make things clearer.