### PR TITLE
fix: atomic file writing and not following symlinks

### DIFF
--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -14,6 +14,7 @@ from jobrunner.job_executor import (
 )
 from jobrunner.lib import docker
 from jobrunner.lib.string_utils import tabulate
+
 # ideally, these should be moved into this module when the old implementation
 # is removed
 from jobrunner.manage_jobs import (

--- a/jobrunner/lib/__init__.py
+++ b/jobrunner/lib/__init__.py
@@ -1,0 +1,20 @@
+import secrets
+from contextlib import contextmanager
+
+
+@contextmanager
+def atomic_writer(dest):
+    """Return a safe temp file on the same filesystem to write to
+
+    On success, the tmp file is renamed to the original target atomically.
+    If the write fails, ensure the tmp file is deleted
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + f".{secrets.token_hex(8)}.tmp")
+    try:
+        yield tmp
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+    else:
+        tmp.replace(dest)

--- a/jobrunner/lib/docker.py
+++ b/jobrunner/lib/docker.py
@@ -4,10 +4,10 @@ Utility functions for interacting with Docker
 import json
 import os
 import re
-import secrets
 import subprocess
 
 from jobrunner import config
+from jobrunner.lib import atomic_writer
 from jobrunner.lib.subprocess_utils import subprocess_run
 
 # Docker requires a container in order to interact with volumes, but it doesn't
@@ -184,9 +184,7 @@ def copy_from_volume(volume_name, source, dest, timeout=None):
     As this command can potentially take a long time with large files it does
     not, by default, have any timeout.
     """
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    tmp = dest.with_suffix(dest.suffix + f".{secrets.token_hex(8)}.tmp")
-    try:
+    with atomic_writer(dest) as tmp:
         docker(
             [
                 "cp",
@@ -197,11 +195,6 @@ def copy_from_volume(volume_name, source, dest, timeout=None):
             capture_output=True,
             timeout=timeout,
         )
-    except Exception:
-        tmp.unlink(missing_ok=True)
-        raise
-    else:
-        tmp.replace(dest)
 
 
 def glob_volume_files(volume_name, glob_patterns):

--- a/tests/lib/test_init.py
+++ b/tests/lib/test_init.py
@@ -1,0 +1,38 @@
+import pytest
+
+from jobrunner.lib import atomic_writer
+
+
+def test_atomic_writer_success(tmp_path):
+    dst = tmp_path / "dst"
+    with atomic_writer(dst) as tmp:
+        tmp.write_text("dst")
+
+    assert dst.read_text() == "dst"
+    assert not tmp.exists()
+
+
+def test_atomic_writer_failure(tmp_path):
+    dst = tmp_path / "dst"
+    with pytest.raises(Exception):
+        with atomic_writer(dst) as tmp:
+            tmp.write_text("dst")
+            raise Exception("test")
+
+    assert not dst.exists()
+    assert not tmp.exists()
+
+
+def test_atomic_writer_overwrite_symlink(tmp_path):
+    target = tmp_path / "target"
+    target.write_text("target")
+    dst = tmp_path / "link"
+    dst.symlink_to(target)
+
+    with atomic_writer(dst) as tmp:
+        tmp.write_text("dst")
+
+    assert dst.read_text() == "dst"
+    assert not dst.is_symlink()
+    assert target.read_text() == "target"
+    assert not tmp.exists()


### PR DESCRIPTION
We previously changed `docker.copy_from_volume()` to write to
a temporary file and rename, to gain basic atomic write behaviour.

This change generalises this and extends it to the non-docker
`copy_file()` method.

It also means we do not follow symlinks when writing to a file, as
`shutil.copy()` and friends do. This is useful in migrating between file
systems
