### PR TITLE
feat: limit job cpu/memory usage by default.

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -217,3 +217,7 @@ EXIT_CODES = {
     # This usually happens because of OOM killer, or else manually
     137: "Killed: out of memory, or stopped by admin",
 }
+
+
+DEFAULT_JOB_CPU_COUNT = float(os.environ.get("DEFAULT_JOB_CPU_COUNT", 2))
+DEFAULT_JOB_MEMORY_LIMIT = os.environ.get("DEFAULT_JOB_MEMORY_LIMIT", "4G")

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -111,6 +111,12 @@ class LocalDockerAPI(ExecutorAPI):
         if current.state != ExecutorState.PREPARED:
             return current
 
+        extra_args = []
+        if job.cpu_count:
+            extra_args.extend(["--cpus", str(job.cpu_count)])
+        if job.memory_limit:
+            extra_args.extend(["--memory", job.memory_limit])
+
         try:
             docker.run(
                 container_name(job),
@@ -120,6 +126,7 @@ class LocalDockerAPI(ExecutorAPI):
                 allow_network_access=job.allow_database_access,
                 label=LABEL,
                 labels=get_job_labels(job),
+                extra_args=extra_args,
             )
         except Exception as exc:
             return JobStatus(

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -30,6 +30,8 @@ class JobDefinition:
         str, str
     ]  # the files that the job should produce (globs mapped to privacy levels)
     allow_database_access: bool  # whether this job should have access to the database
+    cpu_count: str = None  # number of CPUs to be allocated
+    memory_limit: str = None  # memory limit to apply
 
 
 class ExecutorState(Enum):

--- a/jobrunner/lib/docker.py
+++ b/jobrunner/lib/docker.py
@@ -344,9 +344,10 @@ def run(
         env = {}
     for key, value in env.items():
         run_args.extend(["--env", key])
-    docker(
+    ps = docker(
         run_args + args, check=True, capture_output=True, env=dict(os.environ, **env)
     )
+    return ps
 
 
 def image_exists_locally(image_name_and_version):

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -423,18 +423,22 @@ def job_to_job_definition(job):
             outputs[pattern] = privacy_level
 
     return JobDefinition(
-        job.id,
-        job.job_request_id,
-        study,
-        job.workspace,
-        job.action,
-        job.created_at,
-        full_image,
-        action_args,
-        env,
-        input_files,
-        outputs,
-        allow_database_access,
+        id=job.id,
+        job_request_id=job.job_request_id,
+        study=study,
+        workspace=job.workspace,
+        action=job.action,
+        created_at=job.created_at,
+        image=full_image,
+        args=action_args,
+        env=env,
+        inputs=input_files,
+        output_spec=outputs,
+        allow_database_access=allow_database_access,
+        # in future, these may come from the JobRequest, but for now, we have
+        # config defaults.
+        cpu_count=config.DEFAULT_JOB_CPU_COUNT,
+        memory_limit=config.DEFAULT_JOB_MEMORY_LIMIT,
     )
 
 

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -245,6 +245,8 @@ def test_execute_success(use_api, docker_cleanup, test_repo, tmp_work_dir):
         inputs=["output/input.csv"],
         output_spec={},
         allow_database_access=False,
+        cpu_count=1.5,
+        memory_limit="1G",
     )
 
     populate_workspace(job.workspace, "output/input.csv")
@@ -263,6 +265,10 @@ def test_execute_success(use_api, docker_cleanup, test_repo, tmp_work_dir):
         ExecutorState.EXECUTING,
         ExecutorState.EXECUTED,
     )
+
+    container_data = docker.container_inspect(container_name(job), "HostConfig")
+    assert container_data["NanoCpus"] == int(1.5 * 1e9)
+    assert container_data["Memory"] == 2**30  # 1G
 
 
 @pytest.mark.needs_docker

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -428,3 +428,10 @@ def test_get_obsolete_files_case_change(db):
 
     obsolete = run.get_obsolete_files(definition, new_outputs)
     assert obsolete == []
+
+
+def test_job_definition_limits(db):
+    job = job_factory()
+    definition = run.job_to_job_definition(job)
+    assert definition.cpu_count == 2
+    assert definition.memory_limit == "4G"


### PR DESCRIPTION
The default limits are provided by env var config, and are set
deliberately low, but enough that they shouldn't affect `local_run`.
Actual backends would have higher defaults.

It adds the settings into JobDefinition, so that other executors can use
them. Also, we anticipate these limits being able to be included in the
JobRequest from job-server in the future.
