### PR TITLE
fix: handles some bad span attributes and logging

### DIFF
--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -228,6 +228,7 @@ def recursively_build_jobs(jobs_by_action, job_request, pipeline_config, action)
         status_code=StatusCode.CREATED,
         # time in nanoseconds
         status_code_updated_at=int(timestamp * 1e9),
+        status_message="Created",
         repo_url=job_request.repo_url,
         commit=job_request.commit,
         workspace=job_request.workspace,
@@ -335,13 +336,13 @@ def create_failed_job(job_request, exception):
         job_request_id=job_request.id,
         state=state,
         status_code=code,
+        status_message=status_message,
         # time in nanoseconds
         status_code_updated_at=int(now * 1e9),
         repo_url=job_request.repo_url,
         commit=job_request.commit,
         workspace=job_request.workspace,
         action=action,
-        status_message=status_message,
         created_at=int(now),
         started_at=int(now),
         updated_at=int(now),

--- a/jobrunner/lib/log_utils.py
+++ b/jobrunner/lib/log_utils.py
@@ -62,6 +62,10 @@ def configure_logging(
     if debug_log_file:
         logging.getLogger(__name__).info(f"Writing DEBUG logs to '{debug_log_file}'")
 
+    # quieten the trace logs if running locally
+    trace_log_level = os.environ.get("TRACE_LOG_LEVEL", "ERROR")
+    logging.getLogger("jobrunner.tracing").setLevel(trace_log_level)
+
     # We attach a custom handler for uncaught exceptions to display error
     # output from failed subprocesses
     sys.excepthook = show_subprocess_stderr

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -455,7 +455,7 @@ def get_states_of_awaited_jobs(job):
     return states
 
 
-def mark_job_as_failed(job, code, message=None, exc=None, attrs=None):
+def mark_job_as_failed(job, code, message=None, exc=None, **attrs):
     if message is None:
         message = f"{type(exc).__name__}: {exc}"
 

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -234,12 +234,12 @@ def set_span_metadata(span, job, error=None, **attrs):
     clean_attrs = {}
     for k, v in attributes.items():
         if not isinstance(v, OTEL_ATTR_TYPES):
-            # coerce to string so we preserve some information
-            v = str(v)
             # log to help us notice this
-            logger.warn(
+            logger.info(
                 f"Trace span {span.name} attribute {k} was set invalid type: {v}, type {type(v)}"
             )
+            # coerce to string so we preserve some information
+            v = str(v)
         clean_attrs[k] = v
 
     span.set_attributes(clean_attrs)
@@ -270,7 +270,6 @@ def trace_attributes(job):
         job_request=job.job_request_id,
         workspace=job.workspace,
         action=job.action,
-        commit=job.commit,
         run_command=job.run_command,
         user=job._job_request.get("created_by", "unknown"),
         project=job._job_request.get("project", "unknown"),
@@ -278,6 +277,10 @@ def trace_attributes(job):
         state=job.state.name,
         message=job.status_message,
     )
+
+    # local_run jobs don't have a commit
+    if job.commit:
+        attrs["commit"] = job.commit
 
     if job.action_repo_url:
         attrs["reusable_action"] = job.action_repo_url

--- a/tests/test_create_or_update_jobs.py
+++ b/tests/test_create_or_update_jobs.py
@@ -57,7 +57,7 @@ def test_create_or_update_jobs(tmp_work_dir, db):
         " --output-dir=."
     )
     assert old_job.output_spec == {"highly_sensitive": {"cohort": "input.csv"}}
-    assert old_job.status_message is None
+    assert old_job.status_message == "Created"
     # Check no new jobs created from same JobRequest
     create_or_update_jobs(job_request)
     new_job = find_one(Job)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -45,6 +45,41 @@ def test_trace_attributes(db):
     )
 
 
+def test_trace_attributes_missing(db):
+
+    jr = job_request_factory(
+        original=dict(
+            created_by="testuser",
+            project="project",
+            orgs=["org1", "org2"],
+        )
+    )
+    job = job_factory(
+        jr,
+        workspace="workspace",
+        action="action",
+        status_message="message",
+        # no commit
+        # no reusable action
+    )
+
+    attrs = tracing.trace_attributes(job)
+
+    assert attrs == dict(
+        backend="expectations",
+        job=job.id,
+        job_request=job.job_request_id,
+        workspace="workspace",
+        action="action",
+        run_command=job.run_command,
+        user="testuser",
+        project="project",
+        orgs="org1,org2",
+        state="PENDING",
+        message="message",
+    )
+
+
 def test_initialise_trace(db):
     job = job_factory()
     # clear factories default context


### PR DESCRIPTION
The previous commit added some span attribute clean up, and logged when
there were invalid attributes.

This change used that logging to find and fixa few issues:
 - job.commit is None in local_run, so only add if its set
 - job.message is None initially - change it to always be set.
 - the `mark_job_as_failed()` function had the wrong signature for
 attrs, and was adding a `attrs=None` attribute.

 Additionally, lowered the tracing logging level, and quitened it for
 local_run, as we don't want to bother the user with non-fatal tracing
 errors.
