### PR TITLE
fix: Remove pointless local_run metadata and log

### DIFF
--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -295,7 +295,6 @@ def persist_outputs(job, outputs, container_metadata):
     job_metadata["container_metadata"] = container_metadata
     job_metadata["outputs"] = outputs
     job_metadata["commit"] = job.study.commit
-    job_metadata["local_run"] = True
 
     # Dump useful info in log directory
     log_dir = get_log_dir(job)
@@ -379,5 +378,4 @@ KEYS_TO_LOG = [
     "exit_code",
     "created_at",
     "completed_at",
-    "local_run",
 ]


### PR DESCRIPTION
Previously I thought the "local" executor was used to run actions locally via opensafely-cli, so it might be useful to log that.  Since it's actually how jobs are run on the server too, it doesn't serve any useful purpose to log and could be confusing.