### PR TITLE
 feat: record user/project/org metadata

### DIFF
--- a/jobrunner/cli/migrate.py
+++ b/jobrunner/cli/migrate.py
@@ -2,13 +2,14 @@
 Run any pending database migrations
 """
 import argparse
+import sys
 from pathlib import Path
 
 from jobrunner import config
 from jobrunner.lib import database, log_utils
 
 
-def run():
+def run(argv):
     log_utils.configure_logging()
     parser = argparse.ArgumentParser(description=__doc__.partition("\n\n")[0])
     parser.add_argument(
@@ -17,9 +18,9 @@ def run():
         default=config.DATABASE_FILE,
         help="db file to migrate (defaults to configured db)",
     )
-    args = parser.parse_args()
-    database.ensure_db(args.dbpath)
+    args = parser.parse_args(argv)
+    database.ensure_db(args.dbpath, verbose=True)
 
 
 if __name__ == "__main__":
-    run()
+    run(sys.argv[1:])

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -221,6 +221,7 @@ def recursively_build_jobs(jobs_by_action, job_request, pipeline_config, action)
         if required_job.state in [State.PENDING, State.RUNNING]:
             wait_for_job_ids.append(required_job.id)
 
+    timestamp = time.time()
     job = Job(
         job_request_id=job_request.id,
         state=State.PENDING,
@@ -233,8 +234,12 @@ def recursively_build_jobs(jobs_by_action, job_request, pipeline_config, action)
         requires_outputs_from=action_spec.needs,
         run_command=action_spec.run,
         output_spec=action_spec.outputs,
-        created_at=int(time.time()),
-        updated_at=int(time.time()),
+        created_at=int(timestamp),
+        updated_at=int(timestamp),
+        created_by=job_request.created_by,
+        project=job_request.project,
+        # flatten into , separated list
+        org_list=",".join(job_request.orgs),
     )
 
     # Add it to the dictionary of scheduled jobs
@@ -331,10 +336,14 @@ def create_failed_job(job_request, exception):
         workspace=job_request.workspace,
         action=action,
         status_message=status_message,
-        created_at=now,
-        started_at=now,
-        updated_at=now,
-        completed_at=now,
+        created_at=int(now),
+        started_at=int(now),
+        updated_at=int(now),
+        completed_at=int(now),
+        created_by=job_request.created_by,
+        project=job_request.project,
+        # flatten into , separated list
+        org_list=",".join(job_request.orgs),
     )
     insert_into_database(job_request, [job])
 

--- a/jobrunner/lib/database.py
+++ b/jobrunner/lib/database.py
@@ -237,7 +237,6 @@ def ensure_db(filename=None, migrations=MIGRATIONS):
         # set migration level to highest migration version
         conn.execute(f"PRAGMA user_version={max(migrations, default=0)}")
         # print("created new db at {filename}")
-
     return conn
 
 

--- a/jobrunner/lib/log_utils.py
+++ b/jobrunner/lib/log_utils.py
@@ -104,7 +104,7 @@ def formatting_filter(record):
     if status_code:
         tags["status"] = status_code
     if job:
-        tags["project"] = job.project
+        tags["workspace"] = job.workspace
         tags["action"] = job.action
         tags["id"] = job.id
     if req:

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -117,6 +117,9 @@ def job_request_from_remote_format(job_request):
         workspace=job_request["workspace"]["name"],
         database_name=job_request["workspace"]["db"],
         force_run_dependencies=job_request["force_run_dependencies"],
+        created_by=job_request["created_by"],
+        project=job_request["project"],
+        orgs=job_request["orgs"],
         original=job_request,
     )
 
@@ -137,6 +140,9 @@ def job_to_remote_format(job):
         "updated_at": job.updated_at_isoformat,
         "started_at": job.started_at_isoformat,
         "completed_at": job.completed_at_isoformat,
+        "created_by": job.created_by,
+        "project": job.project,
+        "orgs": job.org_list.split(","),
     }
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -32,6 +32,8 @@ JOB_DEFAULTS = {
     "run_command": "python myscript.py",
     "output_spec": {},
     "created_at": 0,
+    "created_by": "user",
+    "project": "project",
 }
 
 

--- a/tests/lib/test_log_utils.py
+++ b/tests/lib/test_log_utils.py
@@ -11,7 +11,12 @@ FROZEN_TIMESTAMP = 1608568119.1467905
 FROZEN_TIMESTRING = datetime.utcfromtimestamp(FROZEN_TIMESTAMP).isoformat()
 
 repo_url = "https://github.com/opensafely/project"
-test_job = Job(id="id", action="action", repo_url=repo_url)
+test_job = Job(
+    id="id",
+    action="action",
+    repo_url=repo_url,
+    workspace="workspace",
+)
 test_request = JobRequest(
     id="request",
     repo_url=repo_url,
@@ -31,20 +36,26 @@ def test_formatting_filter():
     record = logging.makeLogRecord({"job": test_job})
     assert log_utils.formatting_filter(record)
     assert record.action == "action: "
-    assert record.tags == "project=project action=action id=id"
+    assert record.tags == "workspace=workspace action=action id=id"
 
     record = logging.makeLogRecord({"job": test_job, "status_code": "code"})
     assert log_utils.formatting_filter(record)
-    assert record.tags == "status=code project=project action=action id=id"
+    assert record.tags == "status=code workspace=workspace action=action id=id"
 
-    test_job2 = Job(id="id", action="action", repo_url=repo_url, status_code="code")
+    test_job2 = Job(
+        id="id",
+        action="action",
+        repo_url=repo_url,
+        status_code="code",
+        workspace="workspace",
+    )
     record = logging.makeLogRecord({"job": test_job2})
     assert log_utils.formatting_filter(record)
-    assert record.tags == "status=code project=project action=action id=id"
+    assert record.tags == "status=code workspace=workspace action=action id=id"
 
     record = logging.makeLogRecord({"job": test_job, "job_request": test_request})
     assert log_utils.formatting_filter(record)
-    assert record.tags == "project=project action=action id=id req=request"
+    assert record.tags == "workspace=workspace action=action id=id req=request"
 
     record = logging.makeLogRecord({"status_code": ""})
     assert log_utils.formatting_filter(record)
@@ -56,17 +67,17 @@ def test_formatting_filter_with_context():
     with log_utils.set_log_context(job=test_job):
         assert log_utils.formatting_filter(record)
     assert record.action == "action: "
-    assert record.tags == "project=project action=action id=id"
+    assert record.tags == "workspace=workspace action=action id=id"
 
     record = logging.makeLogRecord({"status_code": "code"})
     with log_utils.set_log_context(job=test_job):
         assert log_utils.formatting_filter(record)
-    assert record.tags == "status=code project=project action=action id=id"
+    assert record.tags == "status=code workspace=workspace action=action id=id"
 
     record = logging.makeLogRecord({})
     with log_utils.set_log_context(job=test_job, job_request=test_request):
         assert log_utils.formatting_filter(record)
-    assert record.tags == "project=project action=action id=id req=request"
+    assert record.tags == "workspace=workspace action=action id=id req=request"
 
 
 def test_jobrunner_formatter_default(monkeypatch):
@@ -83,7 +94,7 @@ def test_jobrunner_formatter_default(monkeypatch):
     formatter = log_utils.JobRunnerFormatter(log_utils.DEFAULT_FORMAT, style="{")
     assert formatter.format(record) == (
         "2020-12-21 16:28:39.146Z message "
-        "status=status project=project action=action id=id req=request"
+        "status=status workspace=workspace action=action id=id req=request"
     )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -70,6 +70,9 @@ def test_integration(
             "db": "dummy",
         },
         "sha": test_repo.commit,
+        "created_by": "user",
+        "project": "project",
+        "orgs": ["org"],
     }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",
@@ -117,6 +120,9 @@ def test_integration(
             "db": "dummy",
         },
         "sha": test_repo.commit,
+        "created_by": "user",
+        "project": "project",
+        "orgs": ["org"],
     }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",
@@ -222,6 +228,9 @@ def test_integration_with_databuilder(
             "db": "dummy",
         },
         "sha": test_repo.commit,
+        "created_by": "user",
+        "project": "project",
+        "orgs": ["org"],
     }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",
@@ -267,6 +276,9 @@ def test_integration_with_databuilder(
             "db": "dummy",
         },
         "sha": test_repo.commit,
+        "created_by": "user",
+        "project": "project",
+        "orgs": ["org"],
     }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -19,6 +19,9 @@ def test_job_request_from_remote_format():
         "cancelled_actions": ["analyse"],
         "force_run_dependencies": True,
         "sha": "abcdef",
+        "created_by": "user",
+        "project": "project",
+        "orgs": ["org"],
     }
     expected = JobRequest(
         id="123",
@@ -30,6 +33,9 @@ def test_job_request_from_remote_format():
         requested_actions=["generate_cohort"],
         cancelled_actions=["analyse"],
         force_run_dependencies=True,
+        created_by="user",
+        project="project",
+        orgs=["org"],
         original=remote_job_request,
     )
     job_request = sync.job_request_from_remote_format(remote_job_request)


### PR DESCRIPTION
Job server is now sending project/org data in job requests[1].

This change stores this information in the db. The main use of this so
that we can emit telemetry that is tagged by these values in future.

It includes the first migration using the new migration system.

[1] https://github.com/opensafely-core/job-server/pull/2095/files
