### PR TITLE
chore: remove ensure_overwritable

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -124,9 +124,6 @@ RANDOMISE_JOB_ORDER = True
 # Automatically delete containers and volumes after they have been used
 CLEAN_UP_DOCKER_OBJECTS = True
 
-# See `manage_jobs.ensure_overwritable` for more detail
-ENABLE_PERMISSIONS_WORKAROUND = bool(os.environ.get("ENABLE_PERMISSIONS_WORKAROUND"))
-
 STATA_LICENSE = os.environ.get("STATA_LICENSE")
 STATA_LICENSE_REPO = os.environ.get(
     "STATA_LICENSE_REPO",

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -26,7 +26,6 @@ from jobrunner.manage_jobs import (
     copy_file,
     copy_git_commit_to_volume,
     copy_local_workspace_to_volume,
-    ensure_overwritable,
     get_container_metadata,
     get_high_privacy_workspace,
     get_log_dir,
@@ -299,7 +298,6 @@ def persist_outputs(job, outputs, container_metadata):
 
     # Dump useful info in log directory
     log_dir = get_log_dir(job)
-    ensure_overwritable(log_dir / "logs.txt", log_dir / "metadata.json")
     write_log_file(job, job_metadata, log_dir / "logs.txt")
     with open(log_dir / "metadata.json", "w") as f:
         json.dump(job_metadata, f, indent=2)
@@ -311,7 +309,6 @@ def persist_outputs(job, outputs, container_metadata):
     log.info(f"Logs written to: {metadata_log_file}")
 
     # Extract outputs to workspace
-    ensure_overwritable(*[workspace_dir / f for f in outputs.keys()])
     volume = volume_name(job)
     for filename in outputs.keys():
         log.info(f"Extracting output file: {filename}")


### PR DESCRIPTION
It was only needed for runing on windows in production, and we're
running on linux now.
