### PR TITLE
feat: add a bind mount volume api

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,6 +8,9 @@
 	@echo "DEV_GROUPID=$(shell id -g)" >> $@
 	@echo "DOCKER_HOST_GROUPID=$(shell getent group docker | awk -F: '{print $$3}')" >> $@
 
+/tmp/jobrunner-docker:
+	mkdir $@
+
 
 .PHONY: docker-build
 # enable modern docker build features
@@ -24,7 +27,7 @@ docker-build: .env
 
 .PHONY: docker-test
 # run tests in docker container
-docker-test: docker-build
+docker-test: docker-build | /tmp/jobrunner-docker
 	docker-compose run $(ARGS) --rm test
 
 
@@ -39,7 +42,7 @@ docker-serve: docker-build
 # run command in container
 docker-run: ENV ?= dev
 docker-run: CMD ?= bash
-docker-run: docker-build
+docker-run: docker-build | /tmp/jobrunner-docker
 	docker-compose run --rm $(ARGS) $(ENV) $(CMD)
 
 
@@ -53,7 +56,7 @@ docker-exec: docker-build
 
 .PHONY: docker-clean
 docker-clean:
-	rm -f .env
+	rm -rf .env /tmp/jobrunner-docker
 	docker image rm job-runner job-runner-dev || true
 	# clean up local ssh config
 	rm -f ssh/known_hosts ssh/id_ed25519*

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -62,7 +62,19 @@ services:
         - DEV_USERID=${DEV_USERID:-1000}
         - DEV_GROUPID=${DEV_GROUPID:-1000}
         - DOCKER_HOST_GROUPID=${DOCKER_HOST_GROUPID}
+    # Some tricks are needed here to be able to test the BindMountVolumeAPI
+    # when running inside docker, as we need the volumes to be mountable by the
+    # host docker. Our pytest fixtures create the directories in /tmp, so we
+    # provide a host mounted /tmp to the container, so we can access it from
+    # the host as well.
+    environment:
+      # Tell our test fixture what the root dir is on the host where to point
+      # DOCKER_HOST_VOLUME_DIR to for each isolated test
+      PYTEST_HOST_TMP: /tmp/jobrunner-docker
     volumes:
+      # mount the host provide temp dir as /tmp. Note: this dir must exist
+      - /tmp/jobrunner-docker:/tmp
+      # mount our current code
       - ..:/app
 
   # test runner service - uses dev-image with a different command
@@ -72,3 +84,4 @@ services:
     container_name: job-runner-test
     # override command
     command: /opt/venv/bin/pytest
+

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -208,10 +208,6 @@ MEDIUM_PRIVACY_STORAGE_BASE = Path(
 HIGH_PRIVACY_WORKSPACES_DIR = HIGH_PRIVACY_STORAGE_BASE / "workspaces"
 MEDIUM_PRIVACY_WORKSPACES_DIR = MEDIUM_PRIVACY_STORAGE_BASE / "workspaces"
 JOB_LOG_DIR = HIGH_PRIVACY_STORAGE_BASE / "logs"
-
-# used to store directories to be mounted into jobs with the BindMountVolumeAPI
-HIGH_PRIVACY_VOLUME_DIR = HIGH_PRIVACY_STORAGE_BASE / "volumes"
-
 HIGH_PRIVACY_ARCHIVE_DIR = Path(
     os.environ.get("HIGH_PRIVACY_ARCHIVE_DIR", HIGH_PRIVACY_STORAGE_BASE / "archives")
 )
@@ -229,3 +225,13 @@ DOCKER_EXIT_CODES = {
     # handled already.
     137: "Killed by an OpenSAFELY admin",
 }
+
+# BindMountVolumeAPI config
+#
+# used to store directories to be mounted into jobs with the BindMountVolumeAPI
+HIGH_PRIVACY_VOLUME_DIR = HIGH_PRIVACY_STORAGE_BASE / "volumes"
+
+# when running inside a docker container and using the BindMountVolumeAPI, this
+# needs to point to the path to the HIGH_PRIVACY_VOLUME_DIR from the *hosts*
+# perspective, as that's what docker will be looking for.
+DOCKER_HOST_VOLUME_DIR = os.environ.get("DOCKER_HOST_VOLUME_DIR")

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -194,6 +194,10 @@ EXECUTOR = os.environ.get("EXECUTOR", "jobrunner.executors.local:LocalDockerAPI"
 # LocalDockerAPI executor specific configuration
 # Note: the local backend also reuses the main GIT_REPO_DIR config
 
+LOCAL_VOLUME_API = os.environ.get(
+    "LOCAL_VOLUME_API", "jobrunner.executors.volumes:DockerVolumeAPI"
+)
+
 HIGH_PRIVACY_STORAGE_BASE = Path(
     os.environ.get("HIGH_PRIVACY_STORAGE_BASE", WORKDIR / "high_privacy")
 )

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import logging
-import shutil
 import subprocess
 import tempfile
 import time
@@ -10,7 +9,7 @@ from pathlib import Path
 from pipeline.legacy import get_all_output_patterns_from_project_file
 
 from jobrunner import config
-from jobrunner.executors.volumes import volume_api
+from jobrunner.executors.volumes import copy_file, get_volume_api
 from jobrunner.job_executor import (
     ExecutorAPI,
     ExecutorState,
@@ -19,7 +18,7 @@ from jobrunner.job_executor import (
     JobStatus,
     Privacy,
 )
-from jobrunner.lib import atomic_writer, docker
+from jobrunner.lib import docker
 from jobrunner.lib.git import checkout_commit
 from jobrunner.lib.path_utils import list_dir_with_ignore_patterns
 from jobrunner.lib.string_utils import tabulate
@@ -40,6 +39,7 @@ RESULTS = {}
 LABEL = "jobrunner-local"
 
 log = logging.getLogger(__name__)
+volume_api = get_volume_api()
 
 
 def container_name(job):
@@ -86,6 +86,10 @@ def workspace_is_archived(workspace):
 
 class LocalDockerAPI(ExecutorAPI):
     """ExecutorAPI implementation using local docker service."""
+
+    @property
+    def volume_api(self):
+        return get_volume_api()
 
     def prepare(self, job):
         current = self.get_status(job)
@@ -419,17 +423,6 @@ KEYS_TO_LOG = [
     "created_at",
     "completed_at",
 ]
-
-
-def copy_file(source, dest):
-    """Efficient atomic copy.
-
-    shutil.copy uses sendfile on linux, so should be fast.
-    """
-    dest.parent.mkdir(parents=True, exist_ok=True)
-
-    with atomic_writer(dest) as tmp:
-        shutil.copy(source, tmp)
 
 
 def copy_git_commit_to_volume(job, repo_url, commit, extra_dirs):

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -87,10 +87,6 @@ def workspace_is_archived(workspace):
 class LocalDockerAPI(ExecutorAPI):
     """ExecutorAPI implementation using local docker service."""
 
-    @property
-    def volume_api(self):
-        return get_volume_api()
-
     def prepare(self, job):
         current = self.get_status(job)
         if current.state != ExecutorState.UNKNOWN:
@@ -270,7 +266,6 @@ def prepare_job(job):
 
 
 def finalize_job(job):
-
     container_metadata = docker.container_inspect(
         container_name(job), none_if_not_exists=True
     )

--- a/jobrunner/executors/volumes.py
+++ b/jobrunner/executors/volumes.py
@@ -60,7 +60,18 @@ def host_volume_path(job):
 
 class BindMountVolumeAPI:
     def volume_name(job):
-        return host_volume_path(job)
+        """Return the absolute path to the volume directory.
+
+        In case we're running inside a docker container, make sure the path is
+        relative to the *hosts* POV, not the container.
+        """
+        local_path = host_volume_path(job)
+        if config.DOCKER_HOST_VOLUME_DIR is None:
+            return local_path
+
+        return config.DOCKER_HOST_VOLUME_DIR / local_path.relative_to(
+            config.HIGH_PRIVACY_VOLUME_DIR
+        )
 
     def create_volume(job, labels=None):
         host_volume_path(job).mkdir()

--- a/jobrunner/executors/volumes.py
+++ b/jobrunner/executors/volumes.py
@@ -1,37 +1,122 @@
-from jobrunner.lib import docker
+import importlib
+import shutil
+from collections import defaultdict
+from pathlib import Path
+
+from jobrunner import config
+from jobrunner.lib import atomic_writer, docker
 
 
-def volume_name(job):
+def copy_file(source, dest, follow_symlinks=True):
+    """Efficient atomic copy.
+
+    shutil.copy uses sendfile on linux, so should be fast.
+    """
+    # ensure path
+    dest = Path(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with atomic_writer(dest) as tmp:
+        shutil.copy(source, tmp, follow_symlinks=follow_symlinks)
+
+
+def docker_volume_name(job):
     return f"os-volume-{job.id}"
 
 
 class DockerVolumeAPI:
     def volume_name(job):
-        return volume_name(job)
+        return docker_volume_name(job)
 
     def create_volume(job, labels=None):
-        docker.create_volume(volume_name(job))
+        docker.create_volume(docker_volume_name(job))
 
     def volume_exists(job):
-        return docker.volume_exists(volume_name(job))
+        return docker.volume_exists(docker_volume_name(job))
 
     def copy_to_volume(job, src, dst, timeout=None):
-        docker.copy_to_volume(volume_name(job), src, dst, timeout)
+        docker.copy_to_volume(docker_volume_name(job), src, dst, timeout)
 
     def copy_from_volume(job, src, dst, timeout=None):
-        docker.copy_from_volume(volume_name(job), src, dst, timeout)
+        docker.copy_from_volume(docker_volume_name(job), src, dst, timeout)
 
     def delete_volume(job):
-        docker.delete_volume(volume_name(job))
+        docker.delete_volume(docker_volume_name(job))
 
     def touch_file(job, path, timeout=None):
-        docker.touch_file(volume_name(job), path, timeout)
+        docker.touch_file(docker_volume_name(job), path, timeout)
 
     def glob_volume_files(job):
-        return docker.glob_volume_files(volume_name(job), job.output_spec.keys())
+        return docker.glob_volume_files(docker_volume_name(job), job.output_spec.keys())
 
     def find_newer_files(job, path):
-        return docker.find_newer_files(volume_name(job), path)
+        return docker.find_newer_files(docker_volume_name(job), path)
 
 
-volume_api = DockerVolumeAPI
+def host_volume_path(job):
+    path = config.HIGH_PRIVACY_VOLUME_DIR / job.id
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+class BindMountVolumeAPI:
+    def volume_name(job):
+        return host_volume_path(job)
+
+    def create_volume(job, labels=None):
+        host_volume_path(job).mkdir()
+
+    def volume_exists(job):
+        return host_volume_path(job).exists()
+
+    def copy_to_volume(job, src, dst, timeout=None):
+        # We don't respect the timeout.
+        volume = host_volume_path(job)
+        if src.is_dir():
+            shutil.copytree(
+                src,
+                volume / dst,
+                symlinks=True,
+                copy_function=copy_file,
+                dirs_exist_ok=True,
+            )
+        else:
+            copy_file(src, volume / dst)
+
+    def copy_from_volume(job, src, dst, timeout=None):
+        # this is only used to copy final outputs/logs.
+        path = host_volume_path(job) / src
+        copy_file(path, dst)
+
+    def delete_volume(job):
+        shutil.rmtree(host_volume_path(job), ignore_errors=True)
+
+    def touch_file(job, path, timeout=None):
+        (host_volume_path(job) / path).touch()
+
+    def glob_volume_files(job):
+        volume = host_volume_path(job)
+
+        found = defaultdict(list)
+
+        for pattern in job.output_spec.keys():
+            for match in volume.glob(pattern):
+                if match.is_file():
+                    found[pattern].append(str(match.relative_to(volume)))
+
+        return found
+
+    def find_newer_files(job, reference):
+        volume = host_volume_path(job)
+        ref_time = (volume / reference).stat().st_mtime
+        found = []
+        for f in volume.glob("**/*"):
+            if f.is_file() and f.stat().st_mtime > ref_time:
+                found.append(str(f.relative_to(volume)))
+
+        return found
+
+
+def get_volume_api():
+    module_name, cls = config.LOCAL_VOLUME_API.split(":", 1)
+    module = importlib.import_module(module_name)
+    return getattr(module, cls)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ def tmp_work_dir(monkeypatch, tmp_path):
         "HIGH_PRIVACY_WORKSPACES_DIR",
         "MEDIUM_PRIVACY_WORKSPACES_DIR",
         "HIGH_PRIVACY_ARCHIVE_DIR",
+        "HIGH_PRIVACY_VOLUME_DIR",
         "JOB_LOG_DIR",
     ]
     for config_var in config_vars:

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -34,6 +34,7 @@ def get_log(job):
     result = docker.docker(
         ["container", "logs", local.container_name(job)],
         check=True,
+        text=True,
         capture_output=True,
     )
     return result.stdout + result.stderr
@@ -300,7 +301,7 @@ def test_finalize_success(docker_cleanup, test_repo, tmp_work_dir, volume_api):
     ensure_docker_images_present("busybox")
 
     job = JobDefinition(
-        id="test_finalize_finalized",
+        id="test_finalize_success",
         job_request_id="test_request_id",
         study=test_repo.study,
         workspace="test",

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -11,7 +11,7 @@ from tests.factories import ensure_docker_images_present
 
 # this is parametized fixture, and test using it will run multiple times, once
 # for each volume api implementation
-@pytest.fixture(params=[volumes.DockerVolumeAPI])
+@pytest.fixture(params=[volumes.BindMountVolumeAPI, volumes.DockerVolumeAPI])
 def volume_api(request, monkeypatch):
     monkeypatch.setattr(local, "volume_api", request.param)
     return request.param


### PR DESCRIPTION
This volume api implementation uses host directories and bind
mounts them into the docker container.

This approach sould be more efficient than the docker
volume api, which has to `docker cp` everything onto the volume. This
can just fast local filesystem copy, using `os.sendfile` on linux.

This is tested on linux only, and had to be explicitly enabled via
config, and is indended to be used in production backends.
