### PR TITLE
Make job-runner aware of sqlrunner

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -52,6 +52,7 @@ ALLOWED_IMAGES = {
     "r",
     "jupyter",
     "python",
+    "sqlrunner",
 }
 
 DOCKER_REGISTRY = os.environ.get("DOCKER_REGISTRY", "ghcr.io/opensafely-core")

--- a/jobrunner/lib/commands.py
+++ b/jobrunner/lib/commands.py
@@ -5,10 +5,14 @@ def requires_db_access(args):
     valid_commands = {
         "cohortextractor": ("generate_cohort", "generate_codelist_report"),
         "databuilder": ("generate-dataset",),
+        "sqlrunner": None,  # all commands are valid
     }
     if len(args) <= 1:
         return False
 
     image, command = args[0], args[1]
     image = image.split(":")[0]
-    return command in valid_commands.get(image, [])
+    if image in valid_commands:
+        if valid_commands[image] is None or command in valid_commands[image]:
+            return True
+    return False

--- a/tests/lib/test_commands.py
+++ b/tests/lib/test_commands.py
@@ -11,6 +11,8 @@ from jobrunner.lib.commands import requires_db_access
         ["cohortextractor:latest", "generate_codelist_report"],
         # Third and subsequent arguments are ignored:
         ["cohortextractor:latest", "generate_cohort", "could-be-anything-here"],
+        # sqlrunner has an image but doesn't have a command
+        ["sqlrunner:latest", "input.sql"],
     ],
 )
 def test_requires_db_access_privileged_commands_can_access_db(args):


### PR DESCRIPTION
As well as adding sqlrunner's image to the list of allowed images, we also let job-runner know that sqlrunner's image requires DB access. We modify `requires_db_access` slightly, because unlike the other images that require DB access, we don't invoke sqlrunner's image with a (sub)command.

See also opensafely-core/sqlrunner#15 for building and publishing sqlrunner's image.