### PR TITLE
Fix bug in manifest deserialization

### DIFF
--- a/jobrunner/manifest_to_database_migration.py
+++ b/jobrunner/manifest_to_database_migration.py
@@ -96,7 +96,7 @@ def _action_to_job(workspace, repo, files, action, details):
         workspace=workspace,
         repo_url=repo,
         action=action,
-        state=_map_get(details, "state", State.__getitem__, None),
+        state=_map_get(details, "state", State, None),
         commit=details.get("commit"),
         image_id=details.get("docker_image_id"),
         created_at=_map_get(details, "created_at", isoformat_to_timestamp, 0),

--- a/tests/test_manifest_to_database_migration.py
+++ b/tests/test_manifest_to_database_migration.py
@@ -331,7 +331,7 @@ def action(
     job_ = {
         action_: {
             "job_id": job_id,
-            "state": state.name,
+            "state": state.value,
             "commit": commit,
             "docker_image_id": image_id,
             "created_at": timestamp_to_isoformat(created_at),


### PR DESCRIPTION
The State enum is serialized in the manifest as its value, not its name,
here: https://github.com/opensafely-core/job-runner/blob/master/jobrunner/models.py#L145-L146.