### PR TITLE
fix: follow symlinks when copying to volume

### DIFF
--- a/jobrunner/lib/docker.py
+++ b/jobrunner/lib/docker.py
@@ -168,6 +168,7 @@ def copy_to_volume(volume_name, source, dest, timeout=None):
     docker(
         [
             "cp",
+            "--follow-link",
             source,
             f"{manager_name(volume_name)}:{VOLUME_MOUNT_POINT}/{dest}",
         ],
@@ -189,6 +190,7 @@ def copy_from_volume(volume_name, source, dest, timeout=None):
         docker(
             [
                 "cp",
+                "--follow-link",
                 f"{manager_name(volume_name)}:{VOLUME_MOUNT_POINT}/{source}",
                 tmp,
             ],

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set dotenv-load := true
+
 # just has no idiom for setting a default value for an environment variable
 # so we shell out, as we need VIRTUAL_ENV in the justfile environment
 export VIRTUAL_ENV  := `echo ${VIRTUAL_ENV:-.venv}`


### PR DESCRIPTION
Somehow this was missed in the pre-migration testing.

This fix has been cowboy'd in TPP, so this is adding it properly
