### PR TITLE
fix: use execution API by default.

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -188,5 +188,5 @@ STATS_POLL_INTERVAL = float(os.environ.get("STATS_POLL_INTERVAL", "10"))
 
 
 # feature flag to enable new API abstraction
-EXECUTION_API = os.environ.get("EXECUTION_API", "false").lower() == "true"
+EXECUTION_API = os.environ.get("EXECUTION_API", "true").lower() == "true"
 EXECUTOR = os.environ.get("EXECUTOR", "jobrunner.executors.local:LocalDockerAPI")


### PR DESCRIPTION
Still can be disabled by env var for now, incase we find any issues.
