### PR TITLE
chore: Update `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,18 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 21.8b0
     hooks:
     - id: black
       language_version: python3.8
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.8.4
     hooks:
     - id: flake8
       language_version: python3.8
 
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-    - id: seed-isort-config
-
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.3.0
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.6.4
     hooks:
     - id: isort
       language_version: python3.8


### PR DESCRIPTION
* Match the versions in the requirements.
* Switch deprecated `mirrors-isort` to `isort`.
* Change PyCQA GitLab to GitHub.
* Remove deprecated `seed-isort-config` (it's archived and not needed for
  isort versions).