### PR TITLE
fix: retry on docker inpsect timeouts

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -96,6 +96,7 @@ if PRESTO_TLS_CERT_PATH:
 
 MAX_WORKERS = int(os.environ.get("MAX_WORKERS") or max(cpu_count() - 1, 1))
 MAX_DB_WORKERS = int(os.environ.get("MAX_DB_WORKERS") or MAX_WORKERS)
+MAX_RETRIES = int(os.environ.get("MAX_RETRIES", 0))
 
 # This is a crude mechanism for preventing a single large JobRequest with lots
 # of associated Jobs from hogging all the resources. We want this configurable

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -61,6 +61,12 @@ class JobResults:
     message: str = None
 
 
+class ExecutorRetry(Exception):
+    """Indicates to the job scheduler that there's a temporary issue and to try again later."""
+
+    pass
+
+
 class ExecutorAPI:
     """
     API for managing job execution.

--- a/jobrunner/lib/docker.py
+++ b/jobrunner/lib/docker.py
@@ -301,7 +301,7 @@ def container_is_running(name):
     return container_inspect(name, "State.Running", none_if_not_exists=True) or False
 
 
-def container_inspect(name, key="", none_if_not_exists=False):
+def container_inspect(name, key="", none_if_not_exists=False, timeout=None):
     """
     Retrieves metadata about the named container. By default will return
     everything but `key` can be a dotted path to a specific piece of metadata.
@@ -315,7 +315,10 @@ def container_inspect(name, key="", none_if_not_exists=False):
             ["container", "inspect", "--format", "{{json .%s}}" % key, name],
             check=True,
             capture_output=True,
+            timeout=timeout,
         )
+    except subprocess.TimeoutExpired:
+        raise DockerTimeoutError(f"container_inspect timeout for {name}")
     except subprocess.CalledProcessError as e:
         if (
             none_if_not_exists


### PR DESCRIPTION
Fixes #453

This adds a tuneable config for how many retries we allow before
failure.
