### PR TITLE
fix: optimise loop for synchronous prepare/finalize

### DIFF
--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -87,6 +87,8 @@ def workspace_is_archived(workspace):
 class LocalDockerAPI(ExecutorAPI):
     """ExecutorAPI implementation using local docker service."""
 
+    synchronous_transitions = [ExecutorState.PREPARING, ExecutorState.FINALIZING]
+
     def prepare(self, job):
         current = self.get_status(job)
         if current.state != ExecutorState.UNKNOWN:

--- a/jobrunner/executors/logging.py
+++ b/jobrunner/executors/logging.py
@@ -32,6 +32,10 @@ class LoggingExecutor(ExecutorAPI):
     def delete_files(self, workspace: str, privacy: Privacy, paths: [str]) -> List[str]:
         return self._wrapped.delete_files(workspace, privacy, paths)
 
+    @property
+    def synchronous_transitions(self):
+        return getattr(self._wrapped, "synchronous_transitions", [])
+
     def _add_logging(self, method: Callable[[JobDefinition], JobStatus]):
         def wrapper(job: JobDefinition) -> JobStatus:
             status = method(job)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -133,6 +133,13 @@ class StubExecutorAPI:
 
     def set_job_state(self, definition, state, message="message"):
         """Directly set a job state."""
+        # handle the synchronous state meaning the state has completed
+        synchronous = getattr(self, "synchronous_transitions", [])
+        if state in synchronous:
+            if state == ExecutorState.PREPARING:
+                state = ExecutorState.PREPARED
+            if state == ExecutorState.FINALIZING:
+                state = ExecutorState.FINALIZED
         self.state[definition.id] = JobStatus(state, message)
 
     def set_job_transition(self, definition, state, message="executor message"):


### PR DESCRIPTION
The job loop assumes all operations are async. But for the local
executor this isn't true - both `prepare()` and `finalize()` are
synchronous.

This leads head-of-line blocking when a new job request arrives, in that
all jobs that can run are synchronously prepared in one pass of the
loop. This blocks those jobs from executing until the loop goes round
again, which can be a long time (e.g 30+mins), as the file copying for
n jobs can take a while.

This change allows an executor to declare it has certain transitions
that are synchronous, and if the loop detects this, it will immeadiately
run the the handler function again to move it to the next state.

For the local executor, we declare that both PREPARING and FINALIZING
are synchronous.
