### PR TITLE
Record reusable actions in manifest

### DIFF
--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -205,19 +205,16 @@ def recursively_build_jobs(jobs_by_action, job_request, project, action):
         if required_job is not NULL_JOB:
             wait_for_job_ids.append(required_job.id)
 
-    # If action_spec (an instance of ActionSpecifiction) represents a reusable action,
-    # then it will have non-None values for the following attributes.
-    repo_url = action_spec.repo_url if action_spec.repo_url else job_request.repo_url
-    commit = action_spec.commit if action_spec.commit else job_request.commit
-
     job = Job(
         job_request_id=job_request.id,
         state=State.PENDING,
-        repo_url=repo_url,
-        commit=commit,
+        repo_url=job_request.repo_url,
+        commit=job_request.commit,
         workspace=job_request.workspace,
         database_name=job_request.database_name,
         action=action,
+        action_repo_url=action_spec.repo_url,
+        action_commit=action_spec.commit,
         wait_for_job_ids=wait_for_job_ids,
         requires_outputs_from=action_spec.needs,
         run_command=action_spec.run,

--- a/jobrunner/manage_jobs.py
+++ b/jobrunner/manage_jobs.py
@@ -410,6 +410,8 @@ def write_log_file(job, job_metadata, filename):
             "state",
             "commit",
             "docker_image_id",
+            "action_repo_url",
+            "action_commit",
             "exit_code",
             "job_id",
             "run_by_user",
@@ -417,6 +419,8 @@ def write_log_file(job, job_metadata, filename):
             "started_at",
             "completed_at",
         ]:
+            if not job_metadata[key]:
+                continue
             f.write(f"{key}: {job_metadata[key]}\n")
         f.write(f"\n{job_metadata['status_message']}\n")
         if job.unmatched_outputs:
@@ -583,11 +587,14 @@ def update_manifest(manifest, job_metadata):
             "state",
             "commit",
             "docker_image_id",
+            "action_repo_url",
+            "action_commit",
             "job_id",
             "run_by_user",
             "created_at",
             "completed_at",
         ]
+        if job_metadata[key] is not None
     }
 
 

--- a/jobrunner/manage_jobs.py
+++ b/jobrunner/manage_jobs.py
@@ -36,6 +36,21 @@ METADATA_DIR = "metadata"
 # Records details of which action created each file
 MANIFEST_FILE = "manifest.json"
 
+# Keys of fields to log in manifest.json and log file
+KEYS_TO_LOG = [
+    "state",
+    "commit",
+    "docker_image_id",
+    "action_repo_url",
+    "action_commit",
+    "job_id",
+    "run_by_user",
+    "created_at",
+    "completed_at",
+    "exit_code",
+]
+
+
 # This is a Docker label applied in addition to the default label which
 # `docker.py` applies to all containers and volumes it creates. It allows us to
 # easily identify just the containers actually used for running jobs, which is
@@ -406,19 +421,7 @@ def write_log_file(job, job_metadata, filename):
     outputs = sorted(job_metadata["outputs"].items())
     with open(filename, "a") as f:
         f.write("\n\n")
-        for key in [
-            "state",
-            "commit",
-            "docker_image_id",
-            "action_repo_url",
-            "action_commit",
-            "exit_code",
-            "job_id",
-            "run_by_user",
-            "created_at",
-            "started_at",
-            "completed_at",
-        ]:
+        for key in KEYS_TO_LOG:
             if not job_metadata[key]:
                 continue
             f.write(f"{key}: {job_metadata[key]}\n")
@@ -582,19 +585,7 @@ def update_manifest(manifest, job_metadata):
     # so actions end up in the order they were run
     manifest["actions"].pop(action, None)
     manifest["actions"][action] = {
-        key: job_metadata[key]
-        for key in [
-            "state",
-            "commit",
-            "docker_image_id",
-            "action_repo_url",
-            "action_commit",
-            "job_id",
-            "run_by_user",
-            "created_at",
-            "completed_at",
-        ]
-        if job_metadata[key] is not None
+        key: job_metadata[key] for key in KEYS_TO_LOG if job_metadata[key] is not None
     }
 
 

--- a/jobrunner/manage_jobs.py
+++ b/jobrunner/manage_jobs.py
@@ -144,11 +144,13 @@ def create_and_populate_volume(job):
     # `docker cp` can't create parent directories for us so we make sure all
     # these directories get created when we copy in the code
     extra_dirs = set(Path(filename).parent for filename in input_files.keys())
-    # If job represents a reusable action, then job.commit will be non-None and we need
-    # to copy it to the volume whether or not we're in local development mode.
-    if config.LOCAL_RUN_MODE and not job.commit:
+    if config.LOCAL_RUN_MODE and not job.action_commit:
+        # We're in local run mode and we're not running a reusable action, so we need to
+        # copy the workspace to a volume.
         copy_local_workspace_to_volume(volume, workspace_dir, extra_dirs)
     else:
+        # We're either not in local run mode or we're running a reusable action, so we
+        # need to copy a git commit to a volume.
         repo_url = job.action_repo_url or job.repo_url
         commit = job.action_commit or job.commit
         copy_git_commit_to_volume(volume, repo_url, commit, extra_dirs)

--- a/jobrunner/manage_jobs.py
+++ b/jobrunner/manage_jobs.py
@@ -134,7 +134,9 @@ def create_and_populate_volume(job):
     if config.LOCAL_RUN_MODE and not job.commit:
         copy_local_workspace_to_volume(volume, workspace_dir, extra_dirs)
     else:
-        copy_git_commit_to_volume(volume, job.repo_url, job.commit, extra_dirs)
+        repo_url = job.action_repo_url or job.repo_url
+        commit = job.action_commit or job.commit
+        copy_git_commit_to_volume(volume, repo_url, commit, extra_dirs)
 
     for filename, action in input_files.items():
         log.info(f"Copying input file {action}: {filename}")

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -84,6 +84,10 @@ class Job:
     # Name of the action (one of the keys in the `actions` dict in
     # project.yaml)
     action: str = None
+    # URL of git repository for action (None if action is not reusable)
+    action_repo_url: str = None
+    # Full SHA of commit in action repo (None if action is not reusable)
+    action_commit: str = None
     # List of action names whose outputs need to be used as inputs to this
     # action
     requires_outputs_from: list = None

--- a/jobrunner/schema.sql
+++ b/jobrunner/schema.sql
@@ -16,6 +16,8 @@ CREATE TABLE job (
     workspace TEXT,
     database_name TEXT,
     action TEXT,
+    action_repo_url TEXT,
+    action_commit TEXT,
     requires_outputs_from TEXT,
     wait_for_job_ids TEXT,
     run_command TEXT,

--- a/tests/test_manage_jobs.py
+++ b/tests/test_manage_jobs.py
@@ -54,8 +54,9 @@ class TestCreateAndPopulateVolume:
     def reusable_action_job(self):
         """Returns a minimal Job instance that represents a reusable action."""
         return models.Job(
-            repo_url="opensafely-actions/my-reusable-action",
-            commit="the-sha-for-this-commit",
+            repo_url="opensafely/my-study",
+            action_repo_url="opensafely-actions/my-reusable-action",
+            action_commit="the-sha-for-this-commit",
             requires_outputs_from=[],
             workspace="output",
         )


### PR DESCRIPTION
THIS REQUIRES A DATABASE MIGRATION, SO ANY DEPLOY NEEDS BABYSITTING.

There are no existing tests for what gets logged and stored in manifest.json, so I haven't added any new tests here.

Fixes #236.