### PR TITLE
Fix: actually apply the cpu/memory limits for local run

### DIFF
--- a/jobrunner/cli/local_run.py
+++ b/jobrunner/cli/local_run.py
@@ -189,6 +189,9 @@ def main(
             clean_up_docker_objects=(not debug),
             log_format=log_format,
             format_output_for_github=format_output_for_github,
+            concurrency=concurrency,
+            memory=memory,
+            cpu=cpu,
         )
     except KeyboardInterrupt:
         print("\nKilled by user")


### PR DESCRIPTION
Sadly, this feature lacked a functional test, and one function in the
chain did not pass on the user supplied values.

This change adds a fully docker functional test, and checks the user
supplied cpu/memory values were applied to the docker container.
