### PR TITLE
fix: Remove support for cohortextractor-v2

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -59,16 +59,16 @@ If you want to know what it's up to you can get pytest to show the log output wi
 
 To run tests in docker, simply run:
 
-    make -C docker docker-test
+    just docker/test
 
 This will build the docker image and run tests. You can run job-runner as
 a service with:
 
-    make -C docker docker-serve
+    just docker/service
 
 Or run a command inside the docker image:
 
-    make -C docker docker-run ARGS=command  # bash by default
+    just docker/run ARGS=command  # bash by default
 
 
 

--- a/jobrunner/actions.py
+++ b/jobrunner/actions.py
@@ -77,7 +77,7 @@ def get_action_specification(config, action_id, using_dummy_data_backend=False):
             run_parts.append(f"--output-dir={output_dirs[0]}")
 
     elif is_extraction_command(run_parts, require_version=2):
-        # cohortextractor Version 2 expects all command line arguments to be
+        # databuilder expects all command line arguments to be
         # specified in the run command
         target = "--dummy-data-file"
         if using_dummy_data_backend and not any(

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -47,7 +47,6 @@ else:
 
 ALLOWED_IMAGES = {
     "cohortextractor",
-    "cohortextractor-v2",
     "databuilder",
     "stata-mp",
     "r",

--- a/jobrunner/extractors.py
+++ b/jobrunner/extractors.py
@@ -9,8 +9,7 @@ def is_extraction_command(args, require_version=None):
         if args[0].startswith("cohortextractor:"):
             version_found = 1
         # databuilder is a rebranded cohortextractor-v2.
-        # Retain cohortextractor-v2 for backwards compatibility for now.
-        elif args[0].startswith(("cohortextractor-v2:", "databuilder:")):
+        elif args[0].startswith("databuilder:"):
             version_found = 2
 
     # If we're not looking for a specific version then return True if any

--- a/jobrunner/lib/commands.py
+++ b/jobrunner/lib/commands.py
@@ -4,7 +4,6 @@ def requires_db_access(args):
     """
     valid_commands = {
         "cohortextractor": ("generate_cohort", "generate_codelist_report"),
-        "cohortextractor-v2": ("generate_cohort", "generate_dataset"),
         "databuilder": ("generate_dataset",),
     }
     if len(args) <= 1:

--- a/tests/lib/test_commands.py
+++ b/tests/lib/test_commands.py
@@ -7,7 +7,6 @@ from jobrunner.lib.commands import requires_db_access
     "args",
     [
         ["cohortextractor:latest", "generate_cohort", "--output-dir=outputs"],
-        ["cohortextractor-v2:latest", "generate_dataset", "--output-dir=outputs"],
         ["databuilder:latest", "generate_dataset", "--output-dir=outputs"],
         ["cohortextractor:latest", "generate_codelist_report", "--output-dir=outputs"],
     ],
@@ -21,6 +20,8 @@ def test_requires_db_access_privileged_commands_can_access_db(args):
     [
         ["cohortextractor:latest"],
         ["cohortextractor:latest", "generate_dataset", "--output-dir=outputs"],
+        # cohortextractor-v2 is no longer supported
+        ["cohortextractor-v2:latest", "generate_dataset", "--output-dir=outputs"],
         ["python", "script.py", "--output-dir=outputs"],
     ],
 )

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -72,28 +72,32 @@ def test_get_action_specification_for_cohortextractor_generate_cohort_action():
     sys.platform.startswith("win"),
     reason="ActionSpecification is only used to build commands for Docker",
 )
-@pytest.mark.parametrize("image", ["cohortextractor-v2", "databuilder"])
-def test_get_action_specification_for_databuilder_action(image):
+def test_get_action_specification_for_databuilder_action():
     config = Pipeline(
         **{
             "version": 3,
             "expectations": {"population_size": 1000},
             "actions": {
-                "generate_cohort_v2": {
-                    "run": f"{image}:latest generate_cohort --output=output/cohort.csv --dummy-data-file dummy.csv",
-                    "outputs": {"highly_sensitive": {"cohort": "output/cohort.csv"}},
+                "generate_dataset": {
+                    "run": "databuilder:latest generate_dataset "
+                    "--dataset_definition=dataset_definition.py "
+                    "--output=output/dataset.csv "
+                    "--dummy-data-file=dummy.csv",
+                    "outputs": {"highly_sensitive": {"dataset": "output/dataset.csv"}},
                 }
             },
         }
     )
 
     action_spec = get_action_specification(
-        config, "generate_cohort_v2", using_dummy_data_backend=True
+        config, "generate_dataset", using_dummy_data_backend=True
     )
 
     assert (
-        action_spec.run
-        == f"""{image}:latest generate_cohort --output=output/cohort.csv --dummy-data-file dummy.csv"""
+        action_spec.run == "databuilder:latest generate_dataset "
+        "--dataset_definition=dataset_definition.py "
+        "--output=output/dataset.csv "
+        "--dummy-data-file=dummy.csv"
     )
 
 
@@ -101,16 +105,17 @@ def test_get_action_specification_for_databuilder_action(image):
     sys.platform.startswith("win"),
     reason="ActionSpecification is only used to build commands for Docker",
 )
-@pytest.mark.parametrize("image", ["cohortextractor-v2", "databuilder"])
-def test_get_action_specification_for_databuilder_errors(image):
+def test_get_action_specification_for_databuilder_errors():
     config = Pipeline(
         **{
             "version": 3,
             "expectations": {"population_size": 1_000},
             "actions": {
-                "generate_cohort_v2": {
-                    "run": f"{image}:latest generate_cohort --output=output/cohort.csv",
-                    "outputs": {"highly_sensitive": {"cohort": "output/cohort.csv"}},
+                "generate_dataset": {
+                    "run": "databuilder:latest generate_dataset "
+                    "--dataset_definition=dataset_definition.py "
+                    "--output=output/dataset.csv",
+                    "outputs": {"highly_sensitive": {"dataset": "output/dataset.csv"}},
                 }
             },
         }
@@ -120,7 +125,7 @@ def test_get_action_specification_for_databuilder_errors(image):
     with pytest.raises(ProjectValidationError, match=msg):
         get_action_specification(
             config,
-            "generate_cohort_v2",
+            "generate_dataset",
             using_dummy_data_backend=True,
         )
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -10,7 +10,8 @@ from jobrunner.extractors import is_extraction_command
         (1, ["cohortextractor-v2:latest", "generate_cohort"], False),
         (1, ["databuilder:latest", "generate_dataset"], False),
         (2, ["cohortextractor:latest", "generate_cohort"], False),
-        (2, ["cohortextractor-v2:latest", "generate_cohort"], True),
+        # cohortextractor-v2 is no longer supported
+        (2, ["cohortextractor-v2:latest", "generate_cohort"], False),
         (2, ["databuilder:latest", "generate_dataset"], True),
     ],
 )
@@ -24,7 +25,8 @@ def test_is_extraction_command_with_version(args, require_version, desired_outco
     "args,desired_outcome",
     [
         (["cohortextractor:latest", "generate_cohort"], True),
-        (["cohortextractor-v2:latest", "generate_cohort"], True),
+        # cohortextractor-v2 is no longer supported
+        (["cohortextractor-v2:latest", "generate_cohort"], False),
         (["databuilder:latest", "generate_dataset"], True),
         (["test"], False),
         (["test", "generate_cohort"], False),


### PR DESCRIPTION
See #448 (will also need an update to the vendored jobrunner in opensafely-cli once this PR is merged)
