### PR TITLE
fix: rename project to workspace

### DIFF
--- a/jobrunner/lib/log_utils.py
+++ b/jobrunner/lib/log_utils.py
@@ -104,7 +104,7 @@ def formatting_filter(record):
     if status_code:
         tags["status"] = status_code
     if job:
-        tags["project"] = job.project
+        tags["workspace"] = job.workspace
         tags["action"] = job.action
         tags["id"] = job.id
     if req:

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -15,7 +15,7 @@ import secrets
 from enum import Enum
 
 from jobrunner.lib.database import databaseclass
-from jobrunner.lib.string_utils import project_name_from_url, slugify
+from jobrunner.lib.string_utils import slugify
 
 
 class State(Enum):
@@ -209,13 +209,6 @@ class Job:
     @property
     def completed_at_isoformat(self):
         return timestamp_to_isoformat(self.completed_at)
-
-    # On Python 3.8 we could use `functools.cached_property` here and avoid
-    # recomputing this every time
-    @property
-    def project(self):
-        """Project name based on github url."""
-        return project_name_from_url(self.repo_url)
 
     # On Python 3.8 we could use `functools.cached_property` here and avoid
     # recomputing this every time

--- a/tests/lib/test_log_utils.py
+++ b/tests/lib/test_log_utils.py
@@ -11,7 +11,12 @@ FROZEN_TIMESTAMP = 1608568119.1467905
 FROZEN_TIMESTRING = datetime.utcfromtimestamp(FROZEN_TIMESTAMP).isoformat()
 
 repo_url = "https://github.com/opensafely/project"
-test_job = Job(id="id", action="action", repo_url=repo_url)
+test_job = Job(
+    id="id",
+    action="action",
+    repo_url=repo_url,
+    workspace="workspace",
+)
 test_request = JobRequest(
     id="request",
     repo_url=repo_url,
@@ -31,20 +36,26 @@ def test_formatting_filter():
     record = logging.makeLogRecord({"job": test_job})
     assert log_utils.formatting_filter(record)
     assert record.action == "action: "
-    assert record.tags == "project=project action=action id=id"
+    assert record.tags == "workspace=workspace action=action id=id"
 
     record = logging.makeLogRecord({"job": test_job, "status_code": "code"})
     assert log_utils.formatting_filter(record)
-    assert record.tags == "status=code project=project action=action id=id"
+    assert record.tags == "status=code workspace=workspace action=action id=id"
 
-    test_job2 = Job(id="id", action="action", repo_url=repo_url, status_code="code")
+    test_job2 = Job(
+        id="id",
+        action="action",
+        repo_url=repo_url,
+        status_code="code",
+        workspace="workspace",
+    )
     record = logging.makeLogRecord({"job": test_job2})
     assert log_utils.formatting_filter(record)
-    assert record.tags == "status=code project=project action=action id=id"
+    assert record.tags == "status=code workspace=workspace action=action id=id"
 
     record = logging.makeLogRecord({"job": test_job, "job_request": test_request})
     assert log_utils.formatting_filter(record)
-    assert record.tags == "project=project action=action id=id req=request"
+    assert record.tags == "workspace=workspace action=action id=id req=request"
 
     record = logging.makeLogRecord({"status_code": ""})
     assert log_utils.formatting_filter(record)
@@ -56,17 +67,17 @@ def test_formatting_filter_with_context():
     with log_utils.set_log_context(job=test_job):
         assert log_utils.formatting_filter(record)
     assert record.action == "action: "
-    assert record.tags == "project=project action=action id=id"
+    assert record.tags == "workspace=workspace action=action id=id"
 
     record = logging.makeLogRecord({"status_code": "code"})
     with log_utils.set_log_context(job=test_job):
         assert log_utils.formatting_filter(record)
-    assert record.tags == "status=code project=project action=action id=id"
+    assert record.tags == "status=code workspace=workspace action=action id=id"
 
     record = logging.makeLogRecord({})
     with log_utils.set_log_context(job=test_job, job_request=test_request):
         assert log_utils.formatting_filter(record)
-    assert record.tags == "project=project action=action id=id req=request"
+    assert record.tags == "workspace=workspace action=action id=id req=request"
 
 
 def test_jobrunner_formatter_default(monkeypatch):
@@ -83,7 +94,7 @@ def test_jobrunner_formatter_default(monkeypatch):
     formatter = log_utils.JobRunnerFormatter(log_utils.DEFAULT_FORMAT, style="{")
     assert formatter.format(record) == (
         "2020-12-21 16:28:39.146Z message "
-        "status=status project=project action=action id=id req=request"
+        "status=status workspace=workspace action=action id=id req=request"
     )
 
 


### PR DESCRIPTION
Jobrunner's user of project pre-dates jobserver's Project concept, so
rename these in model and logs to workspace
