### PR TITLE
fix: handling initial executor state being ERROR

### DIFF
--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -146,6 +146,12 @@ def handle_job(job, api, mode=None, paused=None):
         set_message(job, message)
         return
 
+    if initial_status.state == ExecutorState.ERROR:
+        # something has gone wrong since we last checked
+        mark_job_as_failed(job, initial_status.message)
+        api.cleanup(definition)
+        return
+
     # ok, handle the state transitions that are our responsibility
     if initial_status.state == ExecutorState.UNKNOWN:
         # a new job

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -90,16 +90,16 @@ class StubExecutorAPI:
         self.state = {}
         self.deleted = defaultdict(lambda: defaultdict(list))
 
-    def add_test_job(self, exec_state, job_state, **kwargs):
+    def add_test_job(self, exec_state, job_state, message="message", **kwargs):
         """Create and track a db job object."""
         job = job_factory(state=job_state, **kwargs)
         if exec_state != ExecutorState.UNKNOWN:
-            self.state[job.id] = exec_state
+            self.state[job.id] = JobStatus(exec_state, message)
         return job
 
-    def set_job_state(self, definition, state):
+    def set_job_state(self, definition, state, message="message"):
         """Directly set a job state."""
-        self.state[definition.id] = state
+        self.state[definition.id] = JobStatus(state, message)
 
     def set_job_transition(self, definition, state, message="executor message"):
         """Set the next transition for this job when called"""
@@ -159,8 +159,7 @@ class StubExecutorAPI:
         return JobStatus(ExecutorState.UNKNOWN)
 
     def get_status(self, definition):
-        state = self.state.get(definition.id, ExecutorState.UNKNOWN)
-        return JobStatus(state)
+        return self.state.get(definition.id, JobStatus(ExecutorState.UNKNOWN))
 
     def get_results(self, definition):
         return self.results.get(definition.id)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -49,6 +49,23 @@ def test_handle_job_stable_states(state, message, db):
     assert job.status_message == message
 
 
+def test_handle_job_initial_error(db):
+    api = StubExecutorAPI()
+    job = api.add_test_job(ExecutorState.ERROR, State.RUNNING, message="broken")
+
+    run.handle_job(job, api)
+
+    # executor state
+    assert job.id in api.tracker["cleanup"]
+    # its been cleaned up and is now unknown
+    assert api.get_status(job).state == ExecutorState.UNKNOWN
+
+    # our state
+    assert job.state == State.FAILED
+    assert job.status_message == "broken"
+    assert job.status_code is None
+
+
 def test_handle_job_pending_to_preparing(db):
     api = StubExecutorAPI()
     job = api.add_test_job(ExecutorState.UNKNOWN, State.PENDING)


### PR DESCRIPTION
In our local docker implementation, this can't happen, as all
transitions to an ERROR state are driven synchronously by the main loop
calling the API.

However, in the Graphnet K8S environment, this happens asynchronously,
so the state of the job can be in ERROR at any point.

This change handles it being in the ERROR state before we even try to
transition it, which is the correct thing to do.

I had to tweak the StubExecutorAPI handle setting a message initially.

Fixes #440
