### PR TITLE
feat: add fine grained status codes and track them in the db.

### DIFF
--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -21,7 +21,7 @@ from jobrunner.lib.github_validators import (
     validate_branch_and_commit,
     validate_repo_url,
 )
-from jobrunner.models import Job, SavedJobRequest, State
+from jobrunner.models import Job, SavedJobRequest, State, StatusCode
 from jobrunner.queries import calculate_workspace_state
 from jobrunner.reusable_actions import (
     ReusableActionError,
@@ -221,9 +221,11 @@ def recursively_build_jobs(jobs_by_action, job_request, pipeline_config, action)
         if required_job.state in [State.PENDING, State.RUNNING]:
             wait_for_job_ids.append(required_job.id)
 
+    timestamp = time.time()
     job = Job(
         job_request_id=job_request.id,
         state=State.PENDING,
+        status_code=StatusCode.CREATED,
         repo_url=job_request.repo_url,
         commit=job_request.commit,
         workspace=job_request.workspace,
@@ -233,8 +235,8 @@ def recursively_build_jobs(jobs_by_action, job_request, pipeline_config, action)
         requires_outputs_from=action_spec.needs,
         run_command=action_spec.run,
         output_spec=action_spec.outputs,
-        created_at=int(time.time()),
-        updated_at=int(time.time()),
+        created_at=int(timestamp),
+        updated_at=int(timestamp),
     )
 
     # Add it to the dictionary of scheduled jobs
@@ -316,25 +318,28 @@ def create_failed_job(job_request, exception):
     # Special case for the NothingToDoError which we treat as a success
     if isinstance(exception, NothingToDoError):
         state = State.SUCCEEDED
+        code = StatusCode.SUCCEEDED
         status_message = "All actions have already run"
         action = job_request.requested_actions[0]
     else:
         state = State.FAILED
+        code = StatusCode.INTERNAL_ERROR
         status_message = f"{type(exception).__name__}: {exception}"
         action = "__error__"
-    now = int(time.time())
+    now = time.time()
     job = Job(
         job_request_id=job_request.id,
         state=state,
+        status_code=code,
         repo_url=job_request.repo_url,
         commit=job_request.commit,
         workspace=job_request.workspace,
         action=action,
         status_message=status_message,
-        created_at=now,
-        started_at=now,
-        updated_at=now,
-        completed_at=now,
+        created_at=int(now),
+        started_at=int(now),
+        updated_at=int(now),
+        completed_at=int(now),
     )
     insert_into_database(job_request, [job])
 

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -26,16 +26,53 @@ class State(Enum):
 
 
 # In contrast to State, these play no role in the state machine controlling
-# what happens with a job. They are simply machine readable versions of the
-# human readable status_message which allow us to provide certain UX
-# affordances in the web and command line interfaces. These get added as we
-# have a direct need for them, hence the minimal list below.
+# what happens with a job. These are designed specifically for reporting the
+# current low-level state of a job. They are simply machine readable versions
+# of the human readable status_message which allow us to provide certain UX
+# affordances in the web, cli and telemetry.
 class StatusCode(Enum):
+
+    # PENDING states
+    #
+    # initial state of a job, not yet running
+    CREATED = "created"
+    # waiting for pause mode to exit
+    WAITING_PAUSED = "paused"
+    # waiting db maintenance mode to exit
+    WAITING_DB_MAINTENANCE = "waiting_db_maintenance"
+    # waiting on dependant jobs
     WAITING_ON_DEPENDENCIES = "waiting_on_dependencies"
-    DEPENDENCY_FAILED = "dependency_failed"
+    # waiting on available resources to run the job
     WAITING_ON_WORKERS = "waiting_on_workers"
+
+    # RUNNING states, these mirror ExecutorState, and are the normal happy path
+    PREPARING = "preparing"
+    PREPARED = "prepared"
+    EXECUTING = "executing"
+    EXECUTED = "executed"
+    FINALIZING = "finalizing"
+    FINALIZED = "finalized"
+
+    # SUCCEEDED states. Simples.
+    SUCCEEDED = "succeeded"
+
+    # FAILED states
+    DEPENDENCY_FAILED = "dependency_failed"
     NONZERO_EXIT = "nonzero_exit"
     CANCELLED_BY_USER = "cancelled_by_user"
+    UNMATCHED_PATTERNS = "unmatched_patterns"
+    INTERNAL_ERROR = "internal_error"
+
+
+# used for tracing to know if a state is final or not
+FINAL_STATUS_CODES = [
+    StatusCode.SUCCEEDED,
+    StatusCode.DEPENDENCY_FAILED,
+    StatusCode.NONZERO_EXIT,
+    StatusCode.CANCELLED_BY_USER,
+    StatusCode.UNMATCHED_PATTERNS,
+    StatusCode.INTERNAL_ERROR,
+]
 
 
 # This is our internal representation of a JobRequest which we pass around but


### PR DESCRIPTION
This means the a StatusCode is always required, and function signatures
have changed as a result.

Also, I noticed that that a few of our failure cases were being handled
in the handle_job(n) method, when really they should have been handled
by the generic exception handler to unify process, so fixed that in the
process.
