### PR TITLE
Test with Data Builder

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,12 @@ jobs:
   test-job:
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-2019]
         # Python 3.8 is what we currently support for running cohortextractor
         # locally, and 3.9 is what we required for databuilder so we need to make
         # sure we can run with those
         python: [3.8, 3.9]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     name: Run test suite
     steps:
     - name: Checkout
@@ -27,27 +28,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.dev.txt
-    - name: Run actual tests
+    - name: Run actual tests on ${{ matrix.os }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: python -m pytest
-
-  # A bit of inelegant copy/paste here, just to see if this works
-  test-job-windows:
-    runs-on: windows-2019
-    name: "Run test suite on Windows"
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-    # Python 3.8 is what we currently require for running the cohortextractor
-    #  locally so we need to make sure we can run with that
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.dev.txt
-    - name: Run actual tests
+    - name: Run actual tests on ${{ matrix.os }}
+      if: ${{ matrix.os == 'windows-2019' }}
       run: python -m pytest -m "not needs_docker"
 
   test-package-build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,15 +8,21 @@ env:
   STATA_LICENSE: ${{ secrets.STATA_LICENSE }}
 jobs:
   test-job:
+    strategy:
+      matrix:
+        # Python 3.8 is what we currently support for running cohortextractor
+        # locally, and 3.9 is what we required for databuilder so we need to make
+        # sure we can run with those
+        python: [3.8, 3.9]
     runs-on: ubuntu-latest
     name: Run test suite
     steps:
     - name: Checkout
       uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -295,7 +295,7 @@ def handle_job_api(job, api):
         elif job.state != State.RUNNING:
             # got an ExecutorState that should mean the job.state is RUNNING, but it is not
             log.warning(
-                "state error: got {new_status.state} for job we thought was {job.state}"
+                f"state error: got {new_status.state} for job we thought was {job.state}"
             )
         set_message(job, new_status.state.value.title())
 

--- a/tests/cli/test_local_run.py
+++ b/tests/cli/test_local_run.py
@@ -26,16 +26,33 @@ def use_api(request, monkeypatch):
 
 
 @pytest.mark.parametrize("use_api", [True, False], indirect=True)
+@pytest.mark.parametrize("extraction_tool", ["cohortextractor", "databuilder"])
 @pytest.mark.slow_test
 @pytest.mark.needs_docker
-def test_local_run_success(use_api, tmp_path, docker_cleanup):
+def test_local_run_success(use_api, extraction_tool, tmp_path, docker_cleanup):
     project_dir = tmp_path / "project"
     shutil.copytree(str(FIXTURE_DIR / "full_project"), project_dir)
-    local_run.main(project_dir=project_dir, actions=["analyse_data"])
-    assert (project_dir / "output/input.csv").exists()
-    assert (project_dir / "counts.txt").exists()
-    assert (project_dir / "metadata/analyse_data.log").exists()
-    assert (project_dir / "metadata" / "db.sqlite").exists()
+
+    local_run.main(project_dir=project_dir, actions=[f"analyse_data_{extraction_tool}"])
+
+    # FIXME: consolidate these when databuilder supports more columns in dummy data
+    if extraction_tool == "cohortextractor":
+        paths = [
+            "output/input.csv",
+            "cohortextractor-counts.txt",
+            "metadata/analyse_data_cohortextractor.log",
+            "metadata/db.sqlite",
+        ]
+    else:
+        paths = [
+            "output/dataset.csv",
+            "output/count_by_year.csv",
+            "metadata/analyse_data_databuilder.log",
+            "metadata/db.sqlite",
+        ]
+
+    for path in paths:
+        assert (project_dir / path).exists(), path
     assert not (project_dir / "metadata/.logs").exists()
 
 
@@ -79,7 +96,10 @@ def test_local_run_triggers_a_manifest_migration(tmp_path, docker_cleanup):
 
 @pytest.mark.slow_test
 @pytest.mark.needs_docker
-def test_local_run_copes_with_detritus_of_earlier_interrupted_run(tmp_path):
+@pytest.mark.parametrize("extraction_tool", ["cohortextractor", "databuilder"])
+def test_local_run_copes_with_detritus_of_earlier_interrupted_run(
+    extraction_tool, tmp_path
+):
     # This test simulates the case where an earlier run has been interrupted (for example by the user pressing ctrl-c).
     # In particular we put a couple of jobs in unfinished states, which they could never be left in under normal
     # operation. The correct behaviour of the local run, which this tests for, is for such unfinished jobs to be marked
@@ -113,10 +133,15 @@ def test_local_run_copes_with_detritus_of_earlier_interrupted_run(tmp_path):
             outputs={},
         )
 
-    database.insert(job(job_id="123", action="generate_cohort", state=State.RUNNING))
-    database.insert(job(job_id="456", action="prepare_data_m", state=State.PENDING))
+    # FIXME: consolidate these when databuilder supports more columns in dummy data
+    if extraction_tool == "cohortextractor":
+        actions = ["generate_cohort", "prepare_data_m_cohortextractor"]
+    else:
+        actions = ["generate_dataset", "analyse_data_databuilder"]
 
-    assert local_run.main(project_dir=project_dir, actions=["prepare_data_m"])
+    database.insert(job(job_id="123", action=actions[0], state=State.RUNNING))
+    database.insert(job(job_id="456", action=actions[1], state=State.PENDING))
+    assert local_run.main(project_dir=project_dir, actions=[actions[1]])
 
     assert database.find_one(Job, id="123").cancelled
     assert database.find_one(Job, id="123").state == State.FAILED

--- a/tests/fixtures/full_project/analysis/count_by_year.py
+++ b/tests/fixtures/full_project/analysis/count_by_year.py
@@ -1,0 +1,18 @@
+import collections
+import csv
+import sys
+
+
+def main(input_file, output_file):
+    with open(input_file, newline="") as f_in:
+        csv_reader = csv.DictReader(f_in)
+        counter = collections.Counter(int(x["year_of_birth"]) for x in csv_reader)
+
+    with open(output_file, "w", newline="") as f_out:
+        csv_writer = csv.writer(f_out)
+        csv_writer.writerow(["year", "count"])
+        csv_writer.writerows(x for x in sorted(counter.items(), key=lambda x: x[0]))
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:])

--- a/tests/fixtures/full_project/analysis/dataset_definition.py
+++ b/tests/fixtures/full_project/analysis/dataset_definition.py
@@ -1,0 +1,9 @@
+from databuilder.definition import register
+from databuilder.query_language import Dataset
+from databuilder.tables import patients
+
+year_of_birth = patients.date_of_birth.year
+dataset = Dataset()
+dataset.set_population(year_of_birth >= 2000)
+dataset.year_of_birth = year_of_birth
+register(dataset)

--- a/tests/fixtures/full_project/analysis/dummy_action.py
+++ b/tests/fixtures/full_project/analysis/dummy_action.py
@@ -1,0 +1,20 @@
+import sys
+
+
+def main(output_file):
+    """
+    Write a dummy file to disk
+
+    Databuilder doesn't currently provide many features for studies, so the
+    options we have for actions in this full_project fixture are limited.  This
+    "action" does the bare minimum just so we can have another action in the
+    project.yaml.  Once databuilder supports more column types in the dummy
+    data then we can remove this in favour of more meaningful actions such as
+    those used in the cohortextractor version of the integration test.
+    """
+    with open(output_file, "w") as f:
+        f.write("test file\n")
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:])

--- a/tests/fixtures/full_project/project.yaml
+++ b/tests/fixtures/full_project/project.yaml
@@ -18,37 +18,37 @@ actions:
       highly_sensitive:
         cohort: output/extra/input.csv
 
-  prepare_data_m:
-    run: python:latest python analysis/filter_by_sex.py M output/input.csv male.csv
+  prepare_data_m_cohortextractor:
+    run: python:latest python analysis/filter_by_sex.py M output/input.csv cohortextractor-male.csv
     needs: [generate_cohort]
     outputs:
       highly_sensitive:
-        male_cohort: male.*
+        male_cohort: cohortextractor-male.*
 
-  prepare_data_f:
-    run: python:latest python analysis/filter_by_sex.py F output/input.csv female.csv
+  prepare_data_f_cohortextractor:
+    run: python:latest python analysis/filter_by_sex.py F output/input.csv cohortextractor-female.csv
     needs: [generate_cohort]
     outputs:
       highly_sensitive:
-        female_cohort: female.*
+        female_cohort: cohortextractor-female.*
 
-  prepare_data_with_quote_in_filename:
-    run: python:latest python analysis/filter_by_sex.py F output/input.csv "qu'ote.csv"
+  prepare_data_with_quote_in_filename_cohortextractor:
+    run: python:latest python analysis/filter_by_sex.py F output/input.csv "cohortextractor-qu'ote.csv"
     needs: [generate_cohort]
     outputs:
       highly_sensitive:
-        quote_cohort: "qu'ote.*"
+        quote_cohort: "cohortextractor-qu'ote.*"
 
-  analyse_data:
-    run: python:latest python analysis/count_lines.py counts.txt
+  analyse_data_cohortextractor:
+    run: python:latest python analysis/count_lines.py cohortextractor-counts.txt
     config:
-      files: ["male.csv", "female.csv", "qu'ote.csv"]
-    needs: [prepare_data_m, prepare_data_f, prepare_data_with_quote_in_filename]
+      files: ["cohortextractor-male.csv", "cohortextractor-female.csv", "cohortextractor-qu'ote.csv"]
+    needs: [prepare_data_m_cohortextractor, prepare_data_f_cohortextractor, prepare_data_with_quote_in_filename_cohortextractor]
     outputs:
       moderately_sensitive:
-        counts: counts.txt
+        counts: cohortextractor-counts.txt
 
-  test_reusable_action:
+  test_reusable_action_cohortextractor:
     run: minimal-action:v1.1.0 output/input.csv
     config:
       suffix: .backup
@@ -57,9 +57,36 @@ actions:
       highly_sensitive:
         cohort: output/input.backup.csv
 
-  test_cancellation:
-    run: python:latest python analysis/filter_by_sex.py F output/input.csv somefile.csv
+  test_cancellation_cohortextractor:
+    run: python:latest python analysis/filter_by_sex.py F output/input.csv cohortextractor-somefile.csv
     needs: [generate_cohort]
     outputs:
       highly_sensitive:
-        somefile: somefile.csv
+        somefile: cohortextractor-somefile.csv
+
+  generate_dataset:
+    run: databuilder:v0.36.0 generate_dataset --dataset-definition=analysis/dataset_definition.py --dataset=output/dataset.csv --dummy-data-file=test-data/databuilder-dummy-data.csv
+    outputs:
+      highly_sensitive:
+        cohort: output/dataset.csv
+
+  analyse_data_databuilder:
+    run: python:latest python analysis/count_by_year.py output/dataset.csv output/count_by_year.csv
+    needs: [generate_dataset]
+    outputs:
+      moderately_sensitive:
+        count: output/count_by_year.csv
+
+  derp_action:
+    run: python:latest python analysis/dummy_action.py output/dummy.txt
+    needs: [generate_dataset]
+    outputs:
+      moderately_sensitive:
+        dummy: output/dummy.txt
+
+  test_cancellation_databuilder:
+    run: python:latest python analysis/count_by_year.py output/dataset.csv output/count_by_year_cancelled.csv
+    needs: [generate_dataset]
+    outputs:
+      highly_sensitive:
+        count: output/count_by_year_cancelled.csv

--- a/tests/fixtures/full_project/test-data/databuilder-dummy-data.csv
+++ b/tests/fixtures/full_project/test-data/databuilder-dummy-data.csv
@@ -1,0 +1,4 @@
+patient_id,year_of_birth
+1,1943
+2,2000
+3,2010

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,8 @@
+"""
+Big integration tests that create a basic project in a git repo, mocks out a
+JobRequest from the job-server to run it, and then exercises the sync and run
+loops to run entire pipeline
+"""
 import json
 import logging
 
@@ -11,15 +16,27 @@ from tests.factories import ensure_docker_images_present
 log = logging.getLogger(__name__)
 
 
-# Big integration test that creates a basic project in a git repo, mocks out a
-# JobRequest from the job-server to run it, and then exercises the sync and run
-# loops to run entire pipeline
 @pytest.mark.parametrize("executor_api", [True, False])
 @pytest.mark.slow_test
 @pytest.mark.needs_docker
 def test_integration(
     executor_api, tmp_work_dir, docker_cleanup, requests_mock, monkeypatch, test_repo
 ):
+    # TODO: add the following parametrize decorator back to this test:
+    #
+    #   @pytest.mark.parametrize("extraction_tool", ["cohortextractor", "databuilder"])
+    #
+    # Databuilder currently supports too few options in dummy data (at the time
+    # of writing we are still building out the "walking skeleton") to be run
+    # alongside cohortextractor in this test, however once it supports a close
+    # enough set of dummy data we can merge them into a single test.
+    extraction_tool = "cohortextractor"
+
+    if extraction_tool == "cohortextractor":
+        generate_action = "generate_cohort"
+    else:
+        generate_action = "generate_dataset"
+
     monkeypatch.setattr("jobrunner.config.EXECUTION_API", executor_api)
     if executor_api:
         api = get_executor_api()
@@ -33,15 +50,20 @@ def test_integration(
     monkeypatch.setattr("jobrunner.config.ALLOWED_GITHUB_ORGS", None)
     # Make job execution order deterministic
     monkeypatch.setattr("jobrunner.config.RANDOMISE_JOB_ORDER", False)
-    ensure_docker_images_present("cohortextractor", "python")
+
+    if extraction_tool == "cohortextractor":
+        image = "cohortextractor"
+    else:
+        image = "databuilder:v0.36.0"
+    ensure_docker_images_present(image, "python")
 
     # Set up a mock job-server with a single job request
     job_request_1 = {
         "identifier": 1,
         "requested_actions": [
-            "analyse_data",
-            "test_reusable_action",
-            "test_cancellation",
+            f"analyse_data_{extraction_tool}",
+            f"test_reusable_action_{extraction_tool}",
+            f"test_cancellation_{extraction_tool}",
         ],
         "cancelled_actions": [],
         "force_run_dependencies": False,
@@ -71,20 +93,20 @@ def test_integration(
     jobrunner.sync.sync()
     # We should now have one running job and all others waiting on dependencies
     jobs = get_posted_jobs(requests_mock)
-    assert jobs["generate_cohort"]["status"] == "running"
+    assert jobs[generate_action]["status"] == "running"
     for action in [
-        "prepare_data_m",
-        "prepare_data_f",
-        "prepare_data_with_quote_in_filename",
-        "analyse_data",
-        "test_reusable_action",
-        "test_cancellation",
+        f"prepare_data_m_{extraction_tool}",
+        f"prepare_data_f_{extraction_tool}",
+        f"prepare_data_with_quote_in_filename_{extraction_tool}",
+        f"analyse_data_{extraction_tool}",
+        f"test_reusable_action_{extraction_tool}",
+        f"test_cancellation_{extraction_tool}",
     ]:
         assert jobs[action]["status_message"].startswith("Waiting on dependencies")
 
     # Update the existing job request to mark a job as cancelled, add a new job
     # request to be run and then sync
-    job_request_1["cancelled_actions"] = ["test_cancellation"]
+    job_request_1["cancelled_actions"] = [f"test_cancellation_{extraction_tool}"]
     job_request_2 = {
         "identifier": 2,
         "requested_actions": [
@@ -114,14 +136,168 @@ def test_integration(
 
     # All jobs should now have succeeded apart from the cancelled one
     jobs = get_posted_jobs(requests_mock)
-    assert jobs["generate_cohort"]["status"] == "succeeded"
-    assert jobs["generate_cohort_with_dummy_data"]["status"] == "succeeded"
-    assert jobs["prepare_data_m"]["status"] == "succeeded"
-    assert jobs["prepare_data_f"]["status"] == "succeeded"
-    assert jobs["prepare_data_with_quote_in_filename"]["status"] == "succeeded"
-    assert jobs["analyse_data"]["status"] == "succeeded"
-    assert jobs["test_reusable_action"]["status"] == "succeeded"
-    assert jobs["test_cancellation"]["status"] == "failed"
+    assert jobs[generate_action]["status"] == "succeeded"
+    assert jobs[f"prepare_data_m_{extraction_tool}"]["status"] == "succeeded"
+    assert jobs[f"prepare_data_f_{extraction_tool}"]["status"] == "succeeded"
+    assert (
+        jobs[f"prepare_data_with_quote_in_filename_{extraction_tool}"]["status"]
+        == "succeeded"
+    )
+    assert jobs[f"analyse_data_{extraction_tool}"]["status"] == "succeeded"
+    assert jobs[f"test_reusable_action_{extraction_tool}"]["status"] == "succeeded"
+    assert jobs[f"test_cancellation_{extraction_tool}"]["status"] == "failed"
+
+    high_privacy_workspace = tmp_work_dir / "high_privacy_workspaces_dir" / "testing"
+    medium_privacy_workspace = (
+        tmp_work_dir / "medium_privacy_workspaces_dir" / "testing"
+    )
+
+    # Check that the manifest contains what we expect. This is a subset of what used to be in the manifest, to support
+    # nicer UX for osrelease. See the comment in manage_jobs.finalize_job().
+    manifest_file = medium_privacy_workspace / "metadata" / "manifest.json"
+    manifest = json.load(manifest_file.open())
+    assert manifest["workspace"] == "testing"
+    assert manifest["repo"] == str(test_repo.path)
+
+    if extraction_tool == "cohortextractor":
+        output_name = "input"
+    else:
+        output_name = "dataset"
+
+    # Check that all the outputs have been produced
+    for highly_sensitive_output in [
+        f"output/{output_name}.csv",  # the cohort/dataset
+        "output/extra/input.csv",  # extracted from dummy data
+        f"{extraction_tool}-male.csv",  # intermediate analysis
+        f"{extraction_tool}-female.csv",  # intermediate analysis
+        f"{extraction_tool}-qu'ote.csv",  # checking handling of problematic characters in filenames
+        f"output/{output_name}.backup.csv",  # from the reusable action
+    ]:
+        path = high_privacy_workspace / highly_sensitive_output
+        assert path.exists(), highly_sensitive_output
+
+    for moderately_sensitive_output in [
+        f"{extraction_tool}-counts.txt",  # the study's actual output
+    ]:
+        assert (medium_privacy_workspace / moderately_sensitive_output).exists()
+
+    # Check that we don't produce outputs for cancelled jobs
+    assert not (high_privacy_workspace / f"{extraction_tool}-somefile.csv").exists()
+
+
+@pytest.mark.parametrize("executor_api", [True, False])
+@pytest.mark.slow_test
+@pytest.mark.needs_docker
+def test_integration_with_databuilder(
+    executor_api, tmp_work_dir, docker_cleanup, requests_mock, monkeypatch, test_repo
+):
+    # TODO: merge this test into test_integration
+    #
+    # Databuilder currently supports too few options in dummy data (at the time
+    # of writing we are still building out the "walking skeleton") to be run
+    # alongside cohortextractor in this test, however once it supports a close
+    # enough set of dummy data we can merge them into a single test.
+    extraction_tool = "databuilder"
+
+    monkeypatch.setattr("jobrunner.config.EXECUTION_API", executor_api)
+    if executor_api:
+        api = get_executor_api()
+    else:
+        api = None
+
+    monkeypatch.setattr(
+        "jobrunner.config.JOB_SERVER_ENDPOINT", "http://testserver/api/v2/"
+    )
+    # Disable repo URL checking so we can run using a local test repo
+    monkeypatch.setattr("jobrunner.config.ALLOWED_GITHUB_ORGS", None)
+    # Make job execution order deterministic
+    monkeypatch.setattr("jobrunner.config.RANDOMISE_JOB_ORDER", False)
+
+    ensure_docker_images_present("databuilder:v0.36.0", "python")
+
+    # Set up a mock job-server with a single job request
+    job_request_1 = {
+        "identifier": 1,
+        "requested_actions": [
+            f"analyse_data_{extraction_tool}",
+            f"test_cancellation_{extraction_tool}",
+        ],
+        "cancelled_actions": [],
+        "force_run_dependencies": False,
+        "workspace": {
+            "name": "testing",
+            "repo": str(test_repo.path),
+            "branch": "HEAD",
+            "db": "dummy",
+        },
+        "sha": test_repo.commit,
+    }
+    requests_mock.get(
+        "http://testserver/api/v2/job-requests/?backend=expectations",
+        json={
+            "results": [job_request_1],
+        },
+    )
+    requests_mock.post("http://testserver/api/v2/jobs/", json={})
+
+    # Run sync to grab the JobRequest from the mocked job-server
+    jobrunner.sync.sync()
+    # Check that expected number of pending jobs are created
+    jobs = get_posted_jobs(requests_mock)
+    assert [job["status"] for job in jobs.values()] == ["pending"] * 3, list(
+        jobs.values()
+    )[0]["status_message"]
+    # Execute one tick of the run loop and then sync
+    jobrunner.run.handle_jobs(api)
+    jobrunner.sync.sync()
+    # We should now have one running job and all others waiting on dependencies
+    jobs = get_posted_jobs(requests_mock)
+    assert jobs["generate_dataset"]["status"] == "running"
+    for action in [
+        f"analyse_data_{extraction_tool}",
+        f"test_cancellation_{extraction_tool}",
+    ]:
+        assert jobs[action]["status_message"].startswith("Waiting on dependencies")
+
+    # Update the existing job request to mark a job as cancelled, add a new job
+    # request to be run and then sync
+    job_request_1["cancelled_actions"] = [f"test_cancellation_{extraction_tool}"]
+    job_request_2 = {
+        "identifier": 2,
+        "requested_actions": [
+            "derp_action",
+        ],
+        "cancelled_actions": [],
+        "force_run_dependencies": False,
+        "workspace": {
+            "name": "testing",
+            "repo": str(test_repo.path),
+            "branch": "HEAD",
+            "db": "dummy",
+        },
+        "sha": test_repo.commit,
+    }
+    requests_mock.get(
+        "http://testserver/api/v2/job-requests/?backend=expectations",
+        json={
+            "results": [job_request_1, job_request_2],
+        },
+    )
+    jobrunner.sync.sync()
+
+    # Run the main loop until there are no jobs left and then sync
+    jobrunner.run.main(exit_callback=lambda active_jobs: len(active_jobs) == 0)
+    jobrunner.sync.sync()
+
+    # All jobs should now have succeeded apart from the cancelled one
+    jobs = get_posted_jobs(requests_mock)
+    test_cancellation_job = jobs.pop(f"test_cancellation_{extraction_tool}")
+    for action, job in jobs.items():
+        assert (
+            job["status"] == "succeeded"
+        ), f"{action} failed with: {job['status_message']}"
+
+    assert test_cancellation_job["status"] == "failed"
 
     high_privacy_workspace = tmp_work_dir / "high_privacy_workspaces_dir" / "testing"
     medium_privacy_workspace = (
@@ -136,23 +312,11 @@ def test_integration(
     assert manifest["repo"] == str(test_repo.path)
 
     # Check that all the outputs have been produced
-    for highly_sensitive_output in [
-        "output/input.csv",  # the cohort
-        "output/extra/input.csv",  # extracted from dummy data
-        "male.csv",  # intermediate analysis
-        "female.csv",  # intermediate analysis
-        "qu'ote.csv",  # checking handling of problematic characters in filenames
-        "output/input.backup.csv",  # from the reusable action
-    ]:
-        assert (high_privacy_workspace / highly_sensitive_output).exists()
-
-    for moderately_sensitive_output in [
-        "counts.txt",  # the study's actual output
-    ]:
-        assert (medium_privacy_workspace / moderately_sensitive_output).exists()
+    assert (high_privacy_workspace / "output/dataset.csv").exists()
+    assert (medium_privacy_workspace / "output/count_by_year.csv").exists()
 
     # Check that we don't produce outputs for cancelled jobs
-    assert not (high_privacy_workspace / "somefile.csv").exists()
+    assert not (high_privacy_workspace / "output/count_by_year_cancelled.csv").exists()
 
 
 def get_posted_jobs(requests_mock):

--- a/tests/test_reusable_actions.py
+++ b/tests/test_reusable_actions.py
@@ -107,7 +107,14 @@ class TestHandleReusableAction:
         with pytest.raises(reusable_actions.ReusableActionError):
             reusable_actions.handle_reusable_action("reusable-action:latest")
 
-    def test_reusable_action_with_invalid_runtime(self, *args, **kwargs):
+    @pytest.mark.parametrize(
+        "action",
+        [
+            "cohortextractor:v1 generate_cohort",
+            "databuilder:v0.36.0 generate_dataset",
+        ],
+    )
+    def test_reusable_action_with_invalid_runtime(self, action, *args, **kwargs):
         action = "foo:v1"
         reusable_action_1 = ReusableAction(
             repo_url="foo", commit="bar", action_file=b"run: notanaction:v1"


### PR DESCRIPTION
This adds databuilder to a handful of job-runner's tests where we're using cohortextractor as a meaningful part of the test.  A few of these changes are a little messier than I'd like (the integration ones in particular), because databuilder doesn't support the columns we need to match cohortextractor.  I've made these changes on the presumption that we'll update these tests as we add those columns to databuilder.