### PR TITLE
Clean up Stata cruft

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on: [push]
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PRIVATE_REPO_ACCESS_TOKEN: ${{ secrets.ACTIONS_PRIVATE_REPO_RO_TOKEN }}
+  STATA_LICENSE: ${{ secrets.STATA_LICENSE }}
 jobs:
   test-job:
     runs-on: ubuntu-latest

--- a/tests/test_local_run.py
+++ b/tests/test_local_run.py
@@ -36,7 +36,7 @@ def test_local_run_stata(tmp_path, monkeypatch):
     monkeypatch.setattr("jobrunner.config.STATA_LICENSE", os.environ["STATA_LICENSE"])
     local_run.main(project_dir=project_dir, actions=["stata"])
     env_file = project_dir / "output/env.txt"
-    assert "University of Oxford" in env_file.read_text()
+    assert "Bennett Institute" in env_file.read_text()
 
 
 @pytest.fixture


### PR DESCRIPTION
Get rid of the "temporary workaround" function, enforce the presence of the license and ensure we test it properly in CI.