### PR TITLE
Validate image names for reusable actions

### DIFF
--- a/jobrunner/github_validators.py
+++ b/jobrunner/github_validators.py
@@ -1,0 +1,56 @@
+from .git import commit_reachable_from_ref
+
+from urllib.parse import urlparse
+
+
+class GithubValidationError(Exception):
+    pass
+
+
+def validate_repo_url(repo_url, allowed_gitub_orgs):
+    parsed_url = urlparse(repo_url)
+    if parsed_url.scheme != "https" or parsed_url.netloc != "github.com":
+        raise GithubValidationError("Repository URLs must start https://github.com")
+    path = parsed_url.path.strip("/").split("/")
+    if not path or path[0] not in allowed_gitub_orgs:
+        raise GithubValidationError(
+            f"Repositories must belong to one of the following Github "
+            f"organisations: {' '.join(allowed_gitub_orgs)}"
+        )
+    expected_url = f"https://github.com/{'/'.join(path[:2])}"
+    if repo_url.rstrip("/") != expected_url or len(path) != 2:
+        raise GithubValidationError(
+            "Repository URL was not of the expected format: "
+            "https://github.com/[organisation]/[project-name]"
+        )
+
+
+def validate_branch_and_commit(repo_url, commit, branch):
+    """
+    Due to the way Github works, anyone who can open a pull request against a
+    repository can make a commit appear to be "in" that repository, even if
+    they do not have write access to it.
+
+    For example, someone created this PR against the Linux kernel:
+    https://github.com/torvalds/linux/pull/437
+
+    And even though this will never be merged, it still appears as a commit in
+    that repo:
+    https://github.com/torvalds/linux/commit/2793ae1df012c7c3f13ea5c0f0adb99017999c3b
+
+    If we are enforcing that only code from certain organisations can be run
+    then we need to check that any commits supplied have been made by someone
+    with write access to the repository, which means we need to check they
+    belong to a branch or tag in the repository.
+    """
+    if not branch:
+        raise GithubValidationError("A branch name must be supplied")
+    # A further wrinkle is that each PR gets an associated ref within the repo
+    # of the form `pull/PR_NUMBER/head`. So we enforce that the branch name
+    # must be a "plain vanilla" branch name with no slashes.
+    if "/" in branch:
+        raise GithubValidationError(f"Branch name must not contain slashes: {branch}")
+    if not commit_reachable_from_ref(repo_url, commit, branch):
+        raise GithubValidationError(
+            f"Could not find commit on branch '{branch}': {commit}"
+        )

--- a/jobrunner/project.py
+++ b/jobrunner/project.py
@@ -70,6 +70,13 @@ class ActionSpecifiction:
     commit: str
 
 
+@dataclasses.dataclass
+class ReusableAction:
+    repo_url: str
+    commit: str
+    action_file: bytes
+
+
 def parse_yaml_file(yaml_file):
     try:
         # We're using the pure-Python version here as we don't care about speed
@@ -127,7 +134,28 @@ def handle_reusable_action(action_id, action):
         # This isn't a reusable action.
         return action
 
-    # This is a reusable action.
+    reusable_action = fetch_reusable_action(action_id, image, tag)
+    new_action = apply_reusable_action(action_id, action, reusable_action)
+    return new_action
+
+
+def fetch_reusable_action(action_id, image, tag):
+    """
+    Fetch all metadata from git needed to apply a reusable action
+
+    Args:
+        action_id: The action's ID as a string. This is the action's key in
+            project.yaml. It is used to raise errors with more informative messages.
+        image: The name of the reusable action
+        tag: The specified version of the reusable action
+
+    Returns:
+        ReusableAction object, wrapping the repo_url, commit and the contents
+        of the `action.yaml` file
+
+    Raises:
+        ReusableActionError: An error occurred when accessing the reusable action.
+    """
     repo_url = f"{config.ACTIONS_GITHUB_ORG_URL}/{image}"
     try:
         validate_repo_url(repo_url, [config.ACTIONS_GITHUB_ORG])
@@ -137,35 +165,65 @@ def handle_reusable_action(action_id, action):
     try:
         # If there's a problem, then it relates to the repository. Maybe the study
         # developer made an error; maybe the reusable action developer made an error.
-        commit_sha = git.get_sha_from_remote_ref(repo_url, tag)
+        commit = git.get_sha_from_remote_ref(repo_url, tag)
     except git.GitError:
         raise ReusableActionError(
             f"Cannot resolve '{action_id}' to a repository at '{repo_url}'"
         )
 
     try:
-        validate_branch_and_commit(repo_url, commit_sha, "main")
+        validate_branch_and_commit(repo_url, commit, "main")
     except GithubValidationError as e:
         raise ReusableActionError(*e.args)
 
     try:
         # If there's a problem, then it relates to the reusable action. The study
         # developer didn't make an error; the reusable action developer did.
-        action_file = git.read_file_from_repo(repo_url, commit_sha, "action.yaml")
-        action_config = parse_yaml_file(action_file)
+        action_file = git.read_file_from_repo(repo_url, commit, "action.yaml")
+    except git.GitError:
+        raise ReusableActionError(
+            f"There is a problem with the reusable action required by '{action_id}'"
+        )
+
+    return ReusableAction(repo_url=repo_url, commit=commit, action_file=action_file)
+
+
+def apply_reusable_action(action_id, action, reusable_action):
+    """
+    Rewrite an `action` dict to run the code specifed by the supplied
+    `ReusableAction` instance.
+
+    Args:
+        action_id: The action's ID as a string. This is the action's key in
+            project.yaml. It is used to raise errors with more informative messages.
+        action: The action's representation as a dict. This is the action's value in
+            project.yaml.
+        reusable_action: A ReusableAction instance
+
+    Returns:
+        The modified action's representation as a dict.
+
+    Raises:
+        ReusableActionError: An error occurred when accessing the reusable action.
+    """
+    try:
+        # If there's a problem, then it relates to the reusable action. The study
+        # developer didn't make an error; the reusable action developer did.
+        action_config = parse_yaml_file(reusable_action.action_file)
         assert "run" in action_config
-    except (git.GitError, ProjectYAMLError, AssertionError):
+    except (ProjectYAMLError, AssertionError):
         raise ReusableActionError(
             f"There is a problem with the reusable action required by '{action_id}'"
         )
 
     # ["action:tag", "arg", ...] -> ["runtime:tag binary entrypoint", "arg", ...]
+    run_args = shlex.split(action["run"])
     run_args[0] = action_config["run"]
 
     new_action = action.copy()
     new_action["run"] = " ".join(run_args)
-    new_action["repo_url"] = repo_url
-    new_action["commit"] = commit_sha
+    new_action["repo_url"] = reusable_action.repo_url
+    new_action["commit"] = reusable_action.commit
     return new_action
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from jobrunner import create_or_update_jobs, git, project
+from jobrunner import git, project
 from jobrunner.project import (
     parse_and_validate_project_file,
     ProjectValidationError,
@@ -92,8 +92,8 @@ class TestHandleReusableAction:
             )
 
     @mock.patch(
-        "jobrunner.create_or_update_jobs.validate_branch_and_commit",
-        side_effect=create_or_update_jobs.JobRequestError,
+        "jobrunner.project.validate_branch_and_commit",
+        side_effect=project.GithubValidationError,
     )
     def test_with_bad_commit(self, *args, **kwargs):
         with pytest.raises(project.ReusableActionError):


### PR DESCRIPTION
This ensures that reusable actions have valid images names, and also prohibits them from invoking data extracts. In theory we could allow these, but we know of no valid use case for that at present and limiting the powers of reusable actions seems sensible.

This PR also moves some common validation code into its own module to avoid circular import problems, and splits out the git-related and non-git-related parts of the "handle" function so we can test independently without needing to mock.