### PR TITLE
Bump actions checkout v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     name: Run test suite
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v1
       with:
@@ -40,7 +40,7 @@ jobs:
     name: Test we can build PyPI package
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
@@ -71,7 +71,7 @@ jobs:
     name: Test docker image
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Build image
       run: make docker-build
     - name: Run tests in docker-image
@@ -82,7 +82,7 @@ jobs:
     name: Inspect test runner output in the context of a Github Workflow
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v1
       with:
@@ -72,6 +74,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: Build image
       run: make docker-build
     - name: Run tests in docker-image


### PR DESCRIPTION
This bumps our use of actions/checkout from v1 to v3.  There have been many changes in the action since v1, most notably for us is the setting of the AUTHORIZATION header to force basic auth with the GITHUB_TOKEN which I've disabled in the `get_sha_from_remote_ref` function.