### PR TITLE
fix: correctly exclude tests from package

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -46,8 +46,9 @@ jobs:
     - name: Generate correct value for VERSION file
       run: |
         echo ${{ needs.tag-new-version.outputs.tag }} > VERSION
+    - uses: extractions/setup-just@v1
     - name: Build package
-      run: python -m build
+      run: just package-build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@master
       if: needs.tag-new-version.outputs.tag

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,22 +73,12 @@ jobs:
       # but it doesn't really matter what version we use
       - name: Set version
         run: echo '1.0' > VERSION
-      - name: Build package
-        run: |
-          pip install build wheel
-          python -m build
-      - name: Check that wheel installs and runs
-        run: |
-          python -m venv test-wheel
-          test-wheel/bin/pip install dist/*.whl
-          # Minimal check that it has actually built correctly
-          test-wheel/bin/python -m jobrunner.cli.local_run --help
-      - name: Check that sdist installs and runs
-        run: |
-          python -m venv test-sdist
-          test-sdist/bin/pip install dist/*.tar.gz
-          # Minimal check that it has actually built correctly
-          test-sdist/bin/python -m jobrunner.cli.local_run --help
+
+      - uses: extractions/setup-just@v1
+      - name: Check the wheel installs and runs
+        run: just package-test wheel
+      - name: Check the sdist installs and runs
+        run: just package-test sdist
 
   test-docker:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -108,6 +108,40 @@ test-no-docker *ARGS: devenv
     $BIN/python -m pytest -m "not needs_docker" {{ ARGS }}
 
 
+package-build: virtualenv
+    rm -rf dist
+
+    $PIP install build
+    $BIN/python -m build
+
+
+package-test type: package-build
+    #!/usr/bin/env bash
+    VENV="test-{{ type }}"
+    distribution_suffix="{{ if type == "wheel" { "whl" } else { "tar.gz" } }}"
+
+    # build a fresh venv
+    python -m venv $VENV
+
+    # ensure a modern pip
+    $VENV/bin/pip install pip --upgrade
+
+    # install the wheel distribution
+    $VENV/bin/pip install dist/*."$distribution_suffix"
+
+    # Minimal check that it has actually built correctly
+    # Note: this uses the command installed into the virtualenv, not python -m,
+    # to make sure we test the installed package and don't accidentally rely on
+    # imports picking code on-disk.
+    $VENV/bin/local_run --help
+
+    # check we haven't packaged tests with it
+    unzip -Z -1 dist/*.whl | grep -vq "^tests/"
+
+    # clean up after ourselves
+    rm -rf $VENV
+
+
 # test the license shenanigins work when run from a console
 test-stata: devenv
     rm -f tests/fixtures/stata_project/output/env.txt

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join("VERSION")) as f:
 setup(
     name="opensafely-jobrunner",
     version=version,
-    packages=find_packages(include=["jobrunner"]),
+    packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     url="https://github.com/opensafely-core/job-runner",
     author="OpenSAFELY",


### PR DESCRIPTION
This improves our packaging story by doing a number of things:
* test the installed package via one of its entrypoints to avoid python -m using the code on-disk
* exclude tests _and_ its sub modules
* check the build distribution doesn't include tests by interrogating the built wheel
* pull the building and testing of distributions into the justfile for easier local testing