### PR TITLE
fix: Fix handling for "frozen" containers

### DIFF
--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -13,6 +13,7 @@ from jobrunner import config
 from jobrunner.lib.database import find_where, select_values, update
 from jobrunner.lib.log_utils import configure_logging, set_log_context
 from jobrunner.manage_jobs import (
+    BrokenContainerError,
     JobError,
     cleanup_job,
     finalise_job,
@@ -86,7 +87,10 @@ def handle_pending_job(job):
                 start_job(job)
             except JobError as exception:
                 mark_job_as_failed(job, exception)
-                cleanup_job(job)
+                # See the `raise` in manage_jobs which explains why we can't
+                # cleanup on this specific error
+                if not isinstance(exception, BrokenContainerError):
+                    cleanup_job(job)
             except Exception:
                 mark_job_as_failed(job, "Internal error when starting job")
                 cleanup_job(job)


### PR DESCRIPTION
Containers which get themselves into this frozen/broken state can't be
cleaned up because any attempt to interact with them hangs indefinitely.
We used not to try, but we've since changed the cleanup logic due to
disk space issues so we now need an explicit guard to prevent the
cleanup (this is better practice anyway).

On the upside, we haven't noticed this bug because we haven't hit the
frozen container issue in quite a while!