### PR TITLE
feat: add pause mode

### DIFF
--- a/jobrunner/queries.py
+++ b/jobrunner/queries.py
@@ -27,17 +27,17 @@ def group_by(iterable, key):
     return groupby(sorted(iterable, key=key), key=key)
 
 
-def get_flag(name):
+def get_flag(name, default=None):
     """Get the current value of a flag, None if not set."""
     # Note: fail gracefully if the flags table does not exist
     # This means we don't need to worry about it in local_run.
     try:
         return find_one(Flag, id=name).value
     except ValueError:
-        return None
+        return default
     except sqlite3.OperationalError as e:
         if "no such table" in str(e):
-            return None
+            return default
         raise
 
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -12,6 +12,10 @@ def test_get_flag_no_row(tmp_work_dir):
     assert get_flag("foo") is None
 
 
+def test_get_flag_no_row_with_default(tmp_work_dir):
+    assert get_flag("foo", "default") == "default"
+
+
 def test_get_set_flag(tmp_work_dir):
     assert get_flag("foo") is None
     set_flag("foo", "bar")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -296,6 +296,40 @@ def test_handle_running_db_maintenance_mode(db, backend_db_config):
     assert job.started_at is None
 
 
+def test_handle_pending_pause_mode(db, backend_db_config):
+    api = StubExecutorAPI()
+    job = api.add_test_job(
+        ExecutorState.UNKNOWN,
+        State.PENDING,
+        run_command="cohortextractor:latest generate_cohort",
+    )
+
+    run.handle_job_api(job, api, paused=True)
+
+    # executor state
+    assert api.get_status(job).state == ExecutorState.UNKNOWN
+    # our state
+    assert job.state == State.PENDING
+    assert job.started_at is None
+
+
+def test_handle_running_pause_mode(db, backend_db_config):
+    api = StubExecutorAPI()
+    job = api.add_test_job(
+        ExecutorState.EXECUTING,
+        State.RUNNING,
+        run_command="cohortextractor:latest generate_cohort",
+    )
+
+    run.handle_job_api(job, api, paused=True)
+
+    # check we did nothing
+    # executor state
+    assert api.get_status(job).state == ExecutorState.EXECUTING
+    # our state
+    assert job.state == State.RUNNING
+
+
 def invalid_transitions():
     """Enumerate all invalid transistions by inverting valid transitions"""
 


### PR DESCRIPTION
Setting mode flag to pause* will stop new jobs from starting. It does
not affect jobs that are already running.

This is designed to allow use to drain the queue of a jobs a bit before
a reboot or other maintenance. It was pleasantly simple to implement.

*`python3 -m jobrunner.cli.flags set mode=pause`
