### PR TITLE
chore: Support databuilder Docker image

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -60,6 +60,7 @@ else:
 ALLOWED_IMAGES = {
     "cohortextractor",
     "cohortextractor-v2",
+    "databuilder",
     "stata-mp",
     "r",
     "jupyter",

--- a/jobrunner/project.py
+++ b/jobrunner/project.py
@@ -249,7 +249,11 @@ def is_generate_cohort_command(args, require_version=None):
     if len(args) > 1 and args[1] == "generate_cohort":
         if args[0].startswith("cohortextractor:"):
             version_found = 1
-        if args[0].startswith("cohortextractor-v2:"):
+        # databuilder is a rebranded cohortextractor-v2.
+        # Retain cohortextractor-v2 for backwards compatibility for now.
+        elif args[0].startswith("cohortextractor-v2:") or args[0].startswith(
+            "databuilder:"
+        ):
             version_found = 2
     # If we're not looking for a specific version then return True if any
     # version found

--- a/jobrunner/project.py
+++ b/jobrunner/project.py
@@ -251,9 +251,7 @@ def is_generate_cohort_command(args, require_version=None):
             version_found = 1
         # databuilder is a rebranded cohortextractor-v2.
         # Retain cohortextractor-v2 for backwards compatibility for now.
-        elif args[0].startswith("cohortextractor-v2:") or args[0].startswith(
-            "databuilder:"
-        ):
+        elif args[0].startswith(("cohortextractor-v2:", "databuilder:")):
             version_found = 2
     # If we're not looking for a specific version then return True if any
     # version found

--- a/jobrunner/reusable_actions.py
+++ b/jobrunner/reusable_actions.py
@@ -183,7 +183,9 @@ def apply_reusable_action(run_args, reusable_action):
         if action_image not in config.ALLOWED_IMAGES:
             raise ReusableActionError(f"Unrecognised runtime: {action_image}")
         if is_generate_cohort_command(action_run_args):
-            raise ReusableActionError("Re-usable actions cannot invoke cohortextractor")
+            raise ReusableActionError(
+                "Re-usable actions cannot invoke cohortextractor/databuilder"
+            )
     except (YAMLError, ReusableActionError) as e:
         formatted_error = textwrap.indent(f"{type(e).__name__}: {e}", "  ")
         raise ReusableActionError(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -127,13 +127,13 @@ def test_get_action_specification_for_cohortextractor_generate_cohort_action():
         == """cohortextractor:latest generate_cohort --expectations-population=1000 --output-dir=output"""
     )
 
-
-def test_get_action_specification_for_cohortextractor_v2_action():
+@pytest.mark.parametrize("image", ["cohortextractor-v2", "databuilder"])
+def test_get_action_specification_for_databuilder_action(image):
     project_dict = {
         "expectations": {"population_size": 1_000},
         "actions": {
             "generate_cohort_v2": {
-                "run": "cohortextractor-v2:latest generate_cohort --output=output/cohort.csv --dummy-data-file dummy.csv",
+                "run": f"{image}:latest generate_cohort --output=output/cohort.csv --dummy-data-file dummy.csv",
                 "outputs": {"highly_sensitive": {"cohort": "output/cohort.csv"}},
             }
         },
@@ -142,29 +142,41 @@ def test_get_action_specification_for_cohortextractor_v2_action():
     action_spec = project.get_action_specification(project_dict, action_id)
     assert (
         action_spec.run
-        == """cohortextractor-v2:latest generate_cohort --output=output/cohort.csv --dummy-data-file dummy.csv"""
+        == f"""{image}:latest generate_cohort --output=output/cohort.csv --dummy-data-file dummy.csv"""
     )
 
 
 @pytest.mark.parametrize(
-    "args,error",
+    "args,error,image",
     [
         (
             "--output=output/cohort1.csv --dummy-data-file dummy.csv",
             "--output in run command and outputs must match",
+            "cohortextractor-v2",
         ),
         (
             "--output=output/cohort1.csv",
             "--dummy-data-file is required for a local run",
+            "cohortextractor-v2",
+        ),
+        (
+            "--output=output/cohort1.csv --dummy-data-file dummy.csv",
+            "--output in run command and outputs must match",
+            "databuilder",
+        ),
+        (
+            "--output=output/cohort1.csv",
+            "--dummy-data-file is required for a local run",
+            "databuilder",
         ),
     ],
 )
-def test_get_action_specification_for_cohortextractor_v2_errors(args, error):
+def test_get_action_specification_for_databuilder_errors(args, error, image):
     project_dict = {
         "expectations": {"population_size": 1_000},
         "actions": {
             "generate_cohort_v2": {
-                "run": f"cohortextractor-v2:latest generate_cohort {args}",
+                "run": f"{image}:latest generate_cohort {args}",
                 "outputs": {"highly_sensitive": {"cohort": "output/cohort.csv"}},
             }
         },


### PR DESCRIPTION
This image is the same as the `cohortextractor-v2` image with a different name.

Eventually we could clean up and remove support for the `cohortextractor-v2` image. That would be once any study/test code using that image is migrated to the databuilder image.