### PR TITLE
Support tags as the job commit sha.

### DIFF
--- a/jobrunner/lib/git.py
+++ b/jobrunner/lib/git.py
@@ -98,13 +98,13 @@ def commit_reachable_from_ref(repo_url, commit_sha, ref):
     supplied commit is reachable from that ref.
     """
     ref_sha = get_sha_from_remote_ref(repo_url, ref)
-    # The commont case is that the cha is the current HEAD of the branch, so optimise for that.
+    # The commont case is that the sha is the current HEAD of the branch, so optimise for that.
     if commit_sha == ref_sha:
         return True
 
-    # The sha could be a tag - try derefence it and recheck against head
+    # The sha could be a tag - try to derefence it and recheck against head
     try:
-        # try deref commit sha in case is a tag
+        # try to deref commit sha in case is a tag
         commit_sha = get_sha_from_remote_ref(repo_url, commit_sha)
     except Exception:
         pass

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -21,15 +21,15 @@ chardet==3.0.4
     # via
     #   -c requirements.prod.txt
     #   requests
-click==8.0.4
+click==8.1.3
     # via
     #   black
     #   pip-tools
-coverage[toml]==6.3.2
+coverage[toml]==6.3.3
     # via pytest-cov
 distlib==0.3.4
     # via virtualenv
-filelock==3.6.0
+filelock==3.7.0
     # via virtualenv
 flake8==4.0.1
     # via
@@ -40,11 +40,11 @@ flake8-builtins==1.5.3
     # via -r requirements.dev.in
 flake8-implicit-str-concat==0.3.0
     # via -r requirements.dev.in
-flake8-no-pep420==2.2.0
+flake8-no-pep420==2.3.0
     # via -r requirements.dev.in
-hypothesis==6.39.4
+hypothesis==6.46.3
     # via -r requirements.dev.in
-identify==2.4.12
+identify==2.5.0
     # via pre-commit
 idna==2.10
     # via
@@ -56,7 +56,7 @@ isort==5.10.1
     # via -r requirements.dev.in
 mccabe==0.6.1
     # via flake8
-more-itertools==8.12.0
+more-itertools==8.13.0
     # via flake8-implicit-str-concat
 mypy-extensions==0.4.3
     # via black
@@ -68,15 +68,15 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.5.1
+pip-tools==6.6.0
     # via -r requirements.dev.in
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via
     #   black
     #   virtualenv
 pluggy==1.0.0
     # via pytest
-pre-commit==2.17.0
+pre-commit==2.19.0
     # via -r requirements.dev.in
 py==1.11.0
     # via pytest
@@ -84,9 +84,9 @@ pycodestyle==2.8.0
     # via flake8
 pyflakes==2.4.0
     # via flake8
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
-pytest==7.1.1
+pytest==7.1.2
     # via
     #   -r requirements.dev.in
     #   pytest-cov
@@ -114,19 +114,19 @@ tomli==2.0.1
     #   coverage
     #   pep517
     #   pytest
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via black
 urllib3==1.26.5
     # via
     #   -c requirements.prod.txt
     #   requests
-virtualenv==20.13.4
+virtualenv==20.14.1
     # via pre-commit
 wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.0.4
+pip==22.1
     # via pip-tools
-setuptools==60.10.0
+setuptools==62.2.0
     # via pip-tools

--- a/tests/lib/test_git.py
+++ b/tests/lib/test_git.py
@@ -83,6 +83,12 @@ def test_commit_reachable_from_ref(tmp_work_dir):
         "test-branch-dont-delete",
     )
     assert is_reachable_good
+    is_reachable_tag = commit_reachable_from_ref(
+        "https://github.com/opensafely-core/test-public-repository.git",
+        "test-tag-dont-delete",
+        "test-branch-dont-delete",
+    )
+    assert is_reachable_tag
     is_reachable_bad = commit_reachable_from_ref(
         "https://github.com/opensafely-core/test-public-repository.git",
         "029a6ff81cb0ab878de24c12bc690969163c5c9e",


### PR DESCRIPTION
Previously, they had to be the actual commit sha. This changes handles
derefencing them if they are, then using the actual commit to check
history.
