### PR TITLE
fix: send all current flag values to job-server

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -16,4 +16,5 @@ pre-commit
 pytest
 pytest-cov
 pytest-freezegun
+pytest-responses
 requests_mock

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -93,9 +93,12 @@ pytest==7.1.1
     #   -r requirements.dev.in
     #   pytest-cov
     #   pytest-freezegun
+    #   pytest-responses
 pytest-cov==3.0.0
     # via -r requirements.dev.in
 pytest-freezegun==0.4.2
+    # via -r requirements.dev.in
+pytest-responses==0.5.0
     # via -r requirements.dev.in
 python-dateutil==2.8.2
     # via freezegun
@@ -105,8 +108,11 @@ requests==2.25.0
     # via
     #   -c requirements.prod.txt
     #   requests-mock
+    #   responses
 requests-mock==1.9.3
     # via -r requirements.dev.in
+responses==0.21.0
+    # via pytest-responses
 six==1.16.0
     # via
     #   python-dateutil
@@ -123,11 +129,14 @@ tomli==2.0.1
     #   pep517
     #   pytest
 typing-extensions==4.1.1
-    # via black
+    # via
+    #   -c requirements.prod.txt
+    #   black
 urllib3==1.26.5
     # via
     #   -c requirements.prod.txt
     #   requests
+    #   responses
 virtualenv==20.13.4
     # via pre-commit
 wheel==0.37.1

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,5 +1,9 @@
+import json
+
+from responses import matchers
+
+from jobrunner import config, queries, sync
 from jobrunner.models import JobRequest
-from jobrunner.sync import job_request_from_remote_format
 
 
 def test_job_request_from_remote_format():
@@ -28,5 +32,54 @@ def test_job_request_from_remote_format():
         force_run_dependencies=True,
         original=remote_job_request,
     )
-    job_request = job_request_from_remote_format(remote_job_request)
+    job_request = sync.job_request_from_remote_format(remote_job_request)
     assert job_request == expected
+
+
+def test_session_request_no_flags(db, responses):
+    responses.add(
+        method="GET",
+        url=f"{config.JOB_SERVER_ENDPOINT}path/?backend=test",
+        status=200,
+        json="{}",
+        match=[
+            matchers.header_matcher(
+                {
+                    "Authorization": config.JOB_SERVER_TOKEN,
+                    "Flags": "{}",
+                }
+            ),
+        ],
+    )
+
+    # if this works, our expected request was generated
+    sync.api_get("path", params={"backend": "test"})
+
+
+def test_session_request_flags(db, responses):
+    f1 = queries.set_flag("mode", "db-maintenance")
+    f2 = queries.set_flag("pause", "true")
+
+    flags_dict = {
+        "mode": {"v": "db-maintenance", "ts": f1.timestamp_isoformat},
+        "pause": {"v": "true", "ts": f2.timestamp_isoformat},
+    }
+    expected_header = json.dumps(flags_dict, separators=(",", ":"))
+
+    responses.add(
+        method="GET",
+        url=f"{config.JOB_SERVER_ENDPOINT}path/?backend=test",
+        status=200,
+        json="{}",
+        match=[
+            matchers.header_matcher(
+                {
+                    "Authorization": config.JOB_SERVER_TOKEN,
+                    "Flags": expected_header,
+                }
+            ),
+        ],
+    )
+
+    # if this works, our expected request was generated
+    sync.api_get("path", params={"backend": "test"})


### PR DESCRIPTION
We now support a `mode` flag and a `pause`, as the two are independantly
enabled.

This change communicates all currently set flags to job-server, rather
than just the 'mode' flag.
