### PR TITLE
Fixes for accessing GitHub when running locally

### DIFF
--- a/jobrunner/cli/local_run.py
+++ b/jobrunner/cli/local_run.py
@@ -208,6 +208,9 @@ def create_and_run_jobs(
     config.USING_DUMMY_DATA_BACKEND = True
     config.CLEAN_UP_DOCKER_OBJECTS = clean_up_docker_objects
 
+    # We want to fetch any reusable actions code directly from Github so as to
+    # avoid pushing unnecessary traffic through the proxy
+    config.GIT_PROXY_DOMAIN = "github.com"
     # Rather than using the throwaway `temp_dir` to store git repos in we use a
     # consistent directory within the system tempdir. This means we don't have
     # to keep refetching commits and also avoids the complexity of deleting

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -133,8 +133,9 @@ ALLOWED_GITHUB_ORGS = (
     os.environ.get("ALLOWED_GITHUB_ORGS", "opensafely").strip().split(",")
 )
 
-# we hardcode this for now, as from a security perspective, we do not want it
-# to be run time configurable.
+# We hardcode this for now, as from a security perspective, we do not want it
+# to be run time configurable. Though we do override this in `local_run.py` as
+# we don't want to push traffic via the proxy when running locally.
 GIT_PROXY_DOMAIN = "github-proxy.opensafely.org"
 
 

--- a/jobrunner/lib/git.py
+++ b/jobrunner/lib/git.py
@@ -18,6 +18,15 @@ log = logging.getLogger(__name__)
 # See `commit_already_fetched`
 SENTINEL_TAG_PREFIX = "fetched/"
 
+# Prevent git from ever prompting for credentials. Hat tip:
+# https://serverfault.com/a/1054253
+NEVER_PROMPT_FOR_AUTH_ENV = dict(
+    os.environ,
+    GIT_TERMINAL_PROMPT="0",
+    GIT_ASKPASS="echo",
+    GCM_INTERACTIVE="never",
+)
+
 
 class GitError(Exception):
     pass
@@ -140,6 +149,7 @@ def get_sha_from_remote_ref(repo_url, ref):
             capture_output=True,
             text=True,
             encoding="utf-8",
+            env=NEVER_PROMPT_FOR_AUTH_ENV,
         )
         output = response.stdout
     except subprocess.SubprocessError as exc:
@@ -268,6 +278,7 @@ def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
                 check=True,
                 capture_output=True,
                 cwd=repo_dir,
+                env=NEVER_PROMPT_FOR_AUTH_ENV,
             )
             mark_commmit_as_fetched(repo_dir, commit_sha)
             break

--- a/tests/lib/test_git.py
+++ b/tests/lib/test_git.py
@@ -70,10 +70,7 @@ def test_get_sha_from_remote_ref_missing_ref(tmp_work_dir):
 def test_get_sha_from_remote_ref_missing_repo(tmp_work_dir):
     with pytest.raises(GitRepoNotReachableError):
         get_sha_from_remote_ref(
-            # We supply some deliberately invalid authentication details here
-            # just to prevent Github prompting us for them
-            "https://foo:bar@github.com/opensafely-core/no-such-repo.git",
-            "main",
+            "https://github.com/opensafely-core/no-such-repo.git", "main"
         )
 
 


### PR DESCRIPTION
This PR changes the local_run config to access Github directly rather than pushing traffic through the proxy which is unnecessary here.

It also prevents git from prompting for credentials which it will do whenever an action repo is mistyped (Github treats all missing repo errors as authentication failures to avoid leaking the existence of private repos).