### PR TITLE
fix: ensure paths passed to docker are unix paths

### DIFF
--- a/jobrunner/actions.py
+++ b/jobrunner/actions.py
@@ -6,6 +6,8 @@ from typing import Dict, List
 from pipeline.exceptions import ProjectValidationError
 from pipeline.outputs import get_output_dirs
 
+from jobrunner.lib.path_utils import ensure_unix_path
+
 from .extractors import is_extraction_command
 
 
@@ -60,7 +62,9 @@ def get_action_specification(config, action_id, using_dummy_data_backend=False):
         # anyway, which would make this unnecessary.
         if using_dummy_data_backend:
             if action_spec.dummy_data_file is not None:
-                run_parts.append(f"--dummy-data-file={action_spec.dummy_data_file}")
+                run_parts.append(
+                    f"--dummy-data-file={ensure_unix_path(action_spec.dummy_data_file)}"
+                )
             else:
                 size = config.expectations.population_size
                 run_parts.append(f"--expectations-population={size}")

--- a/jobrunner/lib/path_utils.py
+++ b/jobrunner/lib/path_utils.py
@@ -37,3 +37,11 @@ def _iter_dir(directory, match_tree):
         # Otherwise filter this subdirectory using the subtree
         else:
             yield from _iter_dir(item, subtree)
+
+
+def ensure_unix_path(path):
+    "Ensure path is unix path string"
+    # if we're string, handle it as a string
+    if isinstance(path, str):
+        return path.replace("\\", "/")
+    return path.as_posix()

--- a/tests/lib/test_path_utils.py
+++ b/tests/lib/test_path_utils.py
@@ -1,0 +1,17 @@
+import pathlib
+
+import pytest
+
+from jobrunner.lib import path_utils
+
+
+@pytest.mark.parametrize("path,expected", [
+    (r"foo/bar", "foo/bar"),
+    (r"foo\bar", "foo/bar"),
+    (pathlib.PurePosixPath("foo/bar"), "foo/bar"),
+    (pathlib.PurePosixPath(r"foo\bar"), r"foo\bar"),
+    (pathlib.PureWindowsPath("foo/bar"), "foo/bar"),
+    (pathlib.PureWindowsPath(r"foo\bar"), "foo/bar"),
+])
+def test_ensure_unix_path(path, expected):
+    assert path_utils.ensure_unix_path(path) == expected


### PR DESCRIPTION
When jobrunner parses the pipeline config on windows, dummy_data_file is
a windows path with \ in. When passed verbatim to docker, this blows up.
So we ensure we convert it to unix path at this point
