### PR TITLE
feat: add schema migrations framework

### DIFF
--- a/jobrunner/cli/migrate.py
+++ b/jobrunner/cli/migrate.py
@@ -1,0 +1,25 @@
+"""
+Run any pending database migrations
+"""
+import argparse
+from pathlib import Path
+
+from jobrunner import config
+from jobrunner.lib import database, log_utils
+
+
+def run():
+    log_utils.configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__.partition("\n\n")[0])
+    parser.add_argument(
+        "--dbpath",
+        type=Path,
+        default=config.DATABASE_FILE,
+        help="db file to migrate (defaults to configured db)",
+    )
+    args = parser.parse_args()
+    database.ensure_db(args.dbpath)
+
+
+if __name__ == "__main__":
+    run()

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -6,7 +6,7 @@ import threading
 import time
 
 from jobrunner import config, record_stats, run, sync
-from jobrunner.lib.database import get_connection
+from jobrunner.lib.database import ensure_valid_db
 from jobrunner.lib.docker import docker
 from jobrunner.lib.log_utils import configure_logging
 from jobrunner.queries import get_flag_value, set_flag
@@ -30,9 +30,9 @@ def main():
     threading.current_thread().name = "run "
     fmt = "{asctime} {threadName} {message} {tags}"
     configure_logging(fmt)
-    # ensure db is set up before we start any threads, otherwise if we don't already have
-    # a database (which we don't in tests) then threads will race to create the schema
-    get_connection()
+
+    # check db is present and up to date, or else error
+    ensure_valid_db()
 
     try:
         log.info("jobrunner.service started")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,13 @@ dynamic = ["version"]
 
 [project.scripts]
 add_job = "jobrunner.cli.add_job:run"
+flags = "jobrunner.cli.flags:run"
 kill_job = "jobrunner.cli.kill_job:run"
 local_run = "jobrunner.cli.local_run:run"
+migrate = "jobrunner.cli.migrate:run"
+prepare_for_reboot = "jobrunner.cli.prepare_for_reboot:run"
 retry_job = "jobrunner.cli.retry_job:run"
+
 
 [project.urls]
 Home = "https://opensafely.org"

--- a/tests/cli/test_local_run.py
+++ b/tests/cli/test_local_run.py
@@ -77,6 +77,7 @@ def test_local_run_copes_with_detritus_of_earlier_interrupted_run(
     project_dir = tmp_path / "project"
     shutil.copytree(str(FIXTURE_DIR / "full_project"), project_dir)
     config.DATABASE_FILE = project_dir / "metadata" / "db.sqlite"
+    database.ensure_db(config.DATABASE_FILE)
 
     project = load_pipeline(project_dir / "project.yaml")
     database.insert(SavedJobRequest(id="previous-request", original={}))

--- a/tests/lib/test_database.py
+++ b/tests/lib/test_database.py
@@ -1,6 +1,18 @@
+import sqlite3
+
 import pytest
 
-from jobrunner.lib.database import find_one, insert, select_values, update
+from jobrunner.lib.database import (
+    CONNECTION_CACHE,
+    MigrationNeeded,
+    ensure_db,
+    ensure_valid_db,
+    find_one,
+    insert,
+    migrate_db,
+    select_values,
+    update,
+)
 from jobrunner.models import Job, State
 
 
@@ -62,3 +74,110 @@ def test_find_one_fails_if_there_is_more_than_one_result(tmp_work_dir):
     insert(Job(id="foo456", workspace="the-workspace"))
     with pytest.raises(ValueError):
         find_one(Job, workspace="the-workspace")
+
+
+def test_ensure_db_new_db(tmp_path):
+    db = tmp_path / "db.sqlite"
+
+    conn = ensure_db(db, {1: "should not run"})
+
+    assert conn.isolation_level is None
+    assert conn.row_factory is sqlite3.Row
+    assert CONNECTION_CACHE.__dict__[db] is conn
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_ensure_db_new_db_memory():
+    db = "file:test?mode=memory&cached=shared"
+    conn = ensure_db(db, {1: "should not run"})
+    assert CONNECTION_CACHE.__dict__[db] is conn
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_ensure_db_existing_db_needs_migration(tmp_path):
+    db = tmp_path / "db.sqlite"
+    conn = ensure_db(db, {})
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+    CONNECTION_CACHE.__dict__.clear()
+
+    ensure_db(db, {1: "ALTER TABLE job ADD COLUMN test TEXT"})
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_ensure_db_existing_db_does_not_need_migration(tmp_path):
+    db = tmp_path / "db.sqlite"
+    conn = ensure_db(db, {})
+    conn.execute("PRAGMA user_version=1")
+    assert CONNECTION_CACHE.__dict__.pop(db)
+
+    # shouldn't run this
+    conn = ensure_db(db, {1: "should not run"})
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_migrate_db(tmp_path):
+    db = tmp_path / "db.sqlite"
+    conn = ensure_db(db, {})
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+
+    migrations = {
+        1: "ALTER TABLE job ADD COLUMN first TEXT;",
+    }
+
+    applied = migrate_db(conn, migrations)
+    assert applied == [1]
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+
+    # this will error if first column doesn't exist
+    conn.execute("SELECT first FROM job")
+
+    migrations[2] = "ALTER TABLE job ADD COLUMN second TEXT;"
+
+    applied = migrate_db(conn, migrations)
+    assert applied == [2]
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+    conn.execute("SELECT second FROM job")
+
+    applied = migrate_db(conn, migrations)
+    assert applied == []
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+
+
+def test_migrate_in_transaction(tmp_path):
+    db = tmp_path / "db.sqlite"
+    conn = ensure_db(db, {})
+
+    migrations = {
+        1: "bad migration",
+    }
+
+    version = conn.execute("PRAGMA user_version").fetchone()[0]
+
+    with pytest.raises(Exception):
+        migrate_db(conn, migrations)
+
+    # check version not incremented
+    assert version == conn.execute("PRAGMA user_version").fetchone()[0]
+
+
+def test_ensure_valid_db(tmp_path):
+
+    # db doesn't exists
+    with pytest.raises(MigrationNeeded) as exc:
+        ensure_valid_db("not_exists")
+
+    assert "does not exist" in str(exc.value)
+
+    # db exists but is out of date
+    db = tmp_path / "db.sqlite"
+    conn = ensure_db(db, {})
+
+    with pytest.raises(MigrationNeeded) as exc:
+        ensure_valid_db(db, {1: "should not run"})
+
+    assert "out of date" in str(exc.value)
+
+    # does not raise when all is well
+    conn.execute("PRAGMA user_version=1")
+    ensure_valid_db(db, {1: "should not run"})

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7,6 +7,7 @@ import time
 import pytest
 
 from jobrunner import config, queries, service
+from jobrunner.lib import database
 
 
 @pytest.mark.skipif(
@@ -16,6 +17,9 @@ def test_service_main(tmp_path):
     """
     Test that the service module handles SIGINT and exits cleanly
     """
+    db = tmp_path / "db.sqlite"
+    database.ensure_db(db)
+
     p = subprocess.Popen(
         [sys.executable, "-m", "jobrunner.service"],
         # For the purposes of this test we don't care if we can actually talk


### PR DESCRIPTION
We have some pending db changes to make. In preparation for this, this
change adds a formal migration system to the micro-ORM.

 * To avoid having to package raw sql files, we track the migrations as
   string literals in python code, as dict mapping version to SQL
   string.

 * We use the `PRAGMA user_version` db variable to track the migration
   version, using transactions to ensure it is set appropriately.

 * We add a migrate command, analagous to django `manage.py migrate`.
   This will ensure a db exists and is at the latest schema version.
   This is the only way to create/migrate a db, and should be run as an
   explicit step as part of production deployments

 * Previously, in production schema creation happened lazily when the
   service started up. Extending this to apply migrations automatically
   on service start up seemed risky. Instead we add an explict check
   that the db exists and is up to date, or else we do not start up.
   This is designed to catch configuration issues or unapplied
   migrations in production.

 * For `jobrunner.cli.local_run` however, we do automatically apply the
   migrations on behalf of the user, as each project has its own db. The
   data they have is an optimisation, rather than a requirement, as they
   can always re-run the entire project if needed.

 * Note: there are no actual migrations in this initial change - the
   migration framework will be used in subsequent PRs
