### PR TITLE
feat: refactor JobAPI.run() into separate preprare/execute/finalize stages

### DIFF
--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -85,7 +85,7 @@ class JobAPI:
 
         1. Validate the JobDefinition. If there are errors, return an ERROR state with message.
 
-        2. Check the job is currently in UNKNOWN state. IF not return its current state with a message indicated invalid
+        2. Check the job is currently in UNKNOWN state. If not return its current state with a message indicated invalid
            state.
 
         3. Check the resources are available to prepare the job. If not, return the UNKNOWN state with an appropriate

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -33,26 +33,95 @@ class JobDefinition:
     allow_database_access: bool  # whether this job should have access to the database
 
 
+class ExecutorState(Enum):
+    PENDING = "pending"
+    PREPARING = "preparing"
+    PREPARED = "prepared"
+    EXECUTING = "executing"
+    EXECUTED = "executed"
+    FINALIZING = "finalizing"
+    FINALIZED = "finalized"
+    GONE = "gone"
+    ERROR = "error"
+
+
+@dataclass
+class JobStatus:
+    state: ExecutorState
+    message: Optional[str]
+
+
 @dataclass
 class JobResults:
-    state: State
-    status_code: Optional[StatusCode]
-    status_message: str
-    outputs: Mapping[str, str]
+    outputs: Mapping[str, str]  # mapping of outputs to privacy levels
+    unmatched_patterns: List[str]  # list of patterns that matched no outputs
     exit_code: int
     image_id: str
 
 
 class JobAPI:
-    def run(self, job: JobDefinition) -> None:
-        """
-        Run a job.
+    """
+    API for managing job execution.
 
-        This method must be idempotent; it may be called more than once with the same job_id, in which case only one
-        job should be created. It must also be idempotent in the face of errors; if it throws an exception because
-        job creation has failed due to a transient error it may be called again to retry the operation and this
-        should succeed if possible. (The implementation may provide a configuration option which breaks this
-        idempotency by preserving resources after a failure to aid debugging.)
+    This API is called by the job-runner to manage each job it is tracking. It models the running of a job as a state
+    machine, and the methods below are the transitions between states.
+
+    They should return either:
+     - the next state if successful
+     - the current state to indicate back pressure and to retry later
+     - the ERROR state with an appropriate message if something has gone wrong.
+
+    Given the long running nature of jobs, it is an asychronous API, and calls should not block for a more than a few
+    seconds.
+
+    All the state transition methods (prepare(), execute(), finalize(), terminate(), cleanup()) must be idempotent. If
+    the relevent task they are responsible for is already running for that job, they must not start a new task, and
+    instead return successfully the current state.
+    """
+
+    def prepare(self, job: JobDefinition) -> JobStatus:
+        """
+        Launch a prepare task for a job, transitioning from PENDING to PREPARING.
+
+        1. Validate the JobDefinition. If there are errors, return an ERROR state with message.
+
+        2. Check the resources are available to prepare the job. If not, return the PENDING state with an appropriate
+           message.
+
+        3. Create an ephemeral workspace to use for executing this job. This is expected to be a volume mounted into the
+           container, but other implementations are allowed.
+
+        4. Launch a prepare task asynchronously. If launched successfully, return the PREPARING state. If not, return an
+           ERROR state with message.
+
+        The prepare task must do the following:
+
+          - check out the supplied study repo via the OpenSAFELY github proxy into the ephemeral workspace, erroring if
+            there are any failures.
+          - copying the supplied file inputs from the long-term workspace storage into the ephermal workspace, erroring
+            if there are any missing.
+
+        When the prepare task finishes, the get_status() call should now return PREPARED for this job.
+
+        This method must be idempotent. If called with a job that is already running a prepare task, it must not
+        launch a new task, and simply return succesfully with PREPARING.
+
+        """
+
+    def execute(self, job: JobDefinition) -> JobStatus:
+        """
+        Launch the execution of a job that has been prepared, transitioning from PREPARED to EXECUTING.
+
+        1. Validate the the ephememeral workspace created by prepare for this job exists.  If not, return an ERROR
+           state with message.
+
+        2. Check there are resources availabe to execute the job. If not, return PREPARED status with an appropriate
+           message.
+
+        3. Launch the job execution task asynchronously. If launched successfully, return the EXECUTING state. If not,
+           return an ERROR state with message.
+
+        The execution task must do the following:
 
         The specified image must be run, with the provided arguments and environment variables. The implementation
         may add environment variables to those in the job definition as necessary for the backend.
@@ -61,15 +130,29 @@ class JobAPI:
         in which case it should be run with a network allowing access to the database and any configuration needed to
         contact and authenticate with the database should be provided as environment variables.
 
-        The job must be run with a workspace directory at /workspace in the filesystem (this is expected to be a
-        volume mounted into the container, but other implementations are allowed). The workspace must contain a
-        checkout of the study and any inputs specified in the job definition, copied from the workspace in long-term
-        storage. If any of the specified inputs is not present in long-term storage then a JobError must be raised with
-        details of the missing file.
+        The job must be run with the ephemeral workspace for this job at /workspace in the filesystem.
 
-        Any files that the job produces that match the output spec in the definition must be copied to the workspace
-        long-term storage. Anything written by the container to stdout or stderr must be captured and written to a
-        log file, metadata/{action}.log, in the workspace in long-term storage.
+        When the prepare task finishes, the get_status() call must now return EXECUTED for this job.
+
+        This method must be idempotent. If called with a job that is already running an execute task, it must not
+        launch a new task, and simply return succesfully with EXECUTING.
+
+        """
+
+    def finalize(self, job: JobDefinition) -> JobStatus:
+        """
+        Launch the finalization of a job, transitioning from EXECUTED to FINALIZING.
+
+        1. Validate that the job's ephemeral workspace exists. If not, return an ERROR state with message.
+
+        2. Launch the finalize task asynchronously. If launched successfully, return the FINALIZING state. If not,
+           return an ERROR state with message.
+
+        The finalize task should do the following:
+
+        Any files that the job produced that match the output spec in the definition must be copied from the ephemeral
+        workspace to the workspace long-term storage. Anything written by the container to stdout or stderr must be
+        captured and written to a log file, metadata/{action}.log, in the workspace in long-term storage.
 
         The action log file and any files in the output spec marked as medium privacy must also be made available in the
         medium privacy view of the workspace in long-term storage.
@@ -77,59 +160,70 @@ class JobAPI:
         The action log file and any useful metadata from the job run should also be written to a separate log storage
         area in long-term storage.
 
-            Raises:
-                JobError: if the job definition is invalid or job creation fails
-        """
-        ...
+        When the finalize task finishes, the get_status() call should now return FINALIZED for this job, and
+        get_results() call should return the JobResults for this job.
 
-    def terminate(self, job: JobDefinition) -> None:
-        """
-        Terminate a running job.
+        This method must be idempotent. If called with a job that is already running an finalize task, it must not
+        launch a new task, and simply return successfully with FINALIZING.
 
-        This method must be idempotent; it may be called for a job that doesn't exist or which has already been
-        terminated in which case it must return silently.
-
-            Raises:
-                JobError: if job termination fails
         """
-        ...
 
-    def get_status(self, job: JobDefinition) -> Tuple[State, Optional[JobResults]]:
+    def terminate(self, job: JobDefinition) -> JobStatus:
         """
-        Return the status of a job and the results if it has finished.
+        Terminate a running job, tranisitioning to the ERROR state.
+
+        1. If any task for this job is running, terminate it, do not wait for it to complete.
+
+        2. Return ERROR state with a message.
+
+        """
+
+    def cleanup(self, job: JobDefinition) -> JobStatus:
+        """
+        Clean up any remaining state for a finished job, transitioning to the GONE state.
+
+        1. Initiate the cleanup, do not wait for it to complete.
+
+        2. Return the GONE status.
+
+        This method must be idempotent; it will be called at least once for every finished job. The implementation
+        may defer resource cleanup to this method if necessary in order to correctly implement idempotency of
+        get_status() or get_results(). If the job is unknown, it should still return GONE successfully.
+
+        This method will not be called for a job that raises an unexpected exception from JobAPI in order
+        to facilitate debugging of unexpected failures. It may therefore be necessary for the backend to provide
+        out-of-band mechanisms for cleaning up resources associated with such failures.
+        """
+
+    def get_status(self, job: JobDefinition) -> JobStatus:
+        """
+        Return the current status of a job.
+
+        1. Check the job is known to the system. If not, return the PENDING state.
+
+        2. Return the current state of the job from the executors perspective.
+
+        This should return a JobStatus with the appropriate state for the job. It is polled by job-runner to track the
+        completion of the various tasks.
 
         This method must be idempotent; it may be called more than once for a job even after it has finished, so any
         irreversible cleanup which loses information about must be deferred to JobAPI.cleanup() which will only be
         called once the results have been persisted.
 
-        If no matching job can be found, it should raise a JobError exception.
+        """
+
+    def get_results(self, job: JobDefinition) -> JobResults:
+        """
+        Return the finalized results for a job.
 
         The results must include a list of output files that the job produced which matched its output spec. It
-        should also include a list of files that it produced but which did not match the output spec,
-        to aid in debugging during study development.
+        should also include a list of files that it produced but which did not match the output spec, to aid in
+        debugging during study development.
 
-            Returns:
-                state (State): the state of the job
-                results (Optional[JobResults]): the results, if the job has finished
-
-            Raises:
-                JobError: if there is a problem retrieving the status of the job
+        This method must be idempotent; it may be called more than once for a job even after it has finished, so any
+        irreversible cleanup which loses information about must be deferred to JobAPI.cleanup() which will only be
+        called once the results have been persisted.
         """
-        ...
-
-    def cleanup(self, job: JobDefinition) -> None:
-        """
-        Clean up any remaining state for a finished job.
-
-        This method must be idempotent; it will be called at least once for every finished job. The implementation
-        may defer resource cleanup to this method if necessary in order to correctly implement idempotency of
-        JobAPI.get_status().
-
-        This method will not be called for a job that raises an unexpected exception from JobAPI.get_status() (anything
-        other than JobError), in order to facilitate debugging of unexpected failures. It may therefore be necessary
-        for the backend to provide out-of-band mechanisms for cleaning up resources associated with such failures.
-        """
-        ...
 
 
 class WorkspaceAPI:
@@ -145,22 +239,31 @@ class WorkspaceAPI:
 class NullJobAPI(JobAPI):
     """Null implementation of JobAPI."""
 
-    def run(self, job: JobDefinition) -> None:
-        raise NotImplemented
+    def prepare(self, job):
+        raise NotImplementedError
 
-    def terminate(self, job: JobDefinition) -> None:
-        raise NotImplemented
+    def execute(self, job):
+        raise NotImplementedError
 
-    def get_status(self, job: JobDefinition) -> Tuple[State, Optional[JobResults]]:
-        raise NotImplemented
+    def finalize(self, job):
+        raise NotImplementedError
 
-    def cleanup(self, job: JobDefinition) -> None:
-        raise NotImplemented
+    def terminate(self, job):
+        raise NotImplementedError
+
+    def get_status(self, job):
+        raise NotImplementedError
+
+    def get_results(self, job):
+        raise NotImplementedError
+
+    def cleanup(self, job):
+        raise NotImplementedError
 
 
 class NullWorkspaceAPI:
     def delete_files(self, workspace: str, privacy: Privacy, paths: [str]):
-        raise NotImplemented
+        raise NotImplementedError
 
 
 def get_job_api():

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -117,7 +117,7 @@ class JobAPI:
 
         1. Check the job is in the PREPARED state. If not, return its current state with a message.
 
-        2. Validate the the ephememeral workspace created by prepare for this job exists.  If not, return an ERROR
+        2. Validate that the ephememeral workspace created by prepare for this job exists.  If not, return an ERROR
            state with message.
 
         3. Check there are resources availabe to execute the job. If not, return PREPARED status with an appropriate
@@ -137,7 +137,7 @@ class JobAPI:
 
         The job must be run with the ephemeral workspace for this job at /workspace in the filesystem.
 
-        When the prepare task finishes, the get_status() call must now return EXECUTED for this job.
+        When the execute task finishes, the get_status() call must now return EXECUTED for this job.
 
         This method must be idempotent. If called with a job that is already running an execute task, it must not
         launch a new task, and simply return succesfully with EXECUTING.

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -278,19 +278,22 @@ def handle_job_api(job, api):
 
 
 def save_results(job, results):
-    """Example the results of the execution and update the job accordingly."""
+    """Extract the results of the execution and update the job accordingly."""
 
     # this logic is adapted directly from jobrunner.manage_jobs.finalize_job()
     job.outputs = results.outputs
 
+    message = None
+    code = None
+
     # Set the final state of the job
     if results.exit_code != 0:
         job.state = State.FAILED
-        job.status_message = "Job exited with an error code"
-        job.status_code = StatusCode.NONZERO_EXIT
+        message = "Job exited with an error code"
+        code = StatusCode.NONZERO_EXIT
     elif results.unmatched_patterns:
         job.state = State.FAILED
-        job.status_message = "No outputs found matching patterns:\n - {}".format(
+        message = "No outputs found matching patterns:\n - {}".format(
             "\n - ".join(results.unmatched_patterns)
         )
         # If the job fails because an output was missing its very useful to
@@ -300,9 +303,9 @@ def save_results(job, results):
         # TODO:  job.unmatched_outputs = ???
     else:
         job.state = State.SUCCEEDED
-        job.status_message = "Completed successfully"
+        message = "Completed successfully"
 
-    set_message(job, results.status_message, results.status_code)
+    set_message(job, message, code)
 
 
 def job_to_job_definition(job):

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -38,6 +38,10 @@ from jobrunner.project import (
 log = logging.getLogger(__name__)
 
 
+class InvalidTransition(Exception):
+    pass
+
+
 def main(exit_callback=lambda _: False):
     log.info("jobrunner.run loop started")
 
@@ -278,7 +282,7 @@ def handle_job_api(job, api):
         api.cleanup(definition)
 
     else:
-        raise Exception(
+        raise InvalidTransition(
             f"unexpected state transition from {old_status.state} to {new_status.state}: {new_status.message}"
         )
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,7 +2,7 @@ import base64
 import secrets
 from copy import deepcopy
 
-from jobrunner import job_executor
+from jobrunner.job_executor import ExecutorState, JobStatus, JobResults
 from jobrunner.models import Job, JobRequest, SavedJobRequest, State
 from jobrunner.lib.database import insert
 from jobrunner.manage_jobs import JobError
@@ -55,66 +55,109 @@ def job_factory(job_request=None, **kwargs):
 
 
 class StubJobAPI:
-    def __init__(self):
-        self.jobs_run = {}
-        self.jobs_status = {}
-        self.jobs_terminated = {}
-        self.jobs_cleaned = {}
-        self.results = {}
-        self.errors = {}
+    """Dummy implementation of the JobAPI, for use in tests.
 
-    def add_test_job(self, *args, **kwargs):
+    It tracks the current state of any jobs based the calls to the various API
+    methods, and get_status() will return the current state.
+
+    You can inject new jobs to the executor with add_test_job(), for which you
+    must supply a current ExecutorState and also job State.
+
+    By default, transition methods successfully move to the next state. If you
+    want to change that, call set_job_transition(job, state), and the next
+    transition method call for that job will instead return that state.
+
+    It also tracks which methods were called with which job ids to check the
+    correct series of methods was invoked.
+
+    """
+
+    def __init__(self):
+
+        self.tracker = {
+            "prepare": set(),
+            "execute": set(),
+            "finalize": set(),
+            "terminate": set(),
+            "cleanup": set(),
+        }
+        self.transitions = {}
+        self.results = {}
+        self.state = {}
+
+    def add_test_job(self, exec_state, job_state, **kwargs):
         """Create and track a db job object."""
-        job = job_factory(*args, **kwargs)
-        if job.state == State.RUNNING:
-            self.jobs_run[job.id] = job
+        job = job_factory(state=job_state, **kwargs)
+        if exec_state != ExecutorState.UNKNOWN:
+            self.state[job.id] = exec_state
         return job
 
-    def add_job_exception(self, job_id, exc):
-        self.errors[job_id] = exc
+    def set_job_state(self, definition, state):
+        """Directly set a job state."""
+        self.state[definition.id] = state
 
-    def add_job_result(
-        self,
-        job_id,
-        state,
-        code=None,
-        message=None,
-        outputs={},
-        exit_code=0,
-        image_id="image_id",
+    def set_job_transition(self, definition, state, message="executor message"):
+        """Set the next transition for this job when called"""
+        self.transitions[definition.id] = (state, message)
+
+    def set_job_result(
+        self, definition, outputs={}, unmatched=[], exit_code=0, image_id="image_id"
     ):
-        self.results[job_id] = job_executor.JobResults(
-            state, code, message, outputs, exit_code, image_id
+
+        self.results[definition.id] = JobResults(
+            outputs,
+            unmatched,
+            exit_code,
+            image_id,
         )
 
-    def run(self, definition):
-        """Track this definition."""
-        self.jobs_run[definition.id] = definition
-        if definition.id in self.errors:
-            raise self.errors[definition.id]
+    def do_transition(self, definition, expected, next_state):
+        current = self.get_status(definition)
+        if current.state != expected:
+            state = current.state
+            message = f"Invalid transition to {next_state}, currently state is {current.state}"
+        elif definition.id in self.transitions:
+            state, message = self.transitions[definition.id]
+        else:
+            state = next_state
+            message = "executor message"
+
+        self.set_job_state(definition, state)
+        return JobStatus(state, message)
+
+    def prepare(self, definition):
+        self.tracker["prepare"].add(definition.id)
+        return self.do_transition(
+            definition, ExecutorState.UNKNOWN, ExecutorState.PREPARING
+        )
+
+    def execute(self, definition):
+        self.tracker["execute"].add(definition.id)
+        return self.do_transition(
+            definition, ExecutorState.PREPARED, ExecutorState.EXECUTING
+        )
+
+    def finalize(self, definition):
+        self.tracker["finalize"].add(definition.id)
+        return self.do_transition(
+            definition, ExecutorState.EXECUTED, ExecutorState.FINALIZING
+        )
 
     def terminate(self, definition):
-        if definition.id not in self.jobs_run:
-            return
-        self.jobs_terminated[definition.id] = definition
-
-        # automatically mark this job as having failed
-        self.add_job_result(definition.id, State.FAILED)
-
-    def get_status(self, definition):
-        if definition.id not in self.jobs_run:
-            raise JobError(f"unknown job {definition.id}")
-
-        if definition.id in self.errors:
-            raise self.errors[definition.id]
-        elif definition.id in self.results:
-            result = self.results[definition.id]
-            return result.state, result
-        else:
-            return State.RUNNING, None
+        self.tracker["terminate"].add(definition.id)
+        return JobStatus(ExecutorState.ERROR)
 
     def cleanup(self, definition):
-        self.jobs_cleaned[definition.id] = definition
+        self.tracker["cleanup"].add(definition.id)
+        self.state.pop(definition.id, None)
+        return JobStatus(ExecutorState.UNKNOWN)
+
+    def get_status(self, definition):
+        state = self.state.get(definition.id, ExecutorState.UNKNOWN)
+        return JobStatus(state)
+
+    def get_results(self, definition):
+        return self.results.get(definition.id)
 
 
 class TestWorkspaceAPI:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,8 +6,6 @@ import pytest
 
 import jobrunner.run
 import jobrunner.sync
-from jobrunner.lib.database import find_where
-from jobrunner.models import Job, State
 from jobrunner import config
 from jobrunner.lib import docker
 from jobrunner.lib.subprocess_utils import subprocess_run
@@ -67,8 +65,7 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
     jobs = get_posted_jobs(requests_mock)
     assert [job["status"] for job in jobs.values()] == ["pending"] * 7
     # Exectue one tick of the run loop and then sync
-    active_jobs = find_where(Job, state__in=[State.PENDING, State.RUNNING])
-    jobrunner.run.handle_jobs(active_jobs)
+    jobrunner.run.handle_jobs()
     jobrunner.sync.sync()
     # We should now have one running job and all others waiting on dependencies
     jobs = get_posted_jobs(requests_mock)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,6 +6,8 @@ import pytest
 
 import jobrunner.run
 import jobrunner.sync
+from jobrunner.lib.database import find_where
+from jobrunner.models import Job, State
 from jobrunner import config
 from jobrunner.lib import docker
 from jobrunner.lib.subprocess_utils import subprocess_run
@@ -65,7 +67,8 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
     jobs = get_posted_jobs(requests_mock)
     assert [job["status"] for job in jobs.values()] == ["pending"] * 7
     # Exectue one tick of the run loop and then sync
-    jobrunner.run.handle_jobs()
+    active_jobs = find_where(Job, state__in=[State.PENDING, State.RUNNING])
+    jobrunner.run.handle_jobs(active_jobs)
     jobrunner.sync.sync()
     # We should now have one running job and all others waiting on dependencies
     jobs = get_posted_jobs(requests_mock)


### PR DESCRIPTION
Split the `JobAPI.run()` into separate prepare/execute/finalize steps.

This also makes JobAPI properly async, and splits out the state it's tracking into a separate ExecutorState.

This simplifies and changes a lot of things, so the main loop for the API is quite different from the the current one, so we diverge and split a function call higher up than previously.

