### PR TITLE
fix: handle uninitialized traces gracefully

### DIFF
--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -168,7 +168,11 @@ def start_new_state(job, timestamp_ns, error=None, **attrs):
 
 def record_job_span(job, name, start_time, end_time, error, **attrs):
     """Record a span for a job."""
-    assert job.trace_context is not None, "job missing trace_context"
+    # handle migration gracefully
+    if not job.trace_context:
+        logger.info(f"not tracing job {job.id} as not initialised")
+        return
+
     ctx = TraceContextTextMapPropagator().extract(carrier=job.trace_context)
     tracer = trace.get_tracer("jobs")
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -110,3 +110,13 @@ def test_start_new_state(db):
     assert spans[-1].name == "ENTER PREPARING"
     assert spans[-1].attributes["enter_state"] is True
     assert spans[-1].end_time == int(ts + 1e9)
+
+
+def test_record_job_span_skips_uninitialized_job(db):
+    job = job_factory()
+    ts = int(time.time() * 1e9)
+    job.trace_context = None
+
+    tracing.record_job_span(job, "name", ts, ts + 10000, error=None)
+
+    assert len(get_trace()) == 0


### PR DESCRIPTION
When we switch over to the new code, we'll encounter jobs that began
under the old code, so just ignore them rather than blowing up.
