### PR TITLE
fix: exclude tests from package artefacts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join("VERSION")) as f:
 setup(
     name="opensafely-jobrunner",
     version=version,
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     url="https://github.com/opensafely-core/job-runner",
     author="OpenSAFELY",


### PR DESCRIPTION
#351 added `__init__.py` files to all the tests directories, turning them into packages which `find_packages()` subsequently found.  However, we don't want that so this exludes said `tests` package.