### PR TITLE
fix: the limit formatting in OOM error message

### DIFF
--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -294,7 +294,7 @@ def finalize_job(job):
         memory_limit = container_metadata.get("HostConfig", {}).get("Memory", 0)
         if memory_limit > 0:
             gb_limit = memory_limit / (1024**3)
-            message += f" (limit for this job was {gb_limit:.1g}GB)"
+            message += f" (limit for this job was {gb_limit:.2f}GB)"
     else:
         message = config.DOCKER_EXIT_CODES.get(exit_code)
 

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -524,9 +524,10 @@ def test_finalize_failed_oomkilled(docker_cleanup, test_repo, tmp_work_dir):
     assert api.get_status(job).state == ExecutorState.FINALIZED
     assert job.id in local.RESULTS
     assert local.RESULTS[job.id].exit_code == 137
+    # Note, 6MB is rounded to 0.01GBM by the formatter
     assert (
         local.RESULTS[job.id].message
-        == "Ran out of memory (limit for this job was 0.006GB)"
+        == "Ran out of memory (limit for this job was 0.01GB)"
     )
 
 


### PR DESCRIPTION
The `g` format specifier unhelpfully switches to scientific notation for
numbers above 10.
