### PR TITLE
fix: fix some trace error handling

### DIFF
--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -324,7 +324,7 @@ def save_results(job, definition, results):
     # save job outputs
     job.outputs = results.outputs
 
-    error = None
+    message = None
 
     if results.exit_code != 0:
         state = State.FAILED
@@ -336,7 +336,6 @@ def save_results(job, definition, results):
             error_msg = config.DATABASE_EXIT_CODES.get(results.exit_code)
             if error_msg:
                 message += f": {error_msg}"
-        error = message
 
     elif results.unmatched_patterns:
         job.unmatched_outputs = results.unmatched_outputs
@@ -348,7 +347,6 @@ def save_results(job, definition, results):
         message = "No outputs found matching patterns:\n - {}".format(
             "\n - ".join(results.unmatched_patterns)
         )
-        error = message
 
     else:
         state = State.SUCCEEDED
@@ -363,7 +361,7 @@ def save_results(job, definition, results):
         unmatched_outputs=len(results.unmatched_outputs),
     )
 
-    set_state(job, state, code, message, error=error, **trace_attrs)
+    set_state(job, state, code, message, error=state == State.FAILED, **trace_attrs)
 
 
 def get_obsolete_files(definition, outputs):


### PR DESCRIPTION
For jobs that have completed but failed in some way, and also for jobs
that failed before they've even started, make them as errors in trace
data and ensure theres exception data
