### PR TITLE
fix: ensure mark_job_as_failed always marks trace as error

### DIFF
--- a/jobrunner/cli/kill_job.py
+++ b/jobrunner/cli/kill_job.py
@@ -19,7 +19,6 @@ def main(partial_job_ids, cleanup=False):
                 job,
                 StatusCode.KILLED_BY_ADMIN,
                 "An OpenSAFELY admin manually killed this job",
-                error=True,
             )
         # All these docker commands are idempotent
         docker.kill(container_name(job))

--- a/jobrunner/executors/logging.py
+++ b/jobrunner/executors/logging.py
@@ -17,7 +17,7 @@ LOGGER_NAME = "executor"
 class LoggingExecutor(ExecutorAPI):
     def __init__(self, wrapped: ExecutorAPI):
         self._logger = logging.getLogger(LOGGER_NAME)
-        self._state_cache = LRUDict(100)  # Maps job ids to states
+        self._state_cache = LRUDict(1024)  # Maps job ids to states
         self._wrapped = wrapped
         self._add_logging(self._wrapped.get_status)
         self._add_logging(self._wrapped.prepare)

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -66,7 +66,7 @@ class StatusCode(Enum):
     CANCELLED_BY_USER = "cancelled_by_user"
     UNMATCHED_PATTERNS = "unmatched_patterns"
     INTERNAL_ERROR = "internal_error"
-    KILLED_BY_ADMIN = "Killed by admin"
+    KILLED_BY_ADMIN = "killed_by_admin"
 
 
 # used for tracing to know if a state is final or not
@@ -77,6 +77,7 @@ FINAL_STATUS_CODES = [
     StatusCode.CANCELLED_BY_USER,
     StatusCode.UNMATCHED_PATTERNS,
     StatusCode.INTERNAL_ERROR,
+    StatusCode.KILLED_BY_ADMIN,
 ]
 
 

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -222,7 +222,6 @@ def handle_job(job, api, mode=None, paused=None):
                 job,
                 StatusCode.DEPENDENCY_FAILED,
                 "Not starting as dependency failed",
-                error=True,
             )
             return
 
@@ -456,9 +455,9 @@ def get_states_of_awaited_jobs(job):
     return states
 
 
-def mark_job_as_failed(job, code, message=None, error=None, **attrs):
-    if message is None:
-        message = str(error)
+def mark_job_as_failed(job, code, message, error=None, **attrs):
+    if error is None:
+        error = True
 
     set_state(job, State.FAILED, code, message, error=error, attrs=attrs)
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -671,3 +671,16 @@ def test_job_definition_limits(db):
     definition = run.job_to_job_definition(job)
     assert definition.cpu_count == 2
     assert definition.memory_limit == "4G"
+
+
+def test_mark_job_as_failed_adds_error(db):
+    job = job_factory()
+    run.mark_job_as_failed(job, StatusCode.INTERNAL_ERROR, "error")
+
+    # tracing
+    spans = get_trace()
+    assert spans[-3].name == "CREATED"
+    assert spans[-2].name == "INTERNAL_ERROR"
+    assert spans[-2].status.status_code == trace.StatusCode.ERROR
+    assert spans[-1].name == "JOB"
+    assert spans[-1].status.status_code == trace.StatusCode.ERROR


### PR DESCRIPTION
Previously, the user had to pass error=True (or error=exc) to get this.

To fix this, we make two changes

a) mark_job_as_failed require an explicit 'message'.
b) if `error` isn't explicity passed in, mark it as error anyway

Also, we fix up KILLED_BY_ADMIN

Fixes #497
