### PR TITLE
fix: differentiate 137 exit codes between OOM and admin.

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -214,8 +214,9 @@ DATABASE_EXIT_CODES = {
 }
 EXIT_CODES = {
     # 137 = 128+9, which means was killed by signal 9, SIGKILL
-    # This usually happens because of OOM killer, or else manually
-    137: "Killed: out of memory, or stopped by admin",
+    # Note: this can also mean killed by OOM killer, but that's explicitly
+    # handled already.
+    137: "Killed by an OpenSAFELY admin",
 }
 
 


### PR DESCRIPTION
Previously, the message lists both causes as possible, which actually was more
confusing tothe user, as they didn't know which it was.

This detects when the jobs has been killed by the OOM killer, and provides
useful feedback. 

