### PR TITLE
fix: Raise correct errors from `get_sha_from_remote_ref`

### DIFF
--- a/jobrunner/lib/git.py
+++ b/jobrunner/lib/git.py
@@ -132,7 +132,6 @@ def get_sha_from_remote_ref(repo_url, ref):
                 "git",
                 "ls-remote",
                 "--quiet",
-                "--exit-code",
                 add_access_token_and_proxy(repo_url),
                 ref,
                 deref_ref,


### PR DESCRIPTION
We attempt to distingish between "this repo does not exist" and "this
ref does not exist" so we can provide more helpful error messages.
Unfortunately our use of the [--exit-code][1] flag on `ls-remote` made
this not work as intended. This PR fixes this and adds tests for this
behaviour.

Closes #306

[1]: https://git-scm.com/docs/git-ls-remote#Documentation/git-ls-remote.txt---exit-code