### PR TITLE
fix: List all available actions if no actions supplied

### DIFF
--- a/jobrunner/project.py
+++ b/jobrunner/project.py
@@ -20,14 +20,7 @@ class ProjectValidationError(Exception):
 
 
 class UnknownActionError(ProjectValidationError):
-    """
-    Exception which carries with it the list of valid action names for display
-    to the user
-    """
-
-    def __init__(self, message, project):
-        super().__init__(message)
-        self.valid_actions = [RUN_ALL_COMMAND] + get_all_actions(project)
+    pass
 
 
 class InvalidPatternError(ProjectValidationError):
@@ -167,9 +160,7 @@ def get_action_specification(project, action_id):
     try:
         action_spec = project["actions"][action_id]
     except KeyError:
-        raise UnknownActionError(
-            f"Action '{action_id}' not found in project.yaml", project
-        )
+        raise UnknownActionError(f"Action '{action_id}' not found in project.yaml")
     run_command = action_spec["run"]
     if "config" in action_spec:
         run_command = add_config_to_run_command(run_command, action_spec["config"])


### PR DESCRIPTION
This was how the local_run CLI used to behave before it was accidentally
removed in c5625f50. Given that this is behavior we only need locally,
and given that we now have a seperate "create jobs" function for
local_run we can pull some of this code out of the main `project.py`
file.