### PR TITLE
fix: remove volumes from docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,8 +96,6 @@ ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH"
 
 RUN mkdir /app
 WORKDIR /app
-VOLUME /app
-VOLUME /workdir
 
 # We set command rather than entrypoint, to make it easier to run different
 # things from the cli


### PR DESCRIPTION
The volume mounts were originally added as metadata, but it turns out if
you don't supply a mount, docker creates one for you with the contents
of that dir in your that lasts beyond the containers lifetime and eats
disk.
