### PR TITLE
fix: Bump opensafely-pipeline to v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v0.1.2",
+  "opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v0.2.0",
   "ruamel.yaml",
   "requests",
 ]

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -10,7 +10,7 @@ chardet==3.0.4
     # via requests
 idna==2.10
     # via requests
-opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v0.1.1
+opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v0.2.0
     # via opensafely-jobrunner (pyproject.toml)
 pydantic==1.9.0
     # via opensafely-pipeline


### PR DESCRIPTION
Related to #448, opensafely-pipeline has now removed support for cohortextractor-v2 also