### PR TITLE
Build Distributions with `build`

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -42,13 +42,12 @@ jobs:
         python-version: 3.8
     - name: Install wheel package
       run: |
-        pip install wheel
+        pip install build wheel
     - name: Generate correct value for VERSION file
       run: |
         echo ${{ needs.tag-new-version.outputs.tag }} > VERSION
     - name: Build package
-      run: |
-        python setup.py sdist bdist_wheel
+      run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@master
       if: needs.tag-new-version.outputs.tag

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,8 +75,8 @@ jobs:
         run: echo '1.0' > VERSION
       - name: Build package
         run: |
-          pip install wheel
-          python setup.py sdist bdist_wheel
+          pip install build wheel
+          python -m build
       - name: Check that wheel installs and runs
         run: |
           python -m venv test-wheel

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .python-version
 __pycache__
 app.log
+build
 docker/.env
 docker/ssh/id_*
 docker/ssh/known_hosts

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 
 with open(os.path.join("VERSION")) as f:
@@ -9,7 +9,7 @@ with open(os.path.join("VERSION")) as f:
 setup(
     name="opensafely-jobrunner",
     version=version,
-    packages=find_packages(exclude=["tests"]),
+    packages=["jobrunner"],
     include_package_data=True,
     url="https://github.com/opensafely-core/job-runner",
     author="OpenSAFELY",


### PR DESCRIPTION
This switches us from invoking setup.py directly to using the `build` tool, as documented in the [packaging guide](https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives).

In trying to remove tests (#381 didn't work) I found that `python setup.py bdist_wheel` was including tests regardless of whether I [directly set `packages=["jobrunner"]`](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use) or various combinations of [`where`, `include`, and `exclude`](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#automatic-package-discovery).

Since `build` is now the documented tool and does the right thing this moves us to using it.