### PR TITLE
Remove need for LOCAL_RUN_MODE flag

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -107,9 +107,6 @@ MAX_WORKERS = int(os.environ.get("MAX_WORKERS") or max(cpu_count() - 1, 1))
 # locally
 RANDOMISE_JOB_ORDER = True
 
-# See `local_run.py` for more detail
-LOCAL_RUN_MODE = False
-
 # Automatically delete containers and volumes after they have been used
 CLEAN_UP_DOCKER_OBJECTS = True
 

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -90,6 +90,10 @@ def create_or_update_jobs(job_request):
 
 
 def create_jobs(job_request):
+    # NOTE: Similar but non-identical logic is implemented for running jobs
+    # locally in `jobrunner.cli.local_run.create_job_request_and_jobs`. If you
+    # make changes below then consider what the appropriate corresponding
+    # changes are for locally run jobs.
     validate_job_request(job_request)
     project_file = get_project_file(job_request)
     project = parse_and_validate_project_file(project_file)

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -72,7 +72,7 @@ class Job:
     id: str = None
     job_request_id: str = None
     state: State = None
-    # Git repository URL (may be a local path in LOCAL_RUN_MODE)
+    # Git repository URL
     repo_url: str = None
     # Full commit sha
     commit: str = None


### PR DESCRIPTION
Rather than having production and local_run share a single codepath peppered with switches on `config.LOCAL_RUN_MODE` we provide a separate `create_jobs` implementation for local_run, and use common functions to share common behaviour.

This simplifies the code overall, and makes it easier to further customise behaviour between the two execution modes (e.g. to support automatically pulling new docker images in production, but only warning about available updates in local_run). 