### PR TITLE
fix: fix maintenance mode bug

### DIFF
--- a/jobrunner/cli/flags.py
+++ b/jobrunner/cli/flags.py
@@ -58,7 +58,8 @@ def main(action, flags, create=False):
 def run(argv):
     parser = argparse.ArgumentParser(description=__doc__.partition("\n\n")[0])
 
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(dest="action")
+    subparsers.required = True
     # for get, flag arguments is optional
     parser_get = subparsers.add_parser("get", help="get the current values of flags")
     parser_get.add_argument(

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -109,7 +109,7 @@ def maintenance_mode():
         capture_output=True,
         text=True,
     )
-    last_line = ps.stdout.split("\n")[-1]
+    last_line = ps.stdout.strip().split("\n")[-1]
     if "db-maintenance" in last_line:
         if current != "db-maintenance":
             log.warning("Enabling DB maintenance mode")


### PR DESCRIPTION
The output from the cohortextractor command had a trailing new line,
which causes the check to fail.

Also, flags cli command did gracefully handle it when I forgot to add
'get' arg, so fixed that too.
