### PR TITLE
fix: Update docker label to match new value

### DIFF
--- a/scripts/watch-job-logs.sh
+++ b/scripts/watch-job-logs.sh
@@ -24,7 +24,7 @@ done
 # An empty name search matches everything, which is what we want
 job_list="$(
   docker container ls --all \
-    --filter 'label=jobrunner-job' \
+    --filter 'label=jobrunner-local' \
     --filter "name=$name_search" \
     --format='{{.Names}}'
 )"


### PR DESCRIPTION
The new "local Docker" job executor sets a different label from the old
code.