### PR TITLE
ci on pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Tests
 
-on: [push]
+on:
+    pull_request:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PRIVATE_REPO_ACCESS_TOKEN: ${{ secrets.ACTIONS_PRIVATE_REPO_RO_TOKEN }}


### PR DESCRIPTION
Use `pull_request` event to trigger CI, so that PRs from external forks can us it.
