### PR TITLE
feat: add opentelemetry tracing

### DIFF
--- a/jobrunner/cli/local_run.py
+++ b/jobrunner/cli/local_run.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 from pipeline import RUN_ALL_COMMAND, ProjectValidationError, load_pipeline
 
-from jobrunner import config, executors
+from jobrunner import config, executors, tracing
 from jobrunner.actions import UnknownActionError
 from jobrunner.create_or_update_jobs import (
     JobRequestError,
@@ -156,6 +156,8 @@ def main(
 ):
     if not docker_preflight_check():
         return False
+
+    tracing.setup_default_tracing()
 
     project_dir = Path(project_dir).resolve()
     temp_dir = Path(tempfile.mkdtemp(prefix="opensafely_"))
@@ -426,6 +428,7 @@ def create_and_run_jobs(
 
 
 def create_job_request_and_jobs(project_dir, actions, force_run_dependencies):
+
     job_request = JobRequest(
         id=random_id(),
         repo_url=str(project_dir),

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -226,7 +226,7 @@ def recursively_build_jobs(jobs_by_action, job_request, pipeline_config, action)
         job_request_id=job_request.id,
         state=State.PENDING,
         status_code=StatusCode.CREATED,
-        # time in ns
+        # time in nanoseconds
         status_code_updated_at=int(timestamp * 1e9),
         repo_url=job_request.repo_url,
         commit=job_request.commit,

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -334,7 +334,7 @@ def create_failed_job(job_request, exception):
         job_request_id=job_request.id,
         state=state,
         status_code=code,
-        # time in ns
+        # time in nanoseconds
         status_code_updated_at=int(now * 1e9),
         repo_url=job_request.repo_url,
         commit=job_request.commit,

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -498,8 +498,8 @@ def set_code(job, code, message, error=None, **attrs):
 
         if code in FINAL_STATUS_CODES:
             # transitioning to a final state, so just record that state
-            tracing.finish_current_state(
-                job, timestamp_ns, final=True, error=error, message=message, **attrs
+            tracing.record_final_state(
+                job, timestamp_ns, error=error, message=message, **attrs
             )
         else:
             # trace that we've started the next state

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -5,7 +5,7 @@ import logging
 import threading
 import time
 
-from jobrunner import config, record_stats, run, sync
+from jobrunner import config, record_stats, run, sync, tracing
 from jobrunner.lib.database import ensure_valid_db
 from jobrunner.lib.docker import docker
 from jobrunner.lib.log_utils import configure_logging
@@ -30,6 +30,7 @@ def main():
     threading.current_thread().name = "run "
     fmt = "{asctime} {threadName} {message} {tags}"
     configure_logging(fmt)
+    tracing.setup_default_tracing()
 
     # check db is present and up to date, or else error
     ensure_valid_db()

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -1,0 +1,226 @@
+import logging
+import os
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+from jobrunner import config
+from jobrunner.lib import database
+from jobrunner.models import Job, SavedJobRequest, StatusCode
+
+
+logger = logging.getLogger(__name__)
+provider = TracerProvider()
+trace.set_tracer_provider(provider)
+
+
+def add_exporter(exporter, processor=SimpleSpanProcessor):
+    # we default to SimpleSpanProcessor so that it's synchronous for tests
+    provider.add_span_processor(processor(exporter))
+
+
+def setup_default_tracing():
+    """Inspect environmenet variables and set up exporters accordingly.
+
+    We use the SimpleSpanProcessor by default, which is synchronous. The
+    BatchSpanProcess is asynchronous and more efficent at scale, but are
+    emitting so few spans that it is easier just to keep it simpler, and it
+    makes testing easier.
+    """
+    if "OTEL_EXPORTER_OTLP_HEADERS" in os.environ:
+        if "OTEL_SERVICE_NAME" not in os.environ:
+            raise Exception(
+                "OTEL_EXPORTER_OTLP_HEADERS is configured, but missing OTEL_SERVICE_NAME"
+            )
+        if "OTEL_EXPORTER_OTLP_ENDPOINT" not in os.environ:
+            os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://api.honeycomb.io"
+
+        add_exporter(OTLPSpanExporter())
+
+    if "OTEL_EXPORTER_CONSOLE" in os.environ:
+        add_exporter(ConsoleSpanExporter())
+
+
+def trace_attributes(job):
+    """These attributes are added to every span in order to slice and dice by
+    each as needed.
+    """
+    # grab job request metadata, caching it on the job instance to avoid excess
+    # queries/jsoning
+    if job._job_request is None:
+        try:
+            job._job_request = database.find_one(
+                SavedJobRequest, id=job.job_request_id
+            ).original
+        except ValueError:
+            job._job_request = {}
+
+    attrs = dict(
+        backend=config.BACKEND,
+        job=job.id,
+        job_request=job.job_request_id,
+        workspace=job.workspace,
+        action=job.action,
+        commit=job.commit,
+        run_command=job.run_command,
+        user=job._job_request.get("created_by", "unknown"),
+        project=job._job_request.get("project", "unknown"),
+        orgs=",".join(job._job_request.get("orgs", [])),
+        state=job.state.name,
+        message=job.status_message,
+    )
+
+    if job.action_repo_url:
+        attrs["reusable_action"] = job.action_repo_url
+        if job.action_commit:
+            attrs["reusable_action"] += ":" + job.action_commit
+
+    # opentelemetry cannot handle None values
+    return {k: "" if v is None else v for k, v in attrs.items()}
+
+
+def initialise_trace(job):
+    """Initialise the trace for this job by creating a root span.
+
+    We store the serialised trace context in the db, so we can reuse it for
+    later spans.
+
+    We create a root span, which is a requirement in OTEl. For this reason we
+    send it out straight away, which means its duration is very short.
+    """
+    assert not job.trace_context, "this job already has a trace-context"
+    assert job.status_code is not None, "job has no initial StatusCode"
+    assert (
+        job.status_code_updated_at is not None
+    ), "job has no initial status_code_updated_at"
+
+    job.trace_context = {}
+    tracer = trace.get_tracer("jobs")
+    attrs = trace_attributes(job)
+
+    # convert created_at to ns
+    start_time = int(job.created_at * 1e9)
+
+    # TraceContextTextMapPropagator only works with the current span, sadlmy
+    with tracer.start_as_current_span("job", start_time=start_time) as root:
+        root.set_attributes(attrs)
+        # we serialise the entire trace context, as it may grow extra fields
+        # (e.g.  baggage) over time
+        TraceContextTextMapPropagator().inject(job.trace_context)
+
+    # trace the initial job state trace
+    start_new_state(job, job.status_code_updated_at)
+
+
+def finish_current_state(job, timestamp_ns, final=False, error=None, **attrs):
+    """Record a span representing the state we've just exited."""
+    try:
+        name = job.status_code.name
+        # Note: this *must* be timestamp as integer nanoseconds
+        start_time = job.status_code_updated_at
+
+        end_time = timestamp_ns
+
+        if final:
+            # final states have no duration, so make last for 1 sec, just act
+            # as a marker
+            end_time = int(end_time + 1e9)
+
+        record_job_span(job, name, start_time, end_time, error, **attrs)
+
+        if final:
+            # record a full span for the entire run
+            # trace vanity: have the job start 1us before the actualy job, so
+            # it shows up first in the trace
+            job_start_time = int(job.created_at * 1e9) - 1000
+            record_job_span(job, "RUN", job_start_time, timestamp_ns, error, **attrs)
+
+    except Exception:
+        # make sure trace failures do not error the job
+        logger.exception(f"failed to trace state for {job.id}")
+
+
+def start_new_state(job, timestamp_ns, error=None, **attrs):
+    """Record a marker span to say that we've entered a new state."""
+    try:
+        name = f"ENTER {job.status_code.name}"
+        start_time = timestamp_ns
+        # fix the time for these synthenic marker events at one second
+        end_time = int(start_time + 1e9)
+        if attrs is None:
+            attrs = {}
+        # allow them to be filtered out easily
+        attrs["enter_state"] = True
+        record_job_span(job, name, start_time, end_time, error, **attrs)
+    except Exception:
+        # make sure trace failures do not error the job
+        logger.exception(f"failed to trace state for {job.id}")
+
+
+def record_job_span(job, name, start_time, end_time, error, **attrs):
+    """Record a span for a job."""
+    assert job.trace_context is not None, "job missing trace_context"
+    ctx = TraceContextTextMapPropagator().extract(carrier=job.trace_context)
+    tracer = trace.get_tracer("jobs")
+
+    attributes = {}
+
+    if attrs:
+        attributes.update(attrs)
+    attributes.update(trace_attributes(job))
+
+    span = tracer.start_span(
+        name,
+        context=ctx,
+        start_time=start_time,
+    )
+    span.set_attributes(attributes)
+    if error:
+        span.set_status(trace.Status(trace.StatusCode.ERROR))
+    if isinstance(error, Exception):
+        span.record_exception(error)
+
+    span.end(end_time)
+
+
+if __name__ == "__main__":
+    # local testing utility for tracing
+    import time
+
+    from jobrunner.run import set_code
+
+    setup_default_tracing()
+
+    timestamp = int(time.time())
+    job = Job(
+        id="job_id",
+        status_code=StatusCode.CREATED,
+        status_code_updated_at=int(timestamp * 1e9),
+        job_request_id="request_id",
+        workspace="workspace",
+        action="action name",
+        run_command="cohortextractor:latest cmd opt",
+        commit="commit",
+        created_at=timestamp,
+    )
+    initialise_trace(job)
+
+    states = [
+        StatusCode.WAITING_ON_DEPENDENCIES,
+        StatusCode.PREPARING,
+        StatusCode.PREPARED,
+        StatusCode.EXECUTING,
+        StatusCode.EXECUTED,
+        StatusCode.FINALIZING,
+        StatusCode.FINALIZED,
+    ]
+
+    for state in states:
+        time.sleep(1.1)
+        set_code(job, state, "test")
+
+    time.sleep(1.1)
+    set_code(job, StatusCode.SUCCEEDED, "success")

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -9,7 +9,7 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 
 from jobrunner import config
 from jobrunner.lib import database
-from jobrunner.models import Job, SavedJobRequest, StatusCode
+from jobrunner.models import Job, SavedJobRequest, State, StatusCode
 
 
 logger = logging.getLogger(__name__)
@@ -203,6 +203,7 @@ if __name__ == "__main__":
     timestamp = int(time.time())
     job = Job(
         id="job_id",
+        state=State.PENDING,
         status_code=StatusCode.CREATED,
         status_code_updated_at=int(timestamp * 1e9),
         job_request_id="request_id",

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -88,7 +88,7 @@ def initialise_trace(job):
     We store the serialised trace context in the db, so we can reuse it for
     later spans.
 
-    We create a root span, which is a requirement in OTEl. For this reason we
+    We create a root span, which is a requirement in OTel. For this reason we
     send it out straight away, which means its duration is very short.
     """
     assert not job.trace_context, "this job already has a trace-context"
@@ -101,10 +101,10 @@ def initialise_trace(job):
     tracer = trace.get_tracer("jobs")
     attrs = trace_attributes(job)
 
-    # convert created_at to ns
+    # convert created_at to nanoseconds
     start_time = int(job.created_at * 1e9)
 
-    # TraceContextTextMapPropagator only works with the current span, sadlmy
+    # TraceContextTextMapPropagator only works with the current span, sadly
     with tracer.start_as_current_span("job", start_time=start_time) as root:
         root.set_attributes(attrs)
         # we serialise the entire trace context, as it may grow extra fields
@@ -133,7 +133,7 @@ def finish_current_state(job, timestamp_ns, final=False, error=None, **attrs):
 
         if final:
             # record a full span for the entire run
-            # trace vanity: have the job start 1us before the actualy job, so
+            # trace vanity: have the job start 1us before the actual job, so
             # it shows up first in the trace
             job_start_time = int(job.created_at * 1e9) - 1000
             record_job_span(job, "RUN", job_start_time, timestamp_ns, error, **attrs)
@@ -148,7 +148,7 @@ def start_new_state(job, timestamp_ns, error=None, **attrs):
     try:
         name = f"ENTER {job.status_code.name}"
         start_time = timestamp_ns
-        # fix the time for these synthenic marker events at one second
+        # fix the time for these synthetic marker events at one second
         end_time = int(start_time + 1e9)
         if attrs is None:
             attrs = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v0.2.1",
   "ruamel.yaml",
   "requests",
+  "opentelemetry-exporter-otlp-proto-http",
 ]
 dynamic = ["version"]
 

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -4,18 +4,42 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements.prod.txt pyproject.toml
 #
+backoff==2.1.2
+    # via opentelemetry-exporter-otlp-proto-http
 certifi==2020.11.8
     # via requests
 chardet==3.0.4
     # via requests
+deprecated==1.2.13
+    # via opentelemetry-api
+googleapis-common-protos==1.56.4
+    # via opentelemetry-exporter-otlp-proto-http
 idna==2.10
     # via requests
 opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v0.2.1
     # via opensafely-jobrunner (pyproject.toml)
+opentelemetry-api==1.12.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http==1.12.0
+    # via opensafely-jobrunner (pyproject.toml)
+opentelemetry-proto==1.12.0
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.12.0
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.33b0
+    # via opentelemetry-sdk
+protobuf==3.20.2
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 pydantic==1.9.0
     # via opensafely-pipeline
 requests==2.25.0
-    # via opensafely-jobrunner (pyproject.toml)
+    # via
+    #   opensafely-jobrunner (pyproject.toml)
+    #   opentelemetry-exporter-otlp-proto-http
 ruamel-yaml==0.16.12
     # via
     #   opensafely-jobrunner (pyproject.toml)
@@ -23,6 +47,16 @@ ruamel-yaml==0.16.12
 ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
 typing-extensions==4.1.1
-    # via pydantic
+    # via
+    #   opentelemetry-sdk
+    #   pydantic
 urllib3==1.26.5
     # via requests
+wrapt==1.14.1
+    # via deprecated
+
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==65.3.0
+    # via
+    #   opentelemetry-api
+    #   opentelemetry-sdk

--- a/tests/test_create_or_update_jobs.py
+++ b/tests/test_create_or_update_jobs.py
@@ -21,7 +21,7 @@ def disable_github_org_checking(monkeypatch):
 
 
 # Basic smoketest to test the full execution path
-def test_create_or_update_jobs(tmp_work_dir):
+def test_create_or_update_jobs(tmp_work_dir, db):
     repo_url = str(Path(__file__).parent.resolve() / "fixtures/git-repo")
     job_request = JobRequest(
         id="123",
@@ -33,7 +33,11 @@ def test_create_or_update_jobs(tmp_work_dir):
         cancelled_actions=[],
         workspace="1",
         database_name="dummy",
-        original={},
+        original=dict(
+            created_by="user",
+            project="project",
+            orgs=["org1", "org2"],
+        ),
     )
     create_or_update_jobs(job_request)
     old_job = find_one(Job)
@@ -70,7 +74,11 @@ def test_create_or_update_jobs_with_git_error(tmp_work_dir):
         cancelled_actions=[],
         workspace="1",
         database_name="dummy",
-        original={},
+        original=dict(
+            created_by="user",
+            project="project",
+            orgs=["org1", "org2"],
+        ),
     )
     create_or_update_jobs(job_request)
     j = find_one(Job)
@@ -234,7 +242,11 @@ def test_validate_job_request(params, exc_msg, monkeypatch):
         cancelled_actions=[],
         workspace="1",
         database_name="full",  # note db from from job-server is 'full'
-        original={},
+        original=dict(
+            created_by="user",
+            project="project",
+            orgs=["org1", "org2"],
+        ),
     )
     kwargs.update(params)
     job_request = JobRequest(**kwargs)
@@ -258,7 +270,11 @@ def make_job_request(action=None, actions=None, **kwargs):
         database_name="full",
         requested_actions=actions,
         cancelled_actions=[],
-        original={},
+        original=dict(
+            created_by="user",
+            project="project",
+            orgs=["org1", "org2"],
+        ),
     )
     for key, value in kwargs.items():
         setattr(job_request, key, value)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -70,6 +70,9 @@ def test_integration(
             "db": "dummy",
         },
         "sha": test_repo.commit,
+        "created_by": "user",
+        "project": "project",
+        "orgs": ["org"],
     }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",
@@ -117,6 +120,9 @@ def test_integration(
             "db": "dummy",
         },
         "sha": test_repo.commit,
+        "created_by": "user",
+        "project": "project",
+        "orgs": ["org"],
     }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",
@@ -222,6 +228,9 @@ def test_integration_with_databuilder(
             "db": "dummy",
         },
         "sha": test_repo.commit,
+        "created_by": "user",
+        "project": "project",
+        "orgs": ["org"],
     }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",
@@ -267,6 +276,9 @@ def test_integration_with_databuilder(
             "db": "dummy",
         },
         "sha": test_repo.commit,
+        "created_by": "user",
+        "project": "project",
+        "orgs": ["org"],
     }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -19,6 +19,9 @@ def test_job_request_from_remote_format():
         "cancelled_actions": ["analyse"],
         "force_run_dependencies": True,
         "sha": "abcdef",
+        "created_by": "user",
+        "project": "project",
+        "orgs": ["org"],
     }
     expected = JobRequest(
         id="123",

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -71,20 +71,20 @@ def test_finish_current_state(db):
     assert spans[-1].attributes["job"] == job.id
 
 
-def test_finish_current_state_final(db):
+def test_record_final_state(db):
     job = job_factory(status_code=models.StatusCode.SUCCEEDED)
     ts = int(time.time() * 1e9)
-    tracing.finish_current_state(job, ts, final=True)
+    tracing.record_final_state(job, ts)
 
     spans = get_trace()
     assert spans[-2].name == "SUCCEEDED"
     assert spans[-1].name == "RUN"
 
 
-def test_finish_current_state_final_error(db):
+def test_record_final_state_error(db):
     job = job_factory(status_code=models.StatusCode.INTERNAL_ERROR)
     ts = int(time.time() * 1e9)
-    tracing.finish_current_state(job, ts, final=True, error=Exception("error"))
+    tracing.record_final_state(job, ts, error=Exception("error"))
 
     spans = get_trace()
     assert spans[-2].name == "INTERNAL_ERROR"

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,112 @@
+import time
+
+from jobrunner import models, tracing
+from tests.conftest import get_trace
+from tests.factories import job_factory, job_request_factory
+
+
+def test_trace_attributes(db):
+
+    jr = job_request_factory(
+        original=dict(
+            created_by="testuser",
+            project="project",
+            orgs=["org1", "org2"],
+        )
+    )
+    job = job_factory(
+        jr,
+        workspace="workspace",
+        action="action",
+        commit="commit",
+        action_repo_url="action_repo",
+        action_commit="commit",
+        status_message="message",
+    )
+
+    attrs = tracing.trace_attributes(job)
+
+    assert attrs == dict(
+        backend="expectations",
+        job=job.id,
+        job_request=job.job_request_id,
+        workspace="workspace",
+        action="action",
+        commit="commit",
+        run_command=job.run_command,
+        user="testuser",
+        project="project",
+        orgs="org1,org2",
+        state="PENDING",
+        message="message",
+        reusable_action="action_repo:commit",
+    )
+
+
+def test_initialise_trace(db):
+    job = job_factory()
+    # clear factories default context
+    job.trace_context = None
+
+    tracing.initialise_trace(job)
+
+    assert "traceparent" in job.trace_context
+
+    spans = get_trace()
+    assert spans[-1].name == "ENTER CREATED"
+
+
+def test_finish_current_state(db):
+    job = job_factory()
+
+    ts = int(time.time() * 1e9)
+
+    tracing.finish_current_state(job, ts, extra="extra")
+
+    spans = get_trace()
+    assert spans[-1].name == "CREATED"
+    assert spans[-1].start_time == int(job.created_at * 1e9)
+    assert spans[-1].end_time == ts
+    assert spans[-1].attributes["extra"] == "extra"
+    assert spans[-1].attributes["job"] == job.id
+
+
+def test_finish_current_state_final(db):
+    job = job_factory(status_code=models.StatusCode.SUCCEEDED)
+    ts = int(time.time() * 1e9)
+    tracing.finish_current_state(job, ts, final=True)
+
+    spans = get_trace()
+    assert spans[-2].name == "SUCCEEDED"
+    assert spans[-1].name == "RUN"
+
+
+def test_finish_current_state_final_error(db):
+    job = job_factory(status_code=models.StatusCode.INTERNAL_ERROR)
+    ts = int(time.time() * 1e9)
+    tracing.finish_current_state(job, ts, final=True, error=Exception("error"))
+
+    spans = get_trace()
+    assert spans[-2].name == "INTERNAL_ERROR"
+    assert spans[-2].status.status_code.name == "ERROR"
+    assert spans[-2].events[0].name == "exception"
+    assert spans[-2].events[0].attributes["exception.message"] == "error"
+
+    assert spans[-1].name == "RUN"
+    assert spans[-1].status.status_code.name == "ERROR"
+    assert spans[-1].events[0].name == "exception"
+    assert spans[-1].events[0].attributes["exception.message"] == "error"
+
+
+def test_start_new_state(db):
+    job = job_factory()
+    ts = int(time.time() * 1e9)
+
+    job.status_code = models.StatusCode.PREPARING
+
+    tracing.start_new_state(job, ts)
+
+    spans = get_trace()
+    assert spans[-1].name == "ENTER PREPARING"
+    assert spans[-1].attributes["enter_state"] is True
+    assert spans[-1].end_time == int(ts + 1e9)


### PR DESCRIPTION
This adds opentelemetry tracing to running jobs.

A new jobrunner/tracing.py module handles most of the work, and we use
it to trace state changes between the fine grained StatusCode states
added previously.  We store as many attributes on each span as possible.

This includes a migration to add somewhere to store a job's trace
context and last changed timestamp.

We also emit "marker spans" that indicate that a the job has entered
a certain state, but not yet exited it yet. This is intedended to be
useful for ongoing jobs.

Also, we add a final "RUN" span once the job has completed that serves
as coarser grained span to use for graphing whole job metics.
