### PR TITLE
fix: fix span error handling for failed job

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -354,6 +354,7 @@ def test_handle_job_finalized_failed_exit_code(
     assert completed_span.attributes["unmatched_patterns"] == 0
     assert completed_span.attributes["unmatched_outputs"] == 0
     assert completed_span.attributes["image_id"] == "image_id"
+    assert completed_span.status.status_code == trace.StatusCode.ERROR
     assert spans[-1].name == "RUN"
 
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,5 +1,7 @@
 import time
 
+from opentelemetry import trace
+
 from jobrunner import models, tracing
 from tests.conftest import get_trace
 from tests.factories import job_factory, job_request_factory
@@ -92,11 +94,13 @@ def test_record_final_state_error(db):
     assert spans[-2].status.status_code.name == "ERROR"
     assert spans[-2].events[0].name == "exception"
     assert spans[-2].events[0].attributes["exception.message"] == "error"
+    assert spans[-2].status.status_code == trace.StatusCode.ERROR
 
     assert spans[-1].name == "RUN"
     assert spans[-1].status.status_code.name == "ERROR"
     assert spans[-1].events[0].name == "exception"
     assert spans[-1].events[0].attributes["exception.message"] == "error"
+    assert spans[-1].status.status_code == trace.StatusCode.ERROR
 
 
 def test_start_new_state(db):


### PR DESCRIPTION
Previously, spans for a NONZERO_EXIT had not been properly marked as an
error in the span due to this bug.
