### PR TITLE
ci: fix local docker dev setup to not use SSH.

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -69,13 +69,6 @@ jobs:
       run: |
           make docker-build  # build base and dev images
           make docker-build ENV=prod  # build and tag prod image
-    - name: Setup self-SSH
-      run: |
-        # ensure local user is set up to ssh in to the runner
-        chmod 700 ~
-        mkdir ~/.ssh -m 700
-        touch ~/.ssh/authorized_keys
-        chmod 600 ~/.ssh/authorized_keys
     - name: Test image
       run: make docker-test ARGS='-e PRIVATE_REPO_ACCESS_TOKEN'
     - name: Log into GitHub Container Registry

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,13 +83,6 @@ jobs:
       uses: actions/checkout@v1
     - name: Build image
       run: make docker-build
-    - name: Setup self-SSH
-      run: |
-        # ensure local user is set up to ssh in to the runner
-        chmod 700 ~
-        mkdir ~/.ssh -m 700
-        touch ~/.ssh/authorized_keys
-        chmod 600 ~/.ssh/authorized_keys
     - name: Run tests in docker-image
       run: make docker-test ARGS='-e PRIVATE_REPO_ACCESS_TOKEN'
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ service*.log
 tags
 docker/ssh/id_*
 docker/ssh/known_hosts
+docker/.env
 /.idea/
 .hypothesis/

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -66,7 +66,8 @@ To run tests in docker, simply run:
 
     make docker-test
 
-This will build the docker image and run tests. You can run job-runner with:
+This will build the docker image and run tests. You can run job-runner as
+a service with:
 
     make docker-serve
 
@@ -74,16 +75,6 @@ Or run a command inside the docker image:
 
     make docker-run ARGS=command  # bash by default
 
-Note: we use ssh for authenticated network access to the host's docker in
-development. The above commands will automatically generate a local ed25519
-dev ssh key, and add it to your `~/.ssh/authorized_keys` file. You can use
-`make docker-clean` to remove this.  If you wish to use a different user/host,
-you can do so:
-
-1. Specify `DOCKER_USER` and `DOCKER_ADDR` environment variables.
-2. Add an authorized ed25519 private key for that user to `docker/ssh/id_ed25519`.
-3. Run `touch docker/ssh/id_ed25519.authorized` to let Make know that it is all
-   set up.
 
 
 ### Testing on Windows
@@ -143,3 +134,38 @@ See the full set of options it accepts with:
 ```
 python -m jobrunner.cli.add_job --help
 ```
+
+## job-runner docker image
+
+Building the dev docker image:
+
+    make docker-build                   # build base and dev image
+    make docker-build ENV=prod          # build base and prod image
+    make docker-build ARGS=--no-cache   # build without cache
+
+
+### Exposing the host's docker service
+
+By default, running the docker container will mount your host's
+`/var/run/docker.sock` into the container and use that for job-runner to run
+jobs. It does some matching of docker GIDs to do so.
+
+However, it also supports accessing docker over ssh:
+
+    make -C docker enable-docker-over-ssh
+
+The docker-compose invocations will now talk to your host docker over SSH,
+possibly on a remote machine. You can disable with:
+
+    make -C docker disable-docker-over-ssh
+
+Note: The above commands will automatically generate a local ed25519
+dev ssh key, and add it to your `~/.ssh/authorized_keys` file. You can use
+`make docker-clean` to remove this.  If you wish to use a different user/host,
+you can do so:
+
+1. Specify `SSH_USER` and `SSH_HOST` environment variables.
+2. Add an authorized ed25519 private key for that user to `docker/ssh/id_ed25519`.
+3. Run `touch docker/ssh/id_ed25519.authorized` to let Make know that it is all
+   set up.
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,12 @@ FROM ghcr.io/opensafely-core/base-docker:latest as base-python
 # docker clean up that deletes that cache on every apt install
 RUN rm -f /etc/apt/apt.conf.d/docker-clean
 
+# preemptively create a docker group using specific gid, before docker is
+# installed. This allows us to set the host docker gid to the same thing in
+# systems we control, and then we can just mount /var/run/docker.sock into the
+# container.
+RUN groupadd --gid 10010 docker
+
 # ensure fully working base python3 installation
 # see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
 # use space efficient utility from base image
@@ -79,7 +85,7 @@ FROM base-python as job-runner-base
 # We currently use host bind mounts in production backends, which means if we
 # need to match the uid inside the container to the one on the host.  To do
 # this, we reserve uid/gid 10000 to use as our running user on the host.
-RUN useradd --create-home --user-group --uid 10000 appuser
+RUN useradd --create-home --user-group --uid 10000 -G docker appuser
 
 # copy venv over from builder image. These will have root:root ownership, but
 # are readable by all.
@@ -151,10 +157,15 @@ COPY requirements.dev.txt /tmp/requirements.dev.txt
 RUN --mount=type=cache,target=/root/.cache \
     python -m pip install --requirement /tmp/requirements.dev.txt
 
+# modify container docker gid to match host
+ARG DOCKER_HOST_GROUPID
+RUN groupmod -g $DOCKER_HOST_GROUPID docker
+
 # in dev, ensure appuser uid matches host user id
-ARG USERID=1000
-ARG GROUPID=1000
-RUN usermod -u $USERID appuser && groupmod -g $GROUPID appuser
+ARG DEV_USERID=1000
+ARG DEV_GROUPID=1000
+RUN usermod -u $DEV_USERID appuser
+RUN groupmod -g $DEV_GROUPID appuser
 
 # switch back to appuser
 USER appuser

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -165,7 +165,12 @@ RUN groupmod -g $DOCKER_HOST_GROUPID docker
 ARG DEV_USERID=1000
 ARG DEV_GROUPID=1000
 RUN usermod -u $DEV_USERID appuser
-RUN groupmod -g $DEV_GROUPID appuser
+# Modify appuse group only if group id does not already exist. We run dev
+# containers with an explicit group id anyway, so file permissions on the host
+# will be correct, and we do not actually rely on named appuser group access to
+# anything.
+RUN grep -q ":$DEV_GROUPID:" /etc/group || groupmod -g $DEV_GROUPID appuser
+
 
 # switch back to appuser
 USER appuser

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,31 +1,11 @@
-# used to ensure the dev container uses the same uid/gid as the current user
-export DOCKER_USERID ?= $(shell id -u)
-export DOCKER_GROUPID ?= $(shell id -g)
 
-# user to ensure that ssh access is set up to the host
-export DOCKER_USER ?= $(USER)
-export DOCKER_ADDR ?= $(shell docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
-
-SSH_KEY=ssh/id_ed25519
-SSH_PUBKEY=$(SSH_KEY).pub
-SSH_COMMENT=local jobrunner dev key
-
-# create known_hosts file so ssh works without prompting
-ssh/known_hosts:
-	ssh-keyscan $(DOCKER_ADDR) > ssh/known_hosts
-
-
-# create a local dev key with no password to use for ssh access
-$(SSH_KEY):
-	ssh-keygen -t ed25519 -N '' -C "$(SSH_COMMENT)" -f $@
-
-
-# ensure the local dev key is allowed to ssh in as current user
-$(SSH_KEY).authorized: $(SSH_KEY) ssh/known_hosts
-	grep -q "$(shell cat $(SSH_PUBKEY))" ~/.ssh/authorized_keys || cat $(SSH_PUBKEY) >> ~/.ssh/authorized_keys
-	# quick test to fail early if ssh doesn't work for some reason
-	ssh -i $(SSH_KEY) -o UserKnownHostsFile=ssh/known_hosts $(DOCKER_USER)@$(DOCKER_ADDR) true || { echo "Failed to ssh into $(DOCKER_ADDR)"; tail /var/log/auth.log; exit 1; }
-	touch $@
+# local dev env file for docker-compose to use when building
+.env:
+	@echo "Generating local docker-compose .env file..."
+	@echo "# local dev docker-compose config" > $@
+	@echo "DEV_USERID=$(shell id -u)" >> $@
+	@echo "DEV_GROUPID=$(shell id -g)" >> $@
+	@echo "DOCKER_HOST_GROUPID=$(shell getent group docker | awk -F: '{print $$3}')" >> $@
 
 
 .PHONY: docker-build
@@ -37,20 +17,20 @@ docker-build: export BUILD_DATE=$(date -u +'%y-%m-%dT%H:%M:%SZ')
 docker-build: export GITREF=$(git rev-parse --short HEAD)
 docker-build: ENV ?= dev
 docker-build: ARGS ?= --pull
-docker-build:
-	docker-compose build $(ARGS) $(ENV) 
+docker-build: .env
+	docker-compose --env-file .env build  $(ARGS) $(ENV) 
 
 
 .PHONY: docker-test
 # run tests in docker container
-docker-test: docker-build $(SSH_KEY).authorized
+docker-test: docker-build
 	docker-compose run $(ARGS) --rm test
 
 
 .PHONY: docker-serve
 # run server in docker container
 docker-serve: ENV ?= dev
-docker-serve: docker-build $(SSH_KEY).authorized
+docker-serve: docker-build
 	docker-compose up $(ENV)
 
 
@@ -58,20 +38,60 @@ docker-serve: docker-build $(SSH_KEY).authorized
 # run command in container
 docker-run: ENV ?= dev
 docker-run: CMD ?= bash
-docker-run: docker-build $(SSH_KEY).authorized
+docker-run: docker-build
 	docker-compose run --rm $(ARGS) $(ENV) $(CMD)
 
 
 .PHONY: docker-exec
 # exec command in existing dev container
-docker-run: ENV ?= dev
+docker-exec: ENV ?= dev
 docker-exec: CMD ?= bash
-docker-exec: docker-build $(SSH_KEY).authorized
+docker-exec: docker-build
 	docker-compose exec $(ENV) $(CMD)
 
 
 .PHONY: docker-clean
 docker-clean:
+	rm -f .env
+	docker image rm job-runner job-runner-dev || true
 	# clean up local ssh config
 	rm -f ssh/known_hosts ssh/id_ed25519*
 	sed -i '/$(SSH_COMMENT)/d' ~/.ssh/authorized_keys
+
+
+# support using docker over ssh in dev
+SSH_KEY ?= ssh/id_ed25519
+SSH_PUBKEY ?= $(SSH_KEY).pub
+SSH_COMMENT = local jobrunner dev key
+SSH_USER ?= $(USER)
+SSH_HOST ?= $(shell docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
+
+
+# create known_hosts file so ssh works without prompting
+ssh/known_hosts:
+	ssh-keyscan $(SSH_HOST) > ssh/known_hosts
+
+
+# create a local dev key with no password to use for ssh access
+$(SSH_KEY):
+	ssh-keygen -t ed25519 -N '' -C "$(SSH_COMMENT)" -f $@
+
+
+# ensure the local dev key is allowed to ssh in as current user
+$(SSH_KEY).authorized: $(SSH_KEY) ssh/known_hosts
+	grep -q "$(shell cat $(SSH_PUBKEY))" ~/.ssh/authorized_keys || cat $(SSH_PUBKEY) >> ~/.ssh/authorized_keys
+	# quick test to fail early if ssh doesn't work for some reason
+	ssh -i $(SSH_KEY) -o UserKnownHostsFile=ssh/known_hosts $(SSH_USER)@$(SSH_HOST) true || { echo "Failed to ssh into $(SSH_HOST)"; tail /var/log/auth.log; exit 1; }
+	touch $@
+
+
+# this will override the default of /var/run/docker.sock
+enable-docker-over-ssh: $(SSH_KEY).authorized .env
+	@echo "Enabling use of SSH in .env..."
+	@echo "DOCKER_HOST=ssh://$(SSH_USER)@$(SSH_HOST)" >> .env
+
+
+# restore regular socket based docker access
+disable-docker-over-ssh: .env
+	rm -f .env
+	$(MAKE) .env

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -29,14 +29,18 @@ services:
       - ../workdir:/workdir
       # used to configure ssh access for docker
       - ./ssh:/home/appuser/.ssh
+      # docker control
+      - /var/run/docker.sock:/var/run/docker.sock
+    # paths relative to docker-compose.yaml file
+    env_file:
+      - ../.env
     # ensure WORKDIR environment points to fixed location
     environment:
       # default dev config
       WORKDIR: /workdir
       MEDIUM_PRIVACY_STORAGE_BASE: /workdir/workspaces
       HIGH_PRIVACY_STORAGE_BASE: /workdir/workspaces
-      # use docker over SSH to avoid socket file permissions
-      DOCKER_HOST: ssh://${DOCKER_USER}@${DOCKER_ADDR}
+      DOCKER_HOST: ${DOCKER_HOST:-unix:///var/run/docker.sock}
 
   # main development service
   dev:
@@ -47,17 +51,17 @@ services:
     # running as a specific uid/gid allows files written to mounted volumes by
     # the docker container's default user to match the host user's uid/gid, for
     # convienience.
-    user: ${DOCKER_USERID:-1000}:${DOCKER_GROUPID:-1000}
+    user: ${DEV_USERID:-1000}:${DEV_GROUPID:-1000}
+    # also run with additional group docker
+    group_add: [docker]
     build:
       # the dev stage in the Dockerfile
       target: job-runner-dev
       # pass the uid/gid as build arg
       args:
-        - USERID=${DOCKER_USERID:-1000}
-        - GROUPID=${DOCKER_GROUPID:-1000}
-    # paths relative to docker-compose.yaml file
-    env_file:
-      - ../.env
+        - DEV_USERID=${DEV_USERID:-1000}
+        - DEV_GROUPID=${DEV_GROUPID:-1000}
+        - DOCKER_HOST_GROUPID=${DOCKER_HOST_GROUPID}
     volumes:
       - ..:/app
 


### PR DESCRIPTION
Using SSH by default was slower, and error prone on different
developer's environments (e.g. they had to have SSH set up).

Instead, we default matching the docker GIDs so we can mount the socket.
This avoids the need for SSH in prod and dev

SSH is still supported however, as it is possibly useful in prod in the
longer term.
