### PR TITLE
fix: mark jobs as failed on error with executor api

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -282,6 +282,21 @@ def test_bad_transition(current, invalid, db):
         run.handle_job_api(job, api)
 
 
+def test_handle_active_job_marks_as_failed(db, monkeypatch):
+    api = StubExecutorAPI()
+    job = api.add_test_job(ExecutorState.EXECUTED, State.RUNNING)
+
+    def error(*args, **kwargs):
+        raise Exception("test")
+
+    monkeypatch.setattr(api, "get_status", error)
+
+    with pytest.raises(Exception):
+        run.handle_active_job_api(job, api)
+
+    assert job.state is State.FAILED
+
+
 def test_ignores_cancelled_jobs_when_calculating_dependencies(db):
     job_factory(
         id="1",


### PR DESCRIPTION
Somehow this was overlooked in the executor API work. It was there at
one point, as the removal of `handle_active_jobs_api` shows, but in the
refactoring of the active job loop must have got lost, and the tests
were missing.

Most of the diff is the indention of the unalterd main job handling code to be wrapped in try: except