### PR TITLE
Set test coverage target

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -85,4 +85,6 @@ services:
         service: dev
     container_name: job-runner-test
     # override command
-    command: /opt/venv/bin/pytest
+    command: >
+      bash -c "/opt/venv/bin/coverage run --module pytest
+      && (/opt/venv/bin/coverage report || /opt/venv/bin/coverage html)"

--- a/justfile
+++ b/justfile
@@ -85,7 +85,8 @@ upgrade env package="": virtualenv
 
 # Run the tests
 test *ARGS: devenv
-    $BIN/python -m pytest {{ ARGS }}
+    $BIN/coverage run --module pytest {{ ARGS }}
+    $BIN/coverage report || $BIN/coverage html
 
 test-fast *ARGS: devenv
     $BIN/python -m pytest tests -m "not slow_test" {{ ARGS }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,13 +54,16 @@ exclude = '''
 
 [tool.coverage.run]
 branch = true
-omit = [".direnv/*", ".venv/*"]
+dynamic_context = "test_function"
 source = ["jobrunner"]
 
 [tool.coverage.report]
+fail_under = 78
+show_missing = true
 skip_covered = true
 
 [tool.coverage.html]
+show_contexts = true
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This will cause the tests to fail if the code coverage is under this percentage. It's initially been set to match the existing coverage amount, although the hope is that this will increase over time.

Coverage is only run when running `just test` or `just docker/test`. This is because other `just test*` options only run a subset of the tests, so we can't get a useful result from the coverage tool. However, since `just docker/test` is run in CI, it will always run for every code change.