### PR TITLE
fix: Cancelled jobs should not modify workspace

### DIFF
--- a/jobrunner/manage_jobs.py
+++ b/jobrunner/manage_jobs.py
@@ -300,6 +300,12 @@ def finalise_job(job):
     with open(log_dir / "metadata.json", "w") as f:
         json.dump(job_metadata, f, indent=2)
 
+    # If a job was cancelled we bail out before making any changes to the
+    # workspace, but after having written the log and metadata files to the
+    # long-term logs directory for debugging purposes.
+    if job.cancelled:
+        raise JobError("Cancelled by user")
+
     # Copy logs to workspace
     workspace_dir = get_high_privacy_workspace(job.workspace)
     metadata_log_file = workspace_dir / METADATA_DIR / f"{job.action}.log"


### PR DESCRIPTION
At the moment, cancelled jobs are treated like failed jobs with the
consequence that they end up removing previous outputs from the same
action. We want them to act like jobs which were never really run.
However, for debugging purposes we still want to keep their logs and
metadata around. We do this by "part finalizing" them. This is not a
nice way of doing this, but this issue needs fixing now.

Fixes #246