### PR TITLE
chore: remove the ENTER states from the job trace

### DIFF
--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -242,7 +242,6 @@ def recursively_build_jobs(jobs_by_action, job_request, pipeline_config, action)
         updated_at=int(timestamp),
     )
     tracing.initialise_trace(job)
-    tracing.start_new_state(job, job.status_code_updated_at)
 
     # Add it to the dictionary of scheduled jobs
     jobs_by_action[action] = job

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -574,9 +574,6 @@ def set_code(job, code, message, error=None, results=None, timestamp=None, **att
                 results=results,
                 **attrs,
             )
-        else:
-            # trace that we've started the next state
-            tracing.start_new_state(job, timestamp_ns, error=error, **attrs)
 
         log.info(job.status_message, extra={"status_code": job.status_code})
 

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -128,27 +128,6 @@ def record_final_state(job, timestamp_ns, error=None, results=None, **attrs):
         logger.exception(f"failed to trace state for {job.id}")
 
 
-def start_new_state(job, timestamp_ns, error=None, **attrs):
-    """Record a marker span to say that we've entered a new state."""
-    if not _traceable(job):
-        return
-
-    # allow them to be filtered out easily
-    attrs["is_state"] = False
-    # legacy filter, remove once above is deployed for ~1 week
-    attrs["enter_state"] = True
-
-    try:
-        name = f"ENTER {job.status_code.name}"
-        start_time = timestamp_ns
-        # fix the time for these synthetic marker events at one second
-        end_time = int(start_time + 1e9)
-        record_job_span(job, name, start_time, end_time, error, results=None, **attrs)
-    except Exception:
-        # make sure trace failures do not error the job
-        logger.exception(f"failed to trace state for {job.id}")
-
-
 def load_root_span(job):
     """Load the trace for this job from the db.
 

--- a/tests/cli/test_prepare_for_reboot.py
+++ b/tests/cli/test_prepare_for_reboot.py
@@ -37,5 +37,4 @@ def test_prepare_for_reboot(db, monkeypatch):
     mockume_api.delete_volume.assert_called_once_with(job1)
 
     spans = get_trace("jobs")
-    assert spans[-2].name == "EXECUTING"
-    assert spans[-1].name == "ENTER WAITING_ON_REBOOT"
+    assert spans[-1].name == "EXECUTING"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -60,17 +60,11 @@ def test_handle_job_full_execution(synchronous_transitions, db, freezer):
     spans = get_trace("jobs")
     assert [s.name for s in spans] == [
         "CREATED",
-        "ENTER PREPARING",
         "PREPARING",
-        "ENTER PREPARED",
         "PREPARED",
-        "ENTER EXECUTING",
         "EXECUTING",
-        "ENTER EXECUTED",
         "EXECUTED",
-        "ENTER FINALIZING",
         "FINALIZING",
-        "ENTER FINALIZED",
         "FINALIZED",
         "SUCCEEDED",
         "JOB",
@@ -172,8 +166,7 @@ def test_handle_job_pending_to_preparing(db):
 
     # tracing
     spans = get_trace("jobs")
-    assert spans[-2].name == "CREATED"
-    assert spans[-1].name == "ENTER PREPARING"
+    assert spans[-1].name == "CREATED"
 
 
 def test_handle_job_pending_dependency_failed(db):
@@ -232,8 +225,7 @@ def test_handle_pending_job_waiting_on_dependency(db):
 
     # tracing
     spans = get_trace("jobs")
-    assert spans[-2].name == "CREATED"
-    assert spans[-1].name == "ENTER WAITING_ON_DEPENDENCIES"
+    assert spans[-1].name == "CREATED"
 
 
 def test_handle_job_waiting_on_workers(monkeypatch, db):
@@ -252,8 +244,7 @@ def test_handle_job_waiting_on_workers(monkeypatch, db):
 
     # tracing
     spans = get_trace("jobs")
-    assert spans[-2].name == "CREATED"
-    assert spans[-1].name == "ENTER WAITING_ON_WORKERS"
+    assert spans[-1].name == "CREATED"
 
 
 def test_handle_job_waiting_on_db_workers(monkeypatch, db):
@@ -276,8 +267,7 @@ def test_handle_job_waiting_on_db_workers(monkeypatch, db):
 
     # tracing
     spans = get_trace("jobs")
-    assert spans[-2].name == "CREATED"
-    assert spans[-1].name == "ENTER WAITING_ON_DB_WORKERS"
+    assert spans[-1].name == "CREATED"
 
 
 @pytest.mark.parametrize(
@@ -307,8 +297,7 @@ def test_handle_job_waiting_on_workers_via_executor(
     # tracing
     spans = get_trace("jobs")
     expected_trace_state = code.name
-    assert spans[-2].name == expected_trace_state
-    assert spans[-1].name == "ENTER WAITING_ON_WORKERS"
+    assert spans[-1].name == expected_trace_state
 
 
 def test_handle_job_pending_to_error(db):
@@ -340,8 +329,7 @@ def test_handle_job_prepared_to_executing(db):
 
     # tracing
     spans = get_trace("jobs")
-    assert spans[-2].name == "PREPARED"
-    assert spans[-1].name == "ENTER EXECUTING"
+    assert spans[-1].name == "PREPARED"
 
 
 def test_handle_job_executed_to_finalizing(db):
@@ -360,8 +348,7 @@ def test_handle_job_executed_to_finalizing(db):
 
     # tracing
     spans = get_trace("jobs")
-    assert spans[-2].name == "EXECUTED"
-    assert spans[-1].name == "ENTER FINALIZING"
+    assert spans[-1].name == "EXECUTED"
 
 
 def test_handle_job_finalized_success_with_delete(db):
@@ -527,8 +514,7 @@ def test_handle_pending_db_maintenance_mode(db, backend_db_config):
     assert job.started_at is None
 
     spans = get_trace("jobs")
-    assert spans[-2].name == "CREATED"
-    assert spans[-1].name == "ENTER WAITING_DB_MAINTENANCE"
+    assert spans[-1].name == "CREATED"
 
 
 def test_handle_running_db_maintenance_mode(db, backend_db_config):
@@ -553,8 +539,7 @@ def test_handle_running_db_maintenance_mode(db, backend_db_config):
     assert job.started_at is None
 
     spans = get_trace("jobs")
-    assert spans[-2].name == "EXECUTING"
-    assert spans[-1].name == "ENTER WAITING_DB_MAINTENANCE"
+    assert spans[-1].name == "EXECUTING"
 
 
 def test_handle_pending_pause_mode(db, backend_db_config):
@@ -575,8 +560,7 @@ def test_handle_pending_pause_mode(db, backend_db_config):
     assert "paused" in job.status_message
 
     spans = get_trace("jobs")
-    assert spans[-2].name == "CREATED"
-    assert spans[-1].name == "ENTER WAITING_PAUSED"
+    assert spans[-1].name == "CREATED"
 
 
 def test_handle_running_pause_mode(db, backend_db_config):
@@ -755,11 +739,8 @@ def test_handle_single_job_shortcuts_synchronous(db):
     # tracing
     assert [s.name for s in get_trace("jobs")] == [
         "CREATED",
-        "ENTER PREPARING",
         "PREPARING",
-        "ENTER PREPARED",
         "PREPARED",
-        "ENTER EXECUTING",
     ]
 
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -177,23 +177,6 @@ def test_record_final_state_error(db):
     assert spans[-1].attributes["exit_code"] == 1
 
 
-def test_start_new_state(db):
-    job = job_factory()
-    ts = int(time.time() * 1e9)
-
-    job.status_code = models.StatusCode.PREPARING
-
-    tracing.start_new_state(job, ts)
-
-    spans = get_trace("jobs")
-    assert spans[-1].name == "ENTER PREPARING"
-    assert spans[-1].attributes["is_state"] is False
-    assert spans[-1].end_time == int(ts + 1e9)
-
-    # deprecated attribute
-    assert spans[-1].attributes["enter_state"] is True
-
-
 def test_record_job_span_skips_uninitialized_job(db):
     job = job_factory()
     ts = int(time.time() * 1e9)


### PR DESCRIPTION
Now that we have "tick" traces, we don't really need these anymore, and
the add noise that needs filtering out in Honeycomb
