### PR TITLE
Refactor job creation to remove db access

### DIFF
--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -19,12 +19,7 @@ from .database import (
     transaction,
     update_where,
 )
-from .git import (
-    GitError,
-    GitFileNotFoundError,
-    get_sha_from_remote_ref,
-    read_file_from_repo,
-)
+from .git import GitError, GitFileNotFoundError, read_file_from_repo
 from .github_validators import (
     GithubValidationError,
     validate_branch_and_commit,
@@ -96,18 +91,6 @@ def related_jobs_exist(job_request):
 
 def create_jobs(job_request):
     validate_job_request(job_request)
-    # In future I expect the job-server to only ever supply commits and so this
-    # branch resolution will be redundant
-
-    # job_request.commit will be:
-    # 1. None when in local run mode
-    # 2. None when not in local run mode and job-server didn't supply a commit
-    # 3. A non-empty string when not in local run mode and job-server supplied a commit
-    # Are we 2?
-    if not job_request.commit and not config.LOCAL_RUN_MODE:
-        job_request.commit = get_sha_from_remote_ref(
-            job_request.repo_url, job_request.branch
-        )
     try:
         if not config.LOCAL_RUN_MODE:
             project_file = read_file_from_repo(

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -23,7 +23,6 @@ from .models import Job, SavedJobRequest, State
 from .project import (
     RUN_ALL_COMMAND,
     ProjectValidationError,
-    assert_valid_actions,
     get_action_specification,
     get_all_actions,
     parse_and_validate_project_file,
@@ -103,7 +102,6 @@ def create_jobs(job_request):
 
 def create_jobs_with_project_file(job_request, project_file):
     project = parse_and_validate_project_file(project_file)
-    assert_valid_actions(project, job_request.requested_actions)
 
     active_jobs = get_active_jobs_for_workpace(job_request.workspace)
     new_jobs = get_jobs_to_run(job_request, project, active_jobs)
@@ -260,6 +258,8 @@ def validate_job_request(job_request):
         validate_repo_url(job_request.repo_url, config.ALLOWED_GITHUB_ORGS)
     if not job_request.workspace:
         raise JobRequestError("Workspace name cannot be blank")
+    if not job_request.requested_actions:
+        raise JobRequestError("At least one action must be supplied")
     # In local run mode the workspace name is whatever the user's working
     # directory happens to be called, which we don't want or need to place any
     # restrictions on. Otherwise, as these are externally supplied strings that

--- a/jobrunner/project.py
+++ b/jobrunner/project.py
@@ -568,13 +568,3 @@ def assert_valid_glob_pattern(pattern):
     # for both platforms
     if PurePosixPath(pattern).is_absolute() or PureWindowsPath(pattern).is_absolute():
         raise InvalidPatternError("is an absolute path")
-
-
-def assert_valid_actions(project, actions):
-    if not actions:
-        raise UnknownActionError("At least one action must be supplied", project)
-    for action in actions:
-        if action != RUN_ALL_COMMAND and action not in project["actions"]:
-            raise UnknownActionError(
-                f"Action '{action}' not found in project.yaml", project
-            )

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -99,7 +99,7 @@ def job_request_from_remote_format(job_request):
     return JobRequest(
         id=str(job_request["identifier"]),
         repo_url=job_request["workspace"]["repo"],
-        commit=job_request.get("sha"),
+        commit=job_request["sha"],
         branch=job_request["workspace"]["branch"],
         requested_actions=job_request["requested_actions"],
         cancelled_actions=job_request["cancelled_actions"],

--- a/tests/test_create_or_update_jobs.py
+++ b/tests/test_create_or_update_jobs.py
@@ -24,7 +24,8 @@ def test_create_or_update_jobs(tmp_work_dir):
     job_request = JobRequest(
         id="123",
         repo_url=repo_url,
-        commit=None,
+        # GIT_DIR=tests/fixtures/git-repo git rev-parse v1
+        commit="d1e88b31cbe8f67c58f938adb5ee500d54a69764",
         branch="v1",
         requested_actions=["generate_cohort"],
         cancelled_actions=[],
@@ -59,11 +60,12 @@ def test_create_or_update_jobs(tmp_work_dir):
 # Basic smoketest to test the error path
 def test_create_or_update_jobs_with_git_error(tmp_work_dir):
     repo_url = str(Path(__file__).parent.resolve() / "fixtures/git-repo")
+    bad_commit = "0" * 40
     job_request = JobRequest(
         id="123",
         repo_url=repo_url,
-        commit=None,
-        branch="no-such-branch",
+        commit=bad_commit,
+        branch="v1",
         requested_actions=["generate_cohort"],
         cancelled_actions=[],
         workspace="1",
@@ -77,7 +79,7 @@ def test_create_or_update_jobs_with_git_error(tmp_work_dir):
     assert j.job_request_id == "123"
     assert j.state == State.FAILED
     assert j.repo_url == repo_url
-    assert j.commit == None
+    assert j.commit == bad_commit
     assert j.workspace == "1"
     assert j.wait_for_job_ids == None
     assert j.requires_outputs_from == None
@@ -85,7 +87,7 @@ def test_create_or_update_jobs_with_git_error(tmp_work_dir):
     assert j.output_spec == None
     assert (
         j.status_message
-        == f"GitError: Error resolving ref 'no-such-branch' from {repo_url}"
+        == f"GitError: Error fetching commit {bad_commit} from {repo_url}"
     )
 
 
@@ -178,7 +180,8 @@ def test_validate_job_request(params, exc_msg, monkeypatch):
     kwargs = dict(
         id="123",
         repo_url=repo_url,
-        commit=None,
+        # GIT_DIR=tests/fixtures/git-repo git rev-parse v1
+        commit="d1e88b31cbe8f67c58f938adb5ee500d54a69764",
         branch="v1",
         requested_actions=["generate_cohort"],
         cancelled_actions=[],

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -14,11 +14,12 @@ def test_job_request_from_remote_format():
         "requested_actions": ["generate_cohort"],
         "cancelled_actions": ["analyse"],
         "force_run_dependencies": True,
+        "sha": "abcdef",
     }
     expected = JobRequest(
         id="123",
         repo_url="https://github.com/opensafely/foo",
-        commit=None,
+        commit="abcdef",
         branch="master",
         workspace="testing",
         database_name="full",


### PR DESCRIPTION
This refactors the job creation and dependency resolution logic so it is no longer intertwined with database access and so it no longer needs to run within a transaction. As well as making the code clearer (I think) this means we can now do expensive operations like pulling from Docker or fetching from Github after we've worked out what we're going to run but before we written anything to the database or opened a transaction.
