### PR TITLE
Hide logged exceptions in local run

### DIFF
--- a/jobrunner/cli/local_run.py
+++ b/jobrunner/cli/local_run.py
@@ -237,6 +237,15 @@ def create_and_run_jobs(
     config.MEDIUM_PRIVACY_STORAGE_BASE = None
     config.MEDIUM_PRIVACY_WORKSPACES_DIR = None
 
+    configure_logging(
+        fmt=log_format,
+        # All the other output we produce goes to stdout and it's a bit
+        # confusing if the log messages end up on a separate stream
+        stream=sys.stdout,
+        # Filter out log messages in the local run context
+        extra_filter=filter_log_messages,
+    )
+
     # This is a temporary migration step to avoid unnecessarily re-running actions as we migrate away from the manifest.
     manifest_to_database_migration.migrate_one(
         project_dir, write_medium_privacy_manifest=False, batch_size=1000, log=False
@@ -312,15 +321,6 @@ def create_and_run_jobs(
 
     action_names = [job.action for job in jobs]
     print(f"\nRunning actions: {', '.join(action_names)}\n")
-
-    configure_logging(
-        fmt=log_format,
-        # All the other output we produce goes to stdout and it's a bit
-        # confusing if the log messages end up on a separate stream
-        stream=sys.stdout,
-        # Filter out log messages in the local run context
-        extra_filter=filter_log_messages,
-    )
 
     # Wrap all the log output inside an expandable block when running inside
     # Github Actions

--- a/jobrunner/cli/local_run.py
+++ b/jobrunner/cli/local_run.py
@@ -479,7 +479,13 @@ def filter_log_messages(record):
     and make things clearer for the user we filter them out here
     """
     status_code = getattr(record, "status_code", None)
-    return status_code not in STATUS_CODES_NOT_TO_LOG
+    if status_code in STATUS_CODES_NOT_TO_LOG:
+        return False
+    # We sometimes log caught exceptions for debugging purposes in production,
+    # but we don't want to show these to the user when running locally
+    if getattr(record, "exc_info", None):
+        return False
+    return True
 
 
 # Copied from test/conftest.py to avoid a more complex dependency tree

--- a/jobrunner/lib/log_utils.py
+++ b/jobrunner/lib/log_utils.py
@@ -17,12 +17,12 @@ import time
 DEFAULT_FORMAT = "{asctime} {message} {tags}"
 
 
-def configure_logging(fmt=DEFAULT_FORMAT, stream=None, status_codes_to_ignore=None):
+def configure_logging(fmt=DEFAULT_FORMAT, stream=None, extra_filter=None):
     formatter = JobRunnerFormatter(fmt, style="{")
     handler = logging.StreamHandler(stream=stream)
     handler.setFormatter(formatter)
-    if status_codes_to_ignore:
-        handler.addFilter(IgnoreStatusCodes(status_codes_to_ignore))
+    if extra_filter:
+        handler.addFilter(extra_filter)
     handler.addFilter(formatting_filter)
 
     log_level = os.environ.get("LOGLEVEL", "INFO")
@@ -112,19 +112,6 @@ def formatting_filter(record):
     record.action = f"{job.action}: " if job else ""
 
     return True
-
-
-class IgnoreStatusCodes:
-    """
-    Skip log lines which have certain status codes
-    """
-
-    def __init__(self, status_codes_to_ignore):
-        self.status_codes_to_ignore = set(status_codes_to_ignore)
-
-    def filter(self, record):
-        status_code = getattr(record, "status_code", None)
-        return status_code not in self.status_codes_to_ignore
 
 
 class SetLogContext(threading.local):

--- a/tests/cli/test_local_run.py
+++ b/tests/cli/test_local_run.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import logging
 import os
 import shutil
 import time
@@ -195,3 +196,16 @@ def test_add_arguments():
     assert args.project_dir == "dir"
     assert args.timestamps
     assert args.debug
+
+
+def test_filter_log_messages():
+    record = logging.makeLogRecord({})
+    assert local_run.filter_log_messages(record)
+
+    record = logging.makeLogRecord({"status_code": "code"})
+    assert local_run.filter_log_messages(record)
+
+    record = logging.makeLogRecord(
+        {"status_code": local_run.StatusCode.WAITING_ON_DEPENDENCIES}
+    )
+    assert local_run.filter_log_messages(record) is False

--- a/tests/lib/test_log_utils.py
+++ b/tests/lib/test_log_utils.py
@@ -68,22 +68,6 @@ def test_formatting_filter_with_context():
     assert record.tags == "project=project action=action id=id req=request"
 
 
-def test_ignore_status_code_filter():
-    ignore_filter = log_utils.IgnoreStatusCodes(["ignore"])
-
-    record = logging.makeLogRecord({})
-    assert log_utils.formatting_filter(record)
-    assert ignore_filter.filter(record)
-
-    record = logging.makeLogRecord({"status_code": "code"})
-    assert log_utils.formatting_filter(record)
-    assert ignore_filter.filter(record)
-
-    record = logging.makeLogRecord({"status_code": "ignore"})
-    assert log_utils.formatting_filter(record)
-    assert ignore_filter.filter(record) is False
-
-
 def test_jobrunner_formatter_default(monkeypatch):
     monkeypatch.setattr(time, "time", lambda: FROZEN_TIMESTAMP)
     record = logging.makeLogRecord(


### PR DESCRIPTION
For debugging purposes, we log some categories of caught exceptions. This is useful in production, but it's not helpful when running locally and creates confusing noise for the user. For example, trying to run a non-existent reusable action currently gives output like this:
```
$ opensafely run my_action
Error reading from remote repository
Traceback (most recent call last):
  File "/home/dave/projects/ebmdatalab/job-runner/jobrunner/lib/git.py", line 139, in get_sha_from_remote_ref
    response = subprocess_run(
  File "/home/dave/projects/ebmdatalab/job-runner/jobrunner/lib/subprocess_utils.py", line 19, in subprocess_run
    return subprocess.run(cmd_args, **kwargs)
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'ls-remote', '--quiet', 'https://github.com/opensafely-actions/no-such-action', 'latest', 'latest^{}']' returned non-zero exit status 128.

stderr:

remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
fatal: Authentication failed for 'https://github.com/opensafely-actions/no-such-action/'

=> ReusableActionError
   in 'my_action: no-such-action:latest' could not find a repo at https://github.com/opensafely-actions/no-such-action
   Check that 'no-such-action' is in the list of available actions at https://actions.opensafely.org
```

Whereas we want it to look like this:
```
$ opensafely run my_action

=> ReusableActionError
   in 'my_action: no-such-action:latest' could not find a repo at https://github.com/opensafely-actions/no-such-action
   Check that 'no-such-action' is in the list of available actions at https://actions.opensafely.org
```