### PR TITLE
fix: update prepare_for_reboot to handle tracing

### DIFF
--- a/jobrunner/cli/prepare_for_reboot.py
+++ b/jobrunner/cli/prepare_for_reboot.py
@@ -4,32 +4,38 @@ automatically re-run after a reboot.
 """
 import argparse
 
-from jobrunner.executors.local import container_name, docker
-from jobrunner.executors.volumes import docker_volume_name as volume_name
-from jobrunner.lib.database import find_where, update_where
-from jobrunner.models import Job, State
+from jobrunner.executors.local import container_name, docker, volume_api
+from jobrunner.lib.database import find_where
+from jobrunner.models import Job, State, StatusCode
+from jobrunner.run import set_state
 
 
-def main():
-    print(
-        "== DANGER ZONE ==\n"
-        "\n"
-        "This will kill all running jobs and reset them to the PENDING state, ready\n"
-        "to be restarted following a reboot.\n"
-        "\n"
-        "It should only be run when the job-runner service has been stopped."
-        "\n"
-    )
-    confirm = input("Are you sure you want to continue? (y/N)")
-    assert confirm.strip().lower() == "y"
-    # Reset all running jobs to pending
-    update_where(Job, {"state": State.PENDING, "started_at": None}, state=State.RUNNING)
-    # Make sure all containers and volumes are removed ready to freshly restart the jobs
-    # after the reboot
-    for job in find_where(Job, state=State.PENDING):
+def main(pause=True):
+    if pause:
+        print(
+            "== DANGER ZONE ==\n"
+            "\n"
+            "This will kill all running jobs and reset them to the PENDING state, ready\n"
+            "to be restarted following a reboot.\n"
+            "\n"
+            "It should only be run when the job-runner service has been stopped."
+            "\n"
+        )
+        confirm = input("Are you sure you want to continue? (y/N)")
+        assert confirm.strip().lower() == "y"
+
+    for job in find_where(Job, state=State.RUNNING):
+        print(f"reseting job {job.id} to PENDING")
+        set_state(
+            job,
+            State.PENDING,
+            StatusCode.WAITING_ON_REBOOT,
+            "Job restarted - waiting for server to reboot",
+        )
+        # these are idempotent
         docker.kill(container_name(job))
         docker.delete_container(container_name(job))
-        docker.delete_volume(volume_name(job))
+        volume_api.delete_volume(job)
 
 
 def run():

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -46,6 +46,8 @@ class StatusCode(Enum):
     WAITING_ON_DEPENDENCIES = "waiting_on_dependencies"
     # waiting on available resources to run the job
     WAITING_ON_WORKERS = "waiting_on_workers"
+    # reset for reboot
+    WAITING_ON_REBOOT = "waiting_on_reboot"
 
     # RUNNING states, these mirror ExecutorState, and are the normal happy path
     PREPARING = "preparing"

--- a/tests/cli/test_prepare_for_reboot.py
+++ b/tests/cli/test_prepare_for_reboot.py
@@ -1,0 +1,41 @@
+from unittest import mock
+
+from jobrunner.cli import prepare_for_reboot
+from jobrunner.executors.local import container_name, volume_api
+from jobrunner.lib import database, docker
+from jobrunner.models import Job, State, StatusCode
+from tests.conftest import get_trace
+from tests.factories import job_factory
+
+
+def test_prepare_for_reboot(db, monkeypatch):
+
+    j1 = job_factory(state=State.RUNNING, status_code=StatusCode.EXECUTING)
+    j2 = job_factory(
+        state=State.PENDING, status_code=StatusCode.WAITING_ON_DEPENDENCIES
+    )
+
+    mocker = mock.MagicMock(spec=docker)
+    mockume_api = mock.MagicMock(spec=volume_api)
+
+    monkeypatch.setattr(prepare_for_reboot, "docker", mocker)
+    monkeypatch.setattr(prepare_for_reboot, "volume_api", mockume_api)
+
+    prepare_for_reboot.main(pause=False)
+
+    job1 = database.find_one(Job, id=j1.id)
+    assert job1.state == State.PENDING
+    assert job1.status_code == StatusCode.WAITING_ON_REBOOT
+    assert "restarted" in job1.status_message
+
+    job2 = database.find_one(Job, id=j2.id)
+    assert job2.state == State.PENDING
+    assert job2.status_code == StatusCode.WAITING_ON_DEPENDENCIES
+
+    mocker.kill.assert_called_once_with(container_name(job1))
+    mocker.delete_container.assert_called_once_with(container_name(job1))
+    mockume_api.delete_volume.assert_called_once_with(job1)
+
+    spans = get_trace()
+    assert spans[-2].name == "EXECUTING"
+    assert spans[-1].name == "ENTER WAITING_ON_REBOOT"


### PR DESCRIPTION
 - a new status code WAITING_ON_REBOOT
 - properly using the volume_api to remove volmes rather than assuming
   docker volumes.
 - add a test for prepare_to_reboot to make sure it works going forward
