### PR TITLE
Dereference annotated tags

### DIFF
--- a/jobrunner/git.py
+++ b/jobrunner/git.py
@@ -3,15 +3,14 @@ Utility functions for interacting with git
 """
 import logging
 import os
-from pathlib import Path, PurePath
 import subprocess
 import time
+from pathlib import Path, PurePath
 from urllib.parse import urlparse, urlunparse
 
 from . import config
 from .string_utils import project_name_from_url
 from .subprocess_utils import subprocess_run
-
 
 log = logging.getLogger(__name__)
 

--- a/jobrunner/git.py
+++ b/jobrunner/git.py
@@ -101,13 +101,19 @@ def commit_reachable_from_ref(repo_url, commit_sha, ref):
 
 
 def get_sha_from_remote_ref(repo_url, ref):
-    """
-    Given a `ref` (branch name, tag, etc) on a remote repo, turn it into a
-    commit SHA.
+    """Gets the SHA of the ref at the repo URL.
 
-    In future we might not need this as the job-server should only supply us
-    with SHAs, but for now we want to be able to accept branch names and
-    transform them into SHAs.
+    Args:
+        repo_url: A repo URL.
+        ref: A ref, such as a branch name, tag name, etc.
+
+    Returns:
+        A SHA, although this won't always be a commit SHA; it depends on the ref. For
+        example, if the ref is an annotated tag, then the SHA will be a tag SHA; if the
+        ref is a lightweight tag, then the SHA will be a commit SHA.
+
+    Raises:
+        GitError: An error occurred when getting the SHA.
     """
     try:
         response = subprocess_run(

--- a/jobrunner/git.py
+++ b/jobrunner/git.py
@@ -139,19 +139,15 @@ def get_sha_from_remote_ref(repo_url, ref):
         log.exception("Error resolving remote git ref")
         output = ""
     results = _parse_ls_remote_output(output)
-    if len(results) == 1:
-        return list(results.values())[0]
-    elif len(results) > 1:
-        # Where we have more than one match, but there is either an exact match
-        # or a match for a local branch then use that result. (This happens
-        # when using local repos where there are references to both the local
-        # and remote branches.)
-        for target_ref in [ref, f"refs/heads/{ref}", f"refs/tags/{deref_ref}"]:
-            if target_ref in results:
-                return results[target_ref]
-        raise GitError(f"Ambiguous ref '{ref}' in {repo_url}")
-    else:
-        raise GitError(f"Error resolving ref '{ref}' from {repo_url}")
+    for target_ref in [
+        ref,  # e.g. HEAD
+        f"refs/heads/{ref}",  # Branch
+        f"refs/tags/{deref_ref}",  # Annotated tag
+        f"refs/tags/{ref}",  # Lightweight tag
+    ]:
+        if target_ref in results:
+            return results[target_ref]
+    raise GitError(f"Error resolving ref '{ref}' from {repo_url}")
 
 
 def _parse_ls_remote_output(output):

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -48,6 +48,15 @@ def test_get_sha_from_remote_ref(tmp_work_dir):
 
 
 @pytest.mark.slow_test
+def test_get_sha_from_remote_ref_annotated_tag():
+    sha = get_sha_from_remote_ref(
+        "https://github.com/opensafely-core/test-public-repository.git",
+        "test-annotated-tag-dont-delete",
+    )
+    assert sha == "3c15ff525001e039d4e27cfc62f652ecad09fde4"
+
+
+@pytest.mark.slow_test
 def test_commit_reachable_from_ref(tmp_work_dir):
     is_reachable_good = commit_reachable_from_ref(
         "https://github.com/opensafely-core/test-public-repository.git",


### PR DESCRIPTION
Previously, if `get_sha_from_remote_ref` was passed a ref that resolved to [an annotated tag](http://git-scm.com/book/en/v2/Git-Basics-Tagging), then it would return the SHA of the annotated tag and not of the associated commit. This was a pain, because we tend to assume that SHAs are commit SHAs and not tag SHAs; for example, when checking that a branch ref is an ancestor of a commit ref.

This PR ensures that if `get_sha_from_remote_ref` is passed a ref that resolves to an annotated tag, then it returns the SHA of the associated commit.