### PR TITLE
fix: proper tracing for job request internal errors

### DIFF
--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -241,6 +241,7 @@ def recursively_build_jobs(jobs_by_action, job_request, pipeline_config, action)
         updated_at=int(timestamp),
     )
     tracing.initialise_trace(job)
+    tracing.start_new_state(job, job.status_code_updated_at)
 
     # Add it to the dictionary of scheduled jobs
     jobs_by_action[action] = job
@@ -347,6 +348,7 @@ def create_failed_job(job_request, exception):
         completed_at=int(now),
     )
     tracing.initialise_trace(job)
+    tracing.record_final_state(job, job.status_code_updated_at)
     insert_into_database(job_request, [job])
 
 

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -111,9 +111,6 @@ def initialise_trace(job):
         # (e.g.  baggage) over time
         TraceContextTextMapPropagator().inject(job.trace_context)
 
-    # trace the initial job state trace
-    start_new_state(job, job.status_code_updated_at)
-
 
 def _traceable(job):
     """Is a job traceable?

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,7 +16,7 @@ from tests.conftest import test_exporter
 JOB_REQUEST_DEFAULTS = {
     "repo_url": "repo",
     "commit": "commit",
-    "requested_actions": [],
+    "requested_actions": ["action"],
     "cancelled_actions": [],
     "workspace": "workspace",
     "database_name": "full",
@@ -41,13 +41,17 @@ JOB_DEFAULTS = {
 }
 
 
-def job_request_factory(**kwargs):
+def job_request_factory_raw(**kwargs):
     if "id" not in kwargs:
         kwargs["id"] = base64.b32encode(secrets.token_bytes(10)).decode("ascii").lower()
 
     values = deepcopy(JOB_REQUEST_DEFAULTS)
     values.update(kwargs)
-    job_request = JobRequest(**values)
+    return JobRequest(**values)
+
+
+def job_request_factory(**kwargs):
+    job_request = job_request_factory_raw(**kwargs)
     insert(SavedJobRequest(id=job_request.id, original=job_request.original))
     return job_request
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -53,7 +53,8 @@ def test_initialise_trace(db):
     assert "traceparent" in job.trace_context
 
     spans = get_trace()
-    assert spans[-1].name == "ENTER CREATED"
+    assert len(spans) == 1
+    assert spans[0].name == "job"
 
 
 def test_finish_current_state(db):


### PR DESCRIPTION
Sometimes job requests can fail before they even get to creating jobs.

The initial tracing code didn't handle this properly, and this change
fixes that so that it such errors are traced properly
