### PR TITLE
feat: Return custom messages for known db exit codes

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -190,3 +190,19 @@ STATS_POLL_INTERVAL = float(os.environ.get("STATS_POLL_INTERVAL", "10"))
 # feature flag to enable new API abstraction
 EXECUTION_API = os.environ.get("EXECUTION_API", "true").lower() == "true"
 EXECUTOR = os.environ.get("EXECUTOR", "jobrunner.executors.local:LocalDockerAPI")
+
+
+# Map known exit codes to user-friendly messages
+EXIT_CODES = {
+    # Custom database-related exit codes return from cohortextractor, see
+    # https://github.com/opensafely-core/cohort-extractor/blob/0a314a909817dbcc48907643e0b6eeff319337db/cohortextractor/cohortextractor.py#L787
+    3: (
+        "A transient database error occurred, your job may run "
+        "if you try it again, if it keeps failing then contact tech support"
+    ),
+    4: "New data is being imported into the database, please try again in a few hours",
+    5: "Something went wrong with the database, please contact tech support",
+    # 137 = 128+9, which means was killed by signal 9, SIGKILL
+    # This usually happens because of OOM killer, or else manually
+    137: "likely means it ran out of memory",
+}

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -193,7 +193,7 @@ EXECUTOR = os.environ.get("EXECUTOR", "jobrunner.executors.local:LocalDockerAPI"
 
 
 # Map known exit codes to user-friendly messages
-EXIT_CODES = {
+DATABASE_EXIT_CODES = {
     # Custom database-related exit codes return from cohortextractor, see
     # https://github.com/opensafely-core/cohort-extractor/blob/0a314a909817dbcc48907643e0b6eeff319337db/cohortextractor/cohortextractor.py#L787
     3: (
@@ -202,6 +202,8 @@ EXIT_CODES = {
     ),
     4: "New data is being imported into the database, please try again in a few hours",
     5: "Something went wrong with the database, please contact tech support",
+}
+EXIT_CODES = {
     # 137 = 128+9, which means was killed by signal 9, SIGKILL
     # This usually happens because of OOM killer, or else manually
     137: "likely means it ran out of memory",

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -241,7 +241,16 @@ def finalize_job(job):
     container_metadata = get_container_metadata(job)
     outputs, unmatched_patterns = find_matching_outputs(job)
     exit_code = container_metadata["State"]["ExitCode"]
-    message = config.EXIT_CODES.get(exit_code)
+
+    # First get the user-friendly message for known database exit codes, for jobs
+    # that have db access
+    message = None
+    if job.allow_database_access:
+        message = config.DATABASE_EXIT_CODES.get(exit_code)
+    # No database error, check for other known exit codes
+    if message is None:
+        message = config.EXIT_CODES.get(exit_code)
+
     results = JobResults(
         outputs=outputs,
         unmatched_patterns=unmatched_patterns,

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -241,11 +241,7 @@ def finalize_job(job):
     container_metadata = get_container_metadata(job)
     outputs, unmatched_patterns = find_matching_outputs(job)
     exit_code = container_metadata["State"]["ExitCode"]
-    message = None
-    if exit_code == 137:
-        # 137 = 128+9, which means was killed by signal 9, SIGKILL
-        # This usually happens because of OOM killer, or else manually
-        message = "likely means it ran out of memory"
+    message = config.EXIT_CODES.get(exit_code)
     results = JobResults(
         outputs=outputs,
         unmatched_patterns=unmatched_patterns,

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -484,6 +484,62 @@ def test_finalize_failed_137(use_api, docker_cleanup, test_repo, tmp_work_dir):
 
 
 @pytest.mark.needs_docker
+@pytest.mark.parametrize(
+    "exit_code,expected_message",
+    [
+        (
+            3,
+            (
+                "A transient database error occurred, your job may run "
+                "if you try it again, if it keeps failing then contact tech support"
+            ),
+        ),
+        (
+            4,
+            "New data is being imported into the database, please try again in a few hours",
+        ),
+        (5, "Something went wrong with the database, please contact tech support"),
+    ],
+)
+def test_finalize_failed_db_exit_codes(
+    use_api, docker_cleanup, test_repo, tmp_work_dir, exit_code, expected_message
+):
+    ensure_docker_images_present("busybox")
+
+    job = JobDefinition(
+        id=f"test_finalize_failed_{exit_code}",
+        job_request_id="test_request_id",
+        study=test_repo.study,
+        workspace="test",
+        action="action",
+        created_at=int(time.time()),
+        image="ghcr.io/opensafely-core/busybox",
+        args=["sh", "-c", f"exit {exit_code}"],
+        env={},
+        inputs=["output/input.csv"],
+        output_spec={
+            "output/output.*": "high_privacy",
+            "output/summary.*": "medium_privacy",
+        },
+        allow_database_access=False,
+    )
+
+    populate_workspace(job.workspace, "output/input.csv")
+
+    api = local.LocalDockerAPI()
+
+    status = api.prepare(job)
+    assert status.state == ExecutorState.PREPARING
+    status = api.execute(job)
+    assert status.state == ExecutorState.EXECUTING
+
+    wait_for_state(api, job, ExecutorState.EXECUTED)
+    status = api.finalize(job)
+
+    assert local.RESULTS[job.id].message == expected_message
+
+
+@pytest.mark.needs_docker
 def test_cleanup_success(use_api, docker_cleanup, test_repo, tmp_work_dir):
     ensure_docker_images_present("busybox")
 


### PR DESCRIPTION
cohortextractor now exits with custom exit codes for database errors - see https://github.com/opensafely-core/cohort-extractor/pull/791
This PR is just to report user-friendly error messages when job-runner encounters those exit codes
Fixes #184 