### PR TITLE
Further refactoring of `create_job`

### DIFF
--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -70,11 +70,8 @@ def create_or_update_jobs(job_request):
     else:
         if job_request.cancelled_actions:
             log.debug("Cancelling actions: %s", job_request.cancelled_actions)
-            update_where(
-                Job,
-                {"cancelled": True},
-                job_request_id=job_request.id,
-                action__in=job_request.cancelled_actions,
+            set_cancelled_flag_for_actions(
+                job_request.id, job_request.cancelled_actions
             )
         else:
             log.debug("Ignoring already processed JobRequest")
@@ -82,6 +79,15 @@ def create_or_update_jobs(job_request):
 
 def related_jobs_exist(job_request):
     return exists_where(Job, job_request_id=job_request.id)
+
+
+def set_cancelled_flag_for_actions(job_request_id, actions):
+    update_where(
+        Job,
+        {"cancelled": True},
+        job_request_id=job_request_id,
+        action__in=actions,
+    )
 
 
 def create_jobs(job_request):

--- a/tests/test_create_or_update_jobs.py
+++ b/tests/test_create_or_update_jobs.py
@@ -1,11 +1,12 @@
 import uuid
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
 from jobrunner.create_or_update_jobs import (
     JobRequestError,
-    create_jobs_with_project_file,
+    create_jobs,
     create_or_update_jobs,
     validate_job_request,
 )
@@ -210,3 +211,9 @@ def make_job_request(action="generate_cohort", **kwargs):
     for key, value in kwargs.items():
         setattr(job_request, key, value)
     return job_request
+
+
+def create_jobs_with_project_file(job_request, project_file):
+    with mock.patch("jobrunner.create_or_update_jobs.get_project_file") as f:
+        f.return_value = project_file
+        return create_jobs(job_request)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -10,8 +10,21 @@ import pytest
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="tricky to do ctrl-c in windows"
 )
-def test_service_main():
-    p = subprocess.Popen([sys.executable, "-m", "jobrunner.service"])
+def test_service_main(tmp_path):
+    """
+    Test that the service module handles SIGINT and exits cleanly
+    """
+    p = subprocess.Popen(
+        [sys.executable, "-m", "jobrunner.service"],
+        # For the purposes of this test we don't care if we can actually talk
+        # to the job-server endpoint, so to avoid spamming the real job-server
+        # we just point it to a "reserved for future use" IP4 block which hangs
+        # nicely as we want.
+        env={
+            "WORK_DIR": str(tmp_path),
+            "JOB_SERVER_ENDPOINT": "https://240.0.0.1",
+        },
+    )
     assert p.returncode is None
     time.sleep(3)
     p.send_signal(signal.SIGINT)


### PR DESCRIPTION
This refactors the job creation process to do all disk access upfront in
a single batch, as we now already do for database access.

This means that the bulk of the job creation logic is now in a pure
function which takes a list of current jobs and returns a list of new
jobs.

As well as being a general structural improvement this paves the way for
support something other than local disk as the primary data store.