### PR TITLE
feat: initial api support

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -169,3 +169,7 @@ if STATS_DATABASE_FILE:
     STATS_DATABASE_FILE = Path(STATS_DATABASE_FILE)
 
 STATS_POLL_INTERVAL = float(os.environ.get("STATS_POLL_INTERVAL", "10"))
+
+
+# feature flag to enable new API abstraction
+EXECUTION_API = os.environ.get("EXECUTION_API", "false").lower() == "true"

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -27,7 +27,9 @@ class JobDefinition:
     args: List[str]  # the arguments to pass to the Docker container
     env: Mapping[str, str]  # the environment variables to set for the Docker container
     inputs: List[str]  # the files that the job requires
-    output_spec: Mapping[str, str]  # the files that the job should produce (globs mapped to privacy levels)
+    output_spec: Mapping[
+        str, str
+    ]  # the files that the job should produce (globs mapped to privacy levels)
     allow_database_access: bool  # whether this job should have access to the database
 
 
@@ -108,7 +110,7 @@ class JobAPI(Protocol):
 
             Raises:
                 JobError: if there is a problem retrieving the status of the job
-         """
+        """
         ...
 
     def cleanup(self, job: JobDefinition) -> None:
@@ -134,8 +136,6 @@ class WorkspaceAPI(Protocol):
         This method must be idempotent; if any of the files specified doesn't exist then it must ignore them.
         """
         ...
-
-
 
 
 class NullJobAPI(JobAPI):
@@ -165,6 +165,3 @@ def get_job_api():
 
 def get_workspace_api():
     return NullWorkspaceAPI()
-
-
-

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -100,6 +100,8 @@ class JobAPI(Protocol):
         irreversible cleanup which loses information about must be deferred to JobAPI.cleanup() which will only be
         called once the results have been persisted.
 
+        If no matching job can be found, it should raise a JobError exception.
+
         The results must include a list of output files that the job produced which matched its output spec. It
         should also include a list of files that it produced but which did not match the output spec,
         to aid in debugging during study development.

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Protocol, Mapping, List, Tuple, Optional
+from typing import Mapping, List, Tuple, Optional
 
 from jobrunner.models import State, StatusCode
 from jobrunner import config
@@ -43,7 +43,7 @@ class JobResults:
     image_id: str
 
 
-class JobAPI(Protocol):
+class JobAPI:
     def run(self, job: JobDefinition) -> None:
         """
         Run a job.
@@ -132,7 +132,7 @@ class JobAPI(Protocol):
         ...
 
 
-class WorkspaceAPI(Protocol):
+class WorkspaceAPI:
     def delete_files(self, workspace: str, privacy: Privacy, paths: [str]):
         """
         Delete files from a workspace.
@@ -158,7 +158,7 @@ class NullJobAPI(JobAPI):
         raise NotImplemented
 
 
-class NullWorkspaceAPI(Protocol):
+class NullWorkspaceAPI:
     def delete_files(self, workspace: str, privacy: Privacy, paths: [str]):
         raise NotImplemented
 

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -1,0 +1,170 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, Mapping, List, Tuple, Optional
+
+from jobrunner.models import State, StatusCode
+from jobrunner import config
+
+
+class Privacy(Enum):
+    HIGH = "high"
+    MEDIUM = "medium"
+
+
+@dataclass
+class Study:
+    git_repo_url: str
+    commit: str
+
+
+@dataclass
+class JobDefinition:
+    id: str  # a unique identifier for the job
+    study: Study  # the study defining the action for this job
+    workspace: str  # the workspace to run the job in
+    action: str  # the name of the action that the job is running
+    image: str  # the Docker image to run
+    args: List[str]  # the arguments to pass to the Docker container
+    env: Mapping[str, str]  # the environment variables to set for the Docker container
+    inputs: List[str]  # the files that the job requires
+    output_spec: Mapping[str, str]  # the files that the job should produce (globs mapped to privacy levels)
+    allow_database_access: bool  # whether this job should have access to the database
+
+
+@dataclass
+class JobResults:
+    state: State
+    status_code: Optional[StatusCode]
+    status_message: str
+    outputs: Mapping[str, str]
+
+
+class JobAPI(Protocol):
+    def run(self, job: JobDefinition) -> None:
+        """
+        Run a job.
+
+        This method must be idempotent; it may be called more than once with the same job_id, in which case only one
+        job should be created. It must also be idempotent in the face of errors; if it throws an exception because
+        job creation has failed due to a transient error it may be called again to retry the operation and this
+        should succeed if possible. (The implementation may provide a configuration option which breaks this
+        idempotency by preserving resources after a failure to aid debugging.)
+
+        The specified image must be run, with the provided arguments and environment variables. The implementation
+        may add environment variables to those in the job definition as necessary for the backend.
+
+        The job should be run without any network access, unless definition.allow_database_access is set to True,
+        in which case it should be run with a network allowing access to the database and any configuration needed to
+        contact and authenticate with the database should be provided as environment variables.
+
+        The job must be run with a workspace directory at /workspace in the filesystem (this is expected to be a
+        volume mounted into the container, but other implementations are allowed). The workspace must contain a
+        checkout of the study and any inputs specified in the job definition, copied from the workspace in long-term
+        storage. If any of the specified inputs is not present in long-term storage then a JobError must be raised with
+        details of the missing file.
+
+        Any files that the job produces that match the output spec in the definition must be copied to the workspace
+        long-term storage. Anything written by the container to stdout or stderr must be captured and written to a
+        log file, metadata/{action}.log, in the workspace in long-term storage.
+
+        The action log file and any files in the output spec marked as medium privacy must also be made available in the
+        medium privacy view of the workspace in long-term storage.
+
+        The action log file and any useful metadata from the job run should also be written to a separate log storage
+        area in long-term storage.
+
+            Raises:
+                JobError: if the job definition is invalid or job creation fails
+        """
+        ...
+
+    def terminate(self, job: JobDefinition) -> None:
+        """
+        Terminate a running job.
+
+        This method must be idempotent; it may be called for a job that doesn't exist or which has already been
+        terminated in which case it must return silently.
+
+            Raises:
+                JobError: if job termination fails
+        """
+        ...
+
+    def get_status(self, job: JobDefinition) -> Tuple[State, Optional[JobResults]]:
+        """
+        Return the status of a job and the results if it has finished.
+
+        This method must be idempotent; it may be called more than once for a job even after it has finished, so any
+        irreversible cleanup which loses information about must be deferred to JobAPI.cleanup() which will only be
+        called once the results have been persisted.
+
+        The results must include a list of output files that the job produced which matched its output spec. It
+        should also include a list of files that it produced but which did not match the output spec,
+        to aid in debugging during study development.
+
+            Returns:
+                state (State): the state of the job
+                results (Optional[JobResults]): the results, if the job has finished
+
+            Raises:
+                JobError: if there is a problem retrieving the status of the job
+         """
+        ...
+
+    def cleanup(self, job: JobDefinition) -> None:
+        """
+        Clean up any remaining state for a finished job.
+
+        This method must be idempotent; it will be called at least once for every finished job. The implementation
+        may defer resource cleanup to this method if necessary in order to correctly implement idempotency of
+        JobAPI.get_status().
+
+        This method will not be called for a job that raises an unexpected exception from JobAPI.get_status() (anything
+        other than JobError), in order to facilitate debugging of unexpected failures. It may therefore be necessary
+        for the backend to provide out-of-band mechanisms for cleaning up resources associated with such failures.
+        """
+        ...
+
+
+class WorkspaceAPI(Protocol):
+    def delete_files(self, workspace: str, privacy: Privacy, paths: [str]):
+        """
+        Delete files from a workspace.
+
+        This method must be idempotent; if any of the files specified doesn't exist then it must ignore them.
+        """
+        ...
+
+
+
+
+class NullJobAPI(JobAPI):
+    """Null implementation of JobAPI."""
+
+    def run(self, job: JobDefinition) -> None:
+        raise NotImplemented
+
+    def terminate(self, job: JobDefinition) -> None:
+        raise NotImplemented
+
+    def get_status(self, job: JobDefinition) -> Tuple[State, Optional[JobResults]]:
+        raise NotImplemented
+
+    def cleanup(self, job: JobDefinition) -> None:
+        raise NotImplemented
+
+
+class NullWorkspaceAPI(Protocol):
+    def delete_files(self, workspace: str, privacy: Privacy, paths: [str]):
+        raise NotImplemented
+
+
+def get_job_api():
+    return NullJobAPI()
+
+
+def get_workspace_api():
+    return NullWorkspaceAPI()
+
+
+

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -39,6 +39,8 @@ class JobResults:
     status_code: Optional[StatusCode]
     status_message: str
     outputs: Mapping[str, str]
+    exit_code: int
+    image_id: str
 
 
 class JobAPI(Protocol):

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -140,13 +140,14 @@ def handle_pending_job_api(job, api):
             try:
                 set_message(job, "Preparing")
                 api.run(job_to_job_definition(job))
+                mark_job_as_running(job)
             except JobError as exception:
                 mark_job_as_failed(job, exception)
+                # support any clean up needed
+                api.cleanup(job_to_job_definition(job))
             except Exception:
                 mark_job_as_failed(job, "Internal error when starting job")
                 raise
-            else:
-                mark_job_as_running(job)
 
 
 def handle_running_job(job):

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -147,7 +147,6 @@ def handle_pending_job_api(job, api):
             try:
                 set_message(job, "Preparing")
                 api.run(job_to_job_definition(job))
-                mark_job_as_running(job)
             except JobError as exception:
                 mark_job_as_failed(job, exception)
                 # support any clean up needed
@@ -155,6 +154,8 @@ def handle_pending_job_api(job, api):
             except Exception:
                 mark_job_as_failed(job, "Internal error when starting job")
                 raise
+            else:
+                mark_job_as_running(job)
 
 
 def handle_running_job(job):

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 import random
 import sys
+import shlex
 import time
 
 from jobrunner import config
@@ -22,12 +23,17 @@ from jobrunner.manage_jobs import (
     start_job,
 )
 from jobrunner.models import Job, State, StatusCode
+from jobrunner import job_executor
+from jobrunner.project import ( is_generate_cohort_command,)
+
 
 log = logging.getLogger(__name__)
 
 
 def main(exit_callback=lambda _: False):
     log.info("jobrunner.run loop started")
+    if config.EXECUTION_API:
+        log.info("using new EXECUTION_API")
     while True:
         active_jobs = handle_jobs()
         if exit_callback(active_jobs):
@@ -50,9 +56,15 @@ def handle_jobs():
         # further down the stack will have `job` set on them
         with set_log_context(job=job):
             if job.state == State.PENDING:
-                handle_pending_job(job)
+                if config.EXECUTION_API:
+                    handle_pending_job_api(job, job_executor.get_job_api())
+                else:
+                    handle_pending_job(job)
             elif job.state == State.RUNNING:
-                handle_running_job(job)
+                if config.EXECUTION_API:
+                    handle_running_job_api(job, job_executor.get_job_api())
+                else:
+                    handle_running_job(job)
     return active_jobs
 
 
@@ -99,6 +111,44 @@ def handle_pending_job(job):
                 mark_job_as_running(job)
 
 
+def handle_pending_job_api(job, api):
+    if job.cancelled:
+        # Mark the job as running and then immediately invoke
+        # `handle_running_job` to deal with the cancellation. This slightly
+        # counterintuitive appraoch allows us to keep a simple, consistent set
+        # of state transitions and to consolidate all the kill/cleanup code
+        # together. It also means that there aren't edge cases where we could
+        # lose track of jobs completely after losing database state
+        mark_job_as_running(job)
+        handle_running_job_api(job, api)
+        return
+
+    awaited_states = get_states_of_awaited_jobs(job)
+    if State.FAILED in awaited_states:
+        mark_job_as_failed(
+            job, "Not starting as dependency failed", code=StatusCode.DEPENDENCY_FAILED
+        )
+    elif any(state != State.SUCCEEDED for state in awaited_states):
+        set_message(
+            job, "Waiting on dependencies", code=StatusCode.WAITING_ON_DEPENDENCIES
+        )
+    else:
+        not_started_reason = get_reason_job_not_started(job)
+        if not_started_reason:
+            set_message(job, not_started_reason, code=StatusCode.WAITING_ON_WORKERS)
+        else:
+            try:
+                set_message(job, "Preparing")
+                api.run(job_to_job_definition(job))
+            except JobError as exception:
+                mark_job_as_failed(job, exception)
+            except Exception:
+                mark_job_as_failed(job, "Internal error when starting job")
+                raise
+            else:
+                mark_job_as_running(job)
+
+
 def handle_running_job(job):
     if job.cancelled:
         log.info("Cancellation requested, killing job")
@@ -134,6 +184,97 @@ def handle_running_job(job):
         else:
             mark_job_as_completed(job)
             cleanup_job(job)
+
+
+def handle_running_job_api(job, api):
+    if job.cancelled:
+        log.info("Cancellation requested, killing job")
+        api.terminate(job_to_job_definition(job))
+
+    try:
+        is_running = sync_job_status(job, api)
+
+        if is_running:
+            set_message(job, "Running")
+        else:
+            mark_job_as_completed(job)
+            api.cleanup(job_to_job_definition(job))
+    except JobError as exception:
+        set_message(job, "Failed")
+        mark_job_as_failed(job, exception)
+        api.cleanup(job_to_job_definition(job))
+    except Exception:
+        set_message(job, "Failed")
+        mark_job_as_failed(job, "Internal error when finalising job")
+        # We don't clean up here, to facilitate with debugging this unexpected error
+        raise
+
+
+def job_to_job_definition(job):
+    action_args = shlex.split(job.run_command)
+    allow_database_access = False
+    env = {"OPENSAFELY_BACKEND": config.BACKEND}
+    # Check `is True` so we fail closed if we ever get anything else
+    if is_generate_cohort_command(action_args) is True:
+        if not config.USING_DUMMY_DATA_BACKEND:
+            allow_database_access = True
+            env["DATABASE_URL"] = config.DATABASE_URLS[job.database_name]
+            if config.TEMP_DATABASE_NAME:
+                env["TEMP_DATABASE_NAME"] = config.TEMP_DATABASE_NAME
+            if config.PRESTO_TLS_KEY and config.PRESTO_TLS_CERT:
+                env["PRESTO_TLS_CERT"] = config.PRESTO_TLS_CERT
+                env["PRESTO_TLS_KEY"] = config.PRESTO_TLS_KEY
+            if config.EMIS_ORGANISATION_HASH:
+                env["EMIS_ORGANISATION_HASH"] = config.EMIS_ORGANISATION_HASH
+    # Prepend registry name
+    image = action_args.pop(0)
+    full_image = f"{config.DOCKER_REGISTRY}/{image}"
+    if image.startswith("stata-mp"):
+        env["STATA_LICENSE"] = str(config.STATA_LICENSE)
+
+    # Jobs which are running reusable actions pull their code from the reusable
+    # action repo, all other jobs pull their code from the study repo
+    study = job_executor.Study(job.action_repo_url or job.repo_url, job.action_commit or job.commit)
+    # Both of action commit and repo_url should be set if either are
+    assert bool(job.action_commit) == bool(job.action_repo_url)
+
+    input_files = []
+    for action in job.requires_outputs_from:
+        for filename in list_outputs_from_action(action):
+            input_files.append(filename)
+
+    outputs = {}
+    for privacy_level, named_patterns in job.output_spec.items():
+        for name, pattern in named_patterns.items():
+            outputs[pattern] = privacy_level
+
+    return job_executor.JobDefinition(job.id, study, job.workspace,
+            job.action, full_image, action_args, env, input_files, outputs,
+            allow_database_access)
+
+
+def sync_job_status(job, api):
+    """Query API for job status."""
+    state, results = api.get_status(job_to_job_definition(job))
+
+    if state == State.RUNNING:
+        return True
+    assert state != State.PENDING
+
+    # TODO: implement workspace state tracking
+    #delete_obsolete_files(job, results)
+
+    job.state = state
+    job.outputs = results.outputs
+    set_message(job, results.status_message, results.status_code)
+    update(job)
+
+    # TODO: implement workspace state tracking
+    #manifest = read_manifest_file(Path())
+    #update_manifest(manifest, job, results.outputs)
+    #write_manifest_file(Path(), manifest)
+
+    return False
 
 
 def get_states_of_awaited_jobs(job):

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -24,7 +24,9 @@ from jobrunner.manage_jobs import (
 )
 from jobrunner.models import Job, State, StatusCode
 from jobrunner import job_executor
-from jobrunner.project import ( is_generate_cohort_command,)
+from jobrunner.project import (
+    is_generate_cohort_command,
+)
 
 
 log = logging.getLogger(__name__)
@@ -235,7 +237,9 @@ def job_to_job_definition(job):
 
     # Jobs which are running reusable actions pull their code from the reusable
     # action repo, all other jobs pull their code from the study repo
-    study = job_executor.Study(job.action_repo_url or job.repo_url, job.action_commit or job.commit)
+    study = job_executor.Study(
+        job.action_repo_url or job.repo_url, job.action_commit or job.commit
+    )
     # Both of action commit and repo_url should be set if either are
     assert bool(job.action_commit) == bool(job.action_repo_url)
 
@@ -249,9 +253,18 @@ def job_to_job_definition(job):
         for name, pattern in named_patterns.items():
             outputs[pattern] = privacy_level
 
-    return job_executor.JobDefinition(job.id, study, job.workspace,
-            job.action, full_image, action_args, env, input_files, outputs,
-            allow_database_access)
+    return job_executor.JobDefinition(
+        job.id,
+        study,
+        job.workspace,
+        job.action,
+        full_image,
+        action_args,
+        env,
+        input_files,
+        outputs,
+        allow_database_access,
+    )
 
 
 def sync_job_status(job, api):
@@ -263,7 +276,7 @@ def sync_job_status(job, api):
     assert state != State.PENDING
 
     # TODO: implement workspace state tracking
-    #delete_obsolete_files(job, results)
+    # delete_obsolete_files(job, results)
 
     job.state = state
     job.outputs = results.outputs

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -22,16 +22,14 @@ def job_factory(**kwargs):
     values.update(kwargs)
     if "job_request_id" not in values:
         # use random job_request_id as id is derived from it
-        values["job_request_id"] = base64.b32encode(
-            secrets.token_bytes(10)
-        ).decode("ascii").lower()
+        values["job_request_id"] = (
+            base64.b32encode(secrets.token_bytes(10)).decode("ascii").lower()
+        )
     return Job(**values)
 
 
-class TestJobAPI():
-
+class TestJobAPI:
     def __init__(self):
-        self.jobs = {}
         self.jobs_run = {}
         self.jobs_status = {}
         self.jobs_terminated = {}
@@ -85,10 +83,6 @@ class TestJobAPI():
         self.jobs_cleaned[definition.id] = definition
 
 
-class TestWorkspaceAPI():
+class TestWorkspaceAPI:
     def delete_files(self, workspace, privacy, paths):
         raise NotImplemented
-
-
-
-

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -53,7 +53,7 @@ def job_factory(job_request=None, **kwargs):
     return job
 
 
-class TestJobAPI:
+class StubJobAPI:
     def __init__(self):
         self.jobs_run = {}
         self.jobs_status = {}
@@ -62,9 +62,9 @@ class TestJobAPI:
         self.results = {}
         self.errors = {}
 
-    def add_test_job(self, **kwargs):
+    def add_test_job(self, *args, **kwargs):
         """Create and track a db job object."""
-        job = job_factory(**kwargs)
+        job = job_factory(*args, **kwargs)
         if job.state == State.RUNNING:
             self.jobs_run[job.id] = job
         return job

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,92 @@
+import base64
+import secrets
+
+from jobrunner import job_executor
+from jobrunner.models import Job, State
+from jobrunner.lib.database import insert
+from jobrunner.manage_jobs import JobError
+
+
+DEFAULTS = {
+    "action": "action_name",
+    "repo_url": "opensafely/study",
+    "workspace": "workspace",
+    "requires_outputs_from": [],
+    "run_command": "python myscript.py",
+    "output_spec": {},
+}
+
+
+def job_factory(**kwargs):
+    values = DEFAULTS.copy()
+    values.update(kwargs)
+    if "job_request_id" not in values:
+        # use random job_request_id as id is derived from it
+        values["job_request_id"] = base64.b32encode(
+            secrets.token_bytes(10)
+        ).decode("ascii").lower()
+    return Job(**values)
+
+
+class TestJobAPI():
+
+    def __init__(self):
+        self.jobs = {}
+        self.jobs_run = {}
+        self.jobs_status = {}
+        self.jobs_terminated = {}
+        self.jobs_cleaned = {}
+        self.results = {}
+        self.errors = {}
+
+    def add_test_job(self, **kwargs):
+        """Create and track a db job object."""
+        job = job_factory(**kwargs)
+        self.jobs[job.id] = job
+        insert(job)
+        if job.state == State.RUNNING:
+            self.jobs_run[job.id] = job
+        return job
+
+    def add_job_exception(self, job_id, exc):
+        self.errors[job_id] = exc
+
+    def add_job_result(self, job_id, state, code=None, message=None, outputs={}):
+        self.results[job_id] = job_executor.JobResults(state, code, message, outputs)
+
+
+    def run(self, definition):
+        """Track this definition."""
+        self.jobs_run[definition.id] = definition
+
+    def terminate(self, definition):
+        if definition.id not in self.jobs_run:
+            return
+        self.jobs_terminated[definition.id] = definition
+
+        # automatically mark this job as having failed
+        self.add_job_result(definition.id, State.FAILED)
+
+    def get_status(self, definition):
+        if definition.id not in self.jobs_run:
+            raise JobError(f"unknown job {definition.id}")
+
+        if definition.id in self.errors:
+            raise self.errors[definition.id]
+        elif definition.id in self.results:
+            result = self.results[definition.id]
+            return result.state, result
+        else:
+            return State.RUNNING, None
+
+    def cleanup(self, definition):
+        self.jobs_cleaned[definition.id] = definition
+
+
+class TestWorkspaceAPI():
+    def delete_files(self, workspace, privacy, paths):
+        raise NotImplemented
+
+
+
+

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,5 +1,6 @@
 import base64
 import secrets
+from copy import deepcopy
 
 from jobrunner import job_executor
 from jobrunner.models import Job, JobRequest, SavedJobRequest, State
@@ -34,7 +35,7 @@ def job_request_factory(**kwargs):
     if "id" not in kwargs:
         kwargs["id"] = base64.b32encode(secrets.token_bytes(10)).decode("ascii").lower()
 
-    values = JOB_REQUEST_DEFAULTS.copy()
+    values = deepcopy(JOB_REQUEST_DEFAULTS)
     values.update(kwargs)
     job_request = JobRequest(**values)
     insert(SavedJobRequest(id=job_request.id, original=job_request.original))
@@ -45,7 +46,7 @@ def job_factory(job_request=None, **kwargs):
     if job_request is None:
         job_request = job_request_factory()
 
-    values = JOB_DEFAULTS.copy()
+    values = deepcopy(JOB_DEFAULTS)
     values.update(kwargs)
     values["job_request_id"] = job_request.id
     job = Job(**values)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -132,10 +132,14 @@ def test_handle_pending_job_run_exception(db):
     assert job.status_code is None
 
 
-def test_handle_running_job_success(db):
+def test_handle_running_job_success(db, tmp_work_dir):
     api = TestJobAPI()
     job = api.add_test_job(state=State.RUNNING)
     api.add_job_result(job.id, State.SUCCEEDED, None, "Finished")
+
+    # temporary setup until we get the new metadata implementation
+    workspace_dir = config.HIGH_PRIVACY_STORAGE_BASE / job.workspace / "metadata"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
 
     run.handle_running_job_api(job, api)
 
@@ -154,7 +158,7 @@ def test_handle_running_job_still_running(db):
     assert job.state == State.RUNNING
 
 
-def test_handle_running_job_failed(db):
+def test_handle_running_job_failed(db, tmp_work_dir):
     api = TestJobAPI()
     job = api.add_test_job(state=State.RUNNING)
     api.add_job_result(
@@ -163,6 +167,9 @@ def test_handle_running_job_failed(db):
         StatusCode.NONZERO_EXIT,
         "Job exited with an error code",
     )
+    # temporary until we get the new metadata implementation
+    workspace_dir = config.HIGH_PRIVACY_STORAGE_BASE / job.workspace / "metadata"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
 
     run.handle_running_job_api(job, api)
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -13,7 +13,9 @@ from tests.factories import TestJobAPI
 @pytest.fixture()
 def db(monkeypatch):
     """Create a throwaway db."""
-    monkeypatch.setattr(config, "DATABASE_FILE", ":memory:{random.randrange(sys.maxsize)}")
+    monkeypatch.setattr(
+        config, "DATABASE_FILE", ":memory:{random.randrange(sys.maxsize)}"
+    )
 
 
 def test_handle_pending_job_success(db):
@@ -48,8 +50,9 @@ def test_handle_pending_job_dependency_failed(db):
     job = api.add_test_job(
         job_request_id=dependency.job_request_id,
         action="action2",
-        state=State.PENDING, 
-        wait_for_job_ids=[dependency.id])
+        state=State.PENDING,
+        wait_for_job_ids=[dependency.id],
+    )
 
     run.handle_pending_job_api(job, api)
 
@@ -67,8 +70,9 @@ def test_handle_pending_job_waiting_on_dependency(db):
     job = api.add_test_job(
         job_request_id=dependency.job_request_id,
         action="action2",
-        state=State.PENDING, 
-        wait_for_job_ids=[dependency.id])
+        state=State.PENDING,
+        wait_for_job_ids=[dependency.id],
+    )
 
     run.handle_pending_job_api(job, api)
 
@@ -143,7 +147,7 @@ def test_handle_running_job_success(db):
 def test_handle_running_job_still_running(db):
     api = TestJobAPI()
     job = api.add_test_job(state=State.RUNNING)
- 
+
     run.handle_running_job_api(job, api)
 
     assert job.status_message == "Running"
@@ -154,12 +158,12 @@ def test_handle_running_job_failed(db):
     api = TestJobAPI()
     job = api.add_test_job(state=State.RUNNING)
     api.add_job_result(
-            job.id, 
-            State.FAILED, 
-            StatusCode.NONZERO_EXIT,
-            "Job exited with an error code",
+        job.id,
+        State.FAILED,
+        StatusCode.NONZERO_EXIT,
+        "Job exited with an error code",
     )
- 
+
     run.handle_running_job_api(job, api)
 
     assert job.state == State.FAILED
@@ -172,7 +176,7 @@ def test_handle_running_job_joberror(db):
     api = TestJobAPI()
     job = api.add_test_job(state=State.RUNNING)
     api.add_job_exception(job.id, JobError("job error"))
- 
+
     run.handle_running_job_api(job, api)
 
     assert job.state == State.FAILED
@@ -185,7 +189,7 @@ def test_handle_running_job_exception(db):
     api = TestJobAPI()
     job = api.add_test_job(state=State.RUNNING)
     api.add_job_exception(job.id, Exception("unknown error"))
- 
+
     with pytest.raises(Exception):
         run.handle_running_job_api(job, api)
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,164 @@
+import random
+import pytest
+
+from jobrunner.models import State, StatusCode
+from jobrunner.manage_jobs import JobError
+from jobrunner import config
+from jobrunner.lib.database import transaction
+from jobrunner import run
+
+from tests.factories import TestJobAPI
+
+class Rollback(Exception):
+    pass
+
+
+@pytest.fixture()
+def db(monkeypatch):
+    """Create a throwaway db."""
+    monkeypatch.setattr(config, "DATABASE_FILE", ":memory:{random.randrange(sys.maxsize)}")
+
+
+def test_handle_pending_job_success(db):
+    api = TestJobAPI()
+    job = api.add_test_job(state=State.PENDING)
+
+    run.handle_pending_job_api(job, api)
+
+    assert job.id in api.jobs_run
+
+    assert job.status_message == "Running"
+    assert job.state == State.RUNNING
+
+
+def test_handle_pending_job_cancelled(db):
+    api = TestJobAPI()
+    job = api.add_test_job(state=State.PENDING, cancelled=True)
+
+    run.handle_pending_job_api(job, api)
+
+    assert job.id not in api.jobs_run
+    assert job.id not in api.jobs_terminated
+
+    assert job.state == State.FAILED
+    assert job.status_message == "Cancelled by user"
+    assert job.status_code == StatusCode.CANCELLED_BY_USER
+
+
+def test_handle_pending_job_dependency_failed(db):
+    api = TestJobAPI()
+    dependency = api.add_test_job(state=State.FAILED)
+    job = api.add_test_job(
+        job_request_id=dependency.job_request_id,
+        action="action2",
+        state=State.PENDING, 
+        wait_for_job_ids=[dependency.id])
+
+    run.handle_pending_job_api(job, api)
+
+    assert job.id not in api.jobs_run
+
+    assert job.state == State.FAILED
+    assert job.status_message == "Not starting as dependency failed"
+    assert job.status_code == StatusCode.DEPENDENCY_FAILED
+
+
+def test_handle_pending_job_waiting_on_dependency(db):
+    api = TestJobAPI()
+    dependency = api.add_test_job(state=State.RUNNING)
+
+    job = api.add_test_job(
+        job_request_id=dependency.job_request_id,
+        action="action2",
+        state=State.PENDING, 
+        wait_for_job_ids=[dependency.id])
+
+    run.handle_pending_job_api(job, api)
+
+    assert job.id not in api.jobs_run
+
+    assert job.state == State.PENDING
+    assert job.status_message == "Waiting on dependencies"
+    assert job.status_code == StatusCode.WAITING_ON_DEPENDENCIES
+
+
+def test_handle_pending_job_waiting_on_workers(db, monkeypatch):
+    # hack to ensure no workers available
+    monkeypatch.setattr(config, "MAX_WORKERS", 0)
+    api = TestJobAPI()
+    job = api.add_test_job(state=State.PENDING)
+
+    run.handle_pending_job_api(job, api)
+
+    assert job.id not in api.jobs_run
+
+    assert job.state == State.PENDING
+    assert job.status_message == "Waiting on available workers"
+    assert job.status_code == StatusCode.WAITING_ON_WORKERS
+
+
+def test_handle_running_job_success(db):
+    api = TestJobAPI()
+    job = api.add_test_job(state=State.RUNNING)
+    api.add_job_result(job.id, State.SUCCEEDED, None, "Finished")
+ 
+    run.handle_running_job_api(job, api)
+
+    assert job.status_message == "Finished"
+    assert job.state == State.SUCCEEDED
+    assert job.id in api.jobs_cleaned
+
+
+def test_handle_running_job_still_running(db):
+    api = TestJobAPI()
+    job = api.add_test_job(state=State.RUNNING)
+ 
+    run.handle_running_job_api(job, api)
+
+    assert job.status_message == "Running"
+    assert job.state == State.RUNNING
+
+
+def test_handle_running_job_failed(db):
+    api = TestJobAPI()
+    job = api.add_test_job(state=State.RUNNING)
+    api.add_job_result(
+            job.id, 
+            State.FAILED, 
+            StatusCode.NONZERO_EXIT,
+            "Job exited with an error code",
+    )
+ 
+    run.handle_running_job_api(job, api)
+
+    assert job.state == State.FAILED
+    assert job.status_code == StatusCode.NONZERO_EXIT
+    assert job.status_message == "Job exited with an error code"
+    assert job.id in api.jobs_cleaned
+
+
+def test_handle_running_job_joberror(db):
+    api = TestJobAPI()
+    job = api.add_test_job(state=State.RUNNING)
+    api.add_job_exception(job.id, JobError("job error"))
+ 
+    run.handle_running_job_api(job, api)
+
+    assert job.state == State.FAILED
+    assert job.status_code is None
+    assert job.status_message == "JobError: job error"
+    assert job.id in api.jobs_cleaned
+
+
+def test_handle_running_job_exception(db):
+    api = TestJobAPI()
+    job = api.add_test_job(state=State.RUNNING)
+    api.add_job_exception(job.id, Exception("unknown error"))
+ 
+    with pytest.raises(Exception):
+        run.handle_running_job_api(job, api)
+
+    assert job.state == State.FAILED
+    assert job.status_code is None
+    assert job.status_message == "Internal error when finalising job"
+    assert job.id not in api.jobs_cleaned

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -7,7 +7,7 @@ from jobrunner import config
 from jobrunner.lib.database import transaction
 from jobrunner import run
 
-from tests.factories import TestJobAPI
+from tests.factories import StubJobAPI
 
 
 @pytest.fixture()
@@ -19,7 +19,7 @@ def db(monkeypatch):
 
 
 def test_handle_pending_job_success(db):
-    api = TestJobAPI()
+    api = StubJobAPI()
     job = api.add_test_job(state=State.PENDING)
 
     run.handle_pending_job_api(job, api)
@@ -31,7 +31,7 @@ def test_handle_pending_job_success(db):
 
 
 def test_handle_pending_job_cancelled(db):
-    api = TestJobAPI()
+    api = StubJobAPI()
     job = api.add_test_job(state=State.PENDING, cancelled=True)
 
     run.handle_pending_job_api(job, api)
@@ -45,7 +45,7 @@ def test_handle_pending_job_cancelled(db):
 
 
 def test_handle_pending_job_dependency_failed(db):
-    api = TestJobAPI()
+    api = StubJobAPI()
     dependency = api.add_test_job(state=State.FAILED)
     job = api.add_test_job(
         job_request_id=dependency.job_request_id,
@@ -64,7 +64,7 @@ def test_handle_pending_job_dependency_failed(db):
 
 
 def test_handle_pending_job_waiting_on_dependency(db):
-    api = TestJobAPI()
+    api = StubJobAPI()
     dependency = api.add_test_job(state=State.RUNNING)
 
     job = api.add_test_job(
@@ -86,7 +86,7 @@ def test_handle_pending_job_waiting_on_dependency(db):
 def test_handle_pending_job_waiting_on_workers(db, monkeypatch):
     # hack to ensure no workers available
     monkeypatch.setattr(config, "MAX_WORKERS", 0)
-    api = TestJobAPI()
+    api = StubJobAPI()
     job = api.add_test_job(state=State.PENDING)
 
     run.handle_pending_job_api(job, api)
@@ -99,7 +99,7 @@ def test_handle_pending_job_waiting_on_workers(db, monkeypatch):
 
 
 def test_handle_pending_job_run_job_error(db):
-    api = TestJobAPI()
+    api = StubJobAPI()
 
     job = api.add_test_job(state=State.PENDING)
     api.add_job_exception(job.id, JobError("test"))
@@ -115,7 +115,7 @@ def test_handle_pending_job_run_job_error(db):
 
 
 def test_handle_pending_job_run_exception(db):
-    api = TestJobAPI()
+    api = StubJobAPI()
 
     job = api.add_test_job(state=State.PENDING)
     api.add_job_exception(job.id, Exception("test"))
@@ -133,7 +133,7 @@ def test_handle_pending_job_run_exception(db):
 
 
 def test_handle_running_job_success(db, tmp_work_dir):
-    api = TestJobAPI()
+    api = StubJobAPI()
     job = api.add_test_job(state=State.RUNNING)
     api.add_job_result(job.id, State.SUCCEEDED, None, "Finished")
 
@@ -149,7 +149,7 @@ def test_handle_running_job_success(db, tmp_work_dir):
 
 
 def test_handle_running_job_still_running(db):
-    api = TestJobAPI()
+    api = StubJobAPI()
     job = api.add_test_job(state=State.RUNNING)
 
     run.handle_running_job_api(job, api)
@@ -159,7 +159,7 @@ def test_handle_running_job_still_running(db):
 
 
 def test_handle_running_job_failed(db, tmp_work_dir):
-    api = TestJobAPI()
+    api = StubJobAPI()
     job = api.add_test_job(state=State.RUNNING)
     api.add_job_result(
         job.id,
@@ -180,7 +180,7 @@ def test_handle_running_job_failed(db, tmp_work_dir):
 
 
 def test_handle_running_job_joberror(db):
-    api = TestJobAPI()
+    api = StubJobAPI()
     job = api.add_test_job(state=State.RUNNING)
     api.add_job_exception(job.id, JobError("job error"))
 
@@ -193,7 +193,7 @@ def test_handle_running_job_joberror(db):
 
 
 def test_handle_running_job_exception(db):
-    api = TestJobAPI()
+    api = StubJobAPI()
     job = api.add_test_job(state=State.RUNNING)
     api.add_job_exception(job.id, Exception("unknown error"))
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -98,7 +98,10 @@ def test_handle_pending_job_waiting_on_workers(db, monkeypatch):
     assert job.status_code == StatusCode.WAITING_ON_WORKERS
 
 
-def test_handle_pending_job_run_job_error(db):
+def test_handle_pending_job_run_job_error(db, monkeypatch):
+    # GH runners default to 1, which causes this test to fail
+    monkeypatch.setattr(config, "MAX_WORKERS", 4)
+
     api = StubJobAPI()
 
     job = api.add_test_job(state=State.PENDING)
@@ -114,7 +117,9 @@ def test_handle_pending_job_run_job_error(db):
     assert job.status_code is None
 
 
-def test_handle_pending_job_run_exception(db):
+def test_handle_pending_job_run_exception(db, monkeypatch):
+    # GH runners default to 1, which causes this test to fail
+    monkeypatch.setattr(config, "MAX_WORKERS", 4)
     api = StubJobAPI()
 
     job = api.add_test_job(state=State.PENDING)


### PR DESCRIPTION
Inital implementation of the spike API
    
This adds an EXECUTION_API feature flag, which switches the main run
loop to us alternate version of `handle_pending_jobs` and
`handle_running_jobs`, which use the API.
   
It adds unit tests for those new functions, using the fact we now have
an API! Fairly basic branch coverage to start with, but more to add.
    
Things this branch does not do:
    
 - implement selection and loading of the API implementation
 - handle manifest state
   
The spike code is mostly unaltered, except for moving the `set_message`
into `sync_job_status`, and adding an additional `update(job)` call.
