### PR TITLE
fix: record unmatched outputs in local executor

### DIFF
--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -55,6 +55,7 @@ class JobStatus:
 class JobResults:
     outputs: Mapping[str, str]  # mapping of outputs to privacy levels
     unmatched_patterns: List[str]  # list of patterns that matched no outputs
+    unmatched_outputs: List[str]  # outputs that not match the output_spec
     exit_code: int
     image_id: str
     message: str = None

--- a/jobrunner/lib/docker.py
+++ b/jobrunner/lib/docker.py
@@ -178,6 +178,20 @@ def copy_to_volume(volume_name, source, dest, timeout=None):
     )
 
 
+def touch_file(volume_name, path, timeout=None):
+    docker(
+        [
+            "container",
+            "exec",
+            manager_name(volume_name),
+            "touch",
+            f"{VOLUME_MOUNT_POINT}/{path}",
+        ],
+        check=True,
+        timeout=timeout,
+    )
+
+
 def copy_from_volume(volume_name, source, dest, timeout=None):
     """
     Copy the contents of `source` from the root of the named volume to `dest`

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -254,10 +254,7 @@ def save_results(job, results):
         # If the job fails because an output was missing its very useful to
         # show the user what files were created as often the issue is just a
         # typo
-
-        # Can we figure these out from job.outputs and project.yaml? Do we do
-        # it here or just in local run?
-        # TODO:  job.unmatched_outputs = ???
+        job.unmatched_outputs = results.unmatched_outputs
     else:
         job.state = State.SUCCEEDED
         job.status_message = "Completed successfully"

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -105,16 +105,17 @@ class StubExecutorAPI:
         """Set the next transition for this job when called"""
         self.transitions[definition.id] = (state, message)
 
-    def set_job_result(
-        self, definition, outputs={}, unmatched=[], exit_code=0, image_id="image_id"
-    ):
-
-        self.results[definition.id] = JobResults(
-            outputs,
-            unmatched,
-            exit_code,
-            image_id,
-        )
+    def set_job_result(self, definition, **kwargs):
+        defaults = {
+            "outputs": {},
+            "unmatched_patterns": [],
+            "unmatched_outputs": [],
+            "exit_code": 0,
+            "image_id": "image_id",
+            "message": "message",
+        }
+        kwargs = {**defaults, **kwargs}
+        self.results[definition.id] = JobResults(**kwargs)
 
     def do_transition(self, definition, expected, next_state):
         current = self.get_status(definition)

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -396,7 +396,8 @@ def test_finalize_unmatched(docker_cleanup, test_repo, tmp_work_dir):
         action="action",
         created_at=int(time.time()),
         image="ghcr.io/opensafely-core/busybox",
-        args=["true"],
+        # the sleep is needed to make sure the unmatched file is *newer* enough
+        args=["sh", "-c", "sleep 1; touch /workspace/unmatched"],
         env={},
         inputs=["output/input.csv"],
         output_spec={
@@ -430,6 +431,7 @@ def test_finalize_unmatched(docker_cleanup, test_repo, tmp_work_dir):
     assert results.exit_code == 0
     assert results.outputs == {}
     assert results.unmatched_patterns == ["output/output.*", "output/summary.*"]
+    assert results.unmatched_outputs == ["unmatched"]
 
 
 @pytest.mark.needs_docker


### PR DESCRIPTION
Previously, we had punted on collecting unmatched outputs when writing
the local executor, so this was missing from that code path.

In deleting the old code path, that functionality was lost.

This change adds it to the local executor flow. It seemed fairly simple
in the end, not sure why we did not do it the first time round.

There were not tests previously for this, so I added some. In doing so,
it seems the file timestamp logic had a bug, as `docker cp` seems to
preserve the timestamp of the src file, rather than update it on the dst. So
I changed to actually `touch` a new file rather than a copy.

The tests also exposed that docker's filesystem only supports 1s
precision on file timestamps, so the test had to sleep for 1 second.
