### PR TITLE
fix: record timestamp for flag changes

### DIFF
--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -265,9 +265,19 @@ class Flag:
         CREATE TABLE flags (
             id TEXT,
             value TEXT,
+            timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (id)
         )
     """
 
     id: str  # noqa: A003
     value: str
+    timestamp: int = None
+
+    @property
+    def timestamp_isoformat(self):
+        return timestamp_to_isoformat(self.timestamp)
+
+    def __str__(self):
+        ts = self.timestamp_isoformat if self.timestamp else "never set"
+        return f"{self.id}={self.value} ({ts})"

--- a/jobrunner/queries.py
+++ b/jobrunner/queries.py
@@ -1,8 +1,9 @@
 import sqlite3
+import time
 from itertools import groupby
 from operator import attrgetter
 
-from jobrunner.lib.database import find_one, find_where, upsert
+from jobrunner.lib.database import find_all, find_one, find_where, upsert
 from jobrunner.models import Flag, Job
 
 
@@ -27,12 +28,17 @@ def group_by(iterable, key):
     return groupby(sorted(iterable, key=key), key=key)
 
 
-def get_flag(name, default=None):
-    """Get the current value of a flag, None if not set."""
+def get_flag(name):
+    """Get a flag from the db"""
+    return find_one(Flag, id=name)
+
+
+def get_flag_value(name, default=None):
+    """Get the current value of a flag, with a default"""
     # Note: fail gracefully if the flags table does not exist
     # This means we don't need to worry about it in local_run.
     try:
-        return find_one(Flag, id=name).value
+        return get_flag(name).value
     except ValueError:
         return default
     except sqlite3.OperationalError as e:
@@ -41,7 +47,16 @@ def get_flag(name, default=None):
         raise
 
 
-def set_flag(name, value):
+def set_flag(name, value, timestamp=None):
     """Set a flag to a value in the db."""
     # Note: table must exist to set flags
-    upsert(Flag(name, value))
+    if timestamp is None:
+        timestamp = time.time()
+    flag = Flag(name, value, timestamp)
+    upsert(flag)
+    return flag
+
+
+def get_current_flags():
+    """Get all currently set flags"""
+    return find_all(Flag)

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -24,7 +24,7 @@ from jobrunner.lib.database import find_where, select_values, update
 from jobrunner.lib.log_utils import configure_logging, set_log_context
 from jobrunner.models import Job, State, StatusCode
 from jobrunner.project import requires_db_access
-from jobrunner.queries import calculate_workspace_state, get_flag
+from jobrunner.queries import calculate_workspace_state, get_flag_value
 
 
 log = logging.getLogger(__name__)
@@ -76,8 +76,8 @@ STABLE_STATES = [
 
 
 def handle_single_job(job, api):
-    mode = get_flag("mode")
-    paused = get_flag("paused", "").lower() == "true"
+    mode = get_flag_value("mode")
+    paused = get_flag_value("paused", "").lower() == "true"
     try:
         handle_job(job, api, mode, paused)
     except Exception:

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -9,7 +9,7 @@ from jobrunner import config, record_stats, run, sync
 from jobrunner.lib.database import get_connection
 from jobrunner.lib.docker import docker
 from jobrunner.lib.log_utils import configure_logging
-from jobrunner.queries import get_flag, set_flag
+from jobrunner.queries import get_flag_value, set_flag
 
 
 log = logging.getLogger(__name__)
@@ -92,7 +92,7 @@ def maintenance_mode():
     """Check if the db is currently in maintenance mode, and set flags as appropriate."""
     # This did not seem big enough to warrant splitting into a separate module.
     log.info("checking if db undergoing maintenance...")
-    current = get_flag("mode")
+    current = get_flag_value("mode")
     ps = docker(
         [
             "run",
@@ -121,7 +121,7 @@ def maintenance_mode():
             log.info("DB maintenance mode had ended")
         set_flag("mode", None)
 
-    mode = get_flag("mode")
+    mode = get_flag_value("mode")
     log.info(f"db mode: {mode}")
     return mode
 

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -70,7 +70,7 @@ def api_request(method, path, *args, **kwargs):
     url = "{}/{}/".format(config.JOB_SERVER_ENDPOINT.rstrip("/"), path.strip("/"))
     session.headers = {
         "Authorization": config.JOB_SERVER_TOKEN,
-        "Current-Mode": str(queries.get_flag("mode")),
+        "Current-Mode": str(queries.get_flag_value("mode")),
     }
     response = session.request(method, url, *args, **kwargs)
 

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -15,4 +15,5 @@ pip-tools
 pre-commit
 pytest
 pytest-cov
+pytest-freezegun
 requests_mock

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -42,6 +42,8 @@ flake8-implicit-str-concat==0.3.0
     # via -r requirements.dev.in
 flake8-no-pep420==2.2.0
     # via -r requirements.dev.in
+freezegun==1.2.1
+    # via pytest-freezegun
 hypothesis==6.39.4
     # via -r requirements.dev.in
 identify==2.4.12
@@ -90,8 +92,13 @@ pytest==7.1.1
     # via
     #   -r requirements.dev.in
     #   pytest-cov
+    #   pytest-freezegun
 pytest-cov==3.0.0
     # via -r requirements.dev.in
+pytest-freezegun==0.4.2
+    # via -r requirements.dev.in
+python-dateutil==2.8.2
+    # via freezegun
 pyyaml==6.0
     # via pre-commit
 requests==2.25.0
@@ -102,6 +109,7 @@ requests-mock==1.9.3
     # via -r requirements.dev.in
 six==1.16.0
     # via
+    #   python-dateutil
     #   requests-mock
     #   virtualenv
 sortedcontainers==2.4.0

--- a/tests/cli/test_flags.py
+++ b/tests/cli/test_flags.py
@@ -1,8 +1,16 @@
+import time
+
 import pytest
 
 from jobrunner import queries
 from jobrunner.cli import flags
 from jobrunner.lib import database
+from jobrunner.models import timestamp_to_isoformat
+
+
+# use a fixed time for these tests
+TEST_TIME = time.time()
+TEST_DATESTR = timestamp_to_isoformat(TEST_TIME)
 
 
 def test_get_no_args(capsys, tmp_work_dir):
@@ -11,41 +19,43 @@ def test_get_no_args(capsys, tmp_work_dir):
     assert stdout == ""
     assert stderr == ""
 
-    queries.set_flag("foo", "bar")
+    queries.set_flag("foo", "bar", TEST_TIME)
     flags.run(["get"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == "foo=bar\n"
+    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
 
 
 def test_args_get(capsys, tmp_work_dir):
     flags.run(["get", "foo"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == "foo=None\n"
+    assert stdout == "foo=None (never set)\n"
     assert stderr == ""
 
-    queries.set_flag("foo", "bar")
+    queries.set_flag("foo", "bar", TEST_TIME)
     flags.run(["get", "foo"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == "foo=bar\n"
+    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
 
 
-def test_args_set(capsys, tmp_work_dir):
+def test_args_set(capsys, tmp_work_dir, freezer):
+    freezer.move_to(TEST_DATESTR)
     flags.run(["set", "foo=bar"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == "foo=bar\n"
+    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
-    assert queries.get_flag("foo") == "bar"
+    assert queries.get_flag("foo").value == "bar"
 
 
-def test_args_set_clear(capsys, tmp_work_dir):
+def test_args_set_clear(capsys, tmp_work_dir, freezer):
+    freezer.move_to(TEST_DATESTR)
     queries.set_flag("foo", "bar")
     flags.run(["set", "foo="])
     stdout, stderr = capsys.readouterr()
-    assert stdout == "foo=None\n"
+    assert stdout == f"foo=None ({TEST_DATESTR})\n"
     assert stderr == ""
-    assert queries.get_flag("foo") is None
+    assert queries.get_flag("foo").value is None
 
 
 def test_args_get_create(capsys, tmp_work_dir):
@@ -61,7 +71,8 @@ def test_args_get_create(capsys, tmp_work_dir):
     assert stderr == ""
 
 
-def test_args_set_create(capsys, tmp_work_dir):
+def test_args_set_create(capsys, tmp_work_dir, freezer):
+    freezer.move_to(TEST_DATESTR)
     database.get_connection().execute("DROP TABLE flags")
     with pytest.raises(SystemExit) as e:
         flags.run(["set", "foo=bar"])
@@ -70,6 +81,6 @@ def test_args_set_create(capsys, tmp_work_dir):
 
     flags.run(["set", "foo=bar", "--create"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == "foo=bar\n"
+    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
-    assert queries.get_flag("foo") == "bar"
+    assert queries.get_flag("foo").value == "bar"

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,24 +1,24 @@
 from jobrunner.lib.database import get_connection
-from jobrunner.queries import get_flag, set_flag
+from jobrunner.queries import get_flag_value, set_flag
 
 
 def test_get_flag_no_table_does_not_error(tmp_work_dir):
     conn = get_connection()
     conn.execute("DROP TABLE IF EXISTS flags")
-    assert get_flag("foo") is None
+    assert get_flag_value("foo") is None
 
 
 def test_get_flag_no_row(tmp_work_dir):
-    assert get_flag("foo") is None
+    assert get_flag_value("foo") is None
 
 
 def test_get_flag_no_row_with_default(tmp_work_dir):
-    assert get_flag("foo", "default") == "default"
+    assert get_flag_value("foo", "default") == "default"
 
 
 def test_get_set_flag(tmp_work_dir):
-    assert get_flag("foo") is None
+    assert get_flag_value("foo") is None
     set_flag("foo", "bar")
-    assert get_flag("foo") == "bar"
+    assert get_flag_value("foo") == "bar"
     set_flag("foo", None)
-    assert get_flag("foo") is None
+    assert get_flag_value("foo") is None


### PR DESCRIPTION
Record when a flag was last set or unset. This will be helpful in
diagnosing issues, as it can help us see when things changed.

This did involve adding a new column to the Flag table, which we've not
got a mechanism to handle. But errors with the flag table are gracefully
handled, and its a simple manual ALTER TABLE to run on TPP (the only
place that currently has the flag table).
