### PR TITLE
Remove unnecessary black config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .env
 .hypothesis/
 .idea/
+.pytest-cache/
 .python-version
 __pycache__
 app.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,22 +36,6 @@ Home = "https://opensafely.org"
 Documentation = "https://docs.opensafely.org"
 Source = "https://github.com/opensafely-core/job-runner"
 
-[tool.black]
-exclude = '''
-(
-  /(
-      \.git         # exclude a few common directories
-    | \.direnv
-    | \.github
-    | \.pytest_cache
-    | \.venv
-    | htmlcov
-    | venv
-    | lib           # job-runner-dependencies checkout
-  )/
-)
-'''
-
 [tool.coverage.run]
 branch = true
 omit = [".direnv/*", ".venv/*"]

--- a/tests/lib/test_path_utils.py
+++ b/tests/lib/test_path_utils.py
@@ -5,13 +5,16 @@ import pytest
 from jobrunner.lib import path_utils
 
 
-@pytest.mark.parametrize("path,expected", [
-    (r"foo/bar", "foo/bar"),
-    (r"foo\bar", "foo/bar"),
-    (pathlib.PurePosixPath("foo/bar"), "foo/bar"),
-    (pathlib.PurePosixPath(r"foo\bar"), r"foo\bar"),
-    (pathlib.PureWindowsPath("foo/bar"), "foo/bar"),
-    (pathlib.PureWindowsPath(r"foo\bar"), "foo/bar"),
-])
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        (r"foo/bar", "foo/bar"),
+        (r"foo\bar", "foo/bar"),
+        (pathlib.PurePosixPath("foo/bar"), "foo/bar"),
+        (pathlib.PurePosixPath(r"foo\bar"), r"foo\bar"),
+        (pathlib.PureWindowsPath("foo/bar"), "foo/bar"),
+        (pathlib.PureWindowsPath(r"foo\bar"), "foo/bar"),
+    ],
+)
 def test_ensure_unix_path(path, expected):
     assert path_utils.ensure_unix_path(path) == expected


### PR DESCRIPTION
By default (according to --help as of v22.8.0) black is already ignoring this list of directories:

/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|venv|\.svn|_build|buck-out|build|dist|__pypackages__)/

We were using --exclude which overwrote this list.  Black supports --extend-exclude which builds upon this list and also makes use of the repos .gitignore [1].  Since we we want both git and black to ignore the files for this repo can drop all black config here.

1: https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html#gitignore

Refs: opensafely-core/repo-template#85