### PR TITLE
fix: change JobStatus.timestamp to ns precision

### DIFF
--- a/jobrunner/executors/volumes.py
+++ b/jobrunner/executors/volumes.py
@@ -123,7 +123,7 @@ class BindMountVolumeAPI:
             if contents:
                 return int(contents)
             else:
-                # linx host filesystem provides untruncated timestamps
+                # linux host filesystem provides untruncated timestamps
                 stat = abs_path.stat()
                 return int(stat.st_ctime * 1e9)
 

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -49,7 +49,7 @@ class ExecutorState(Enum):
 class JobStatus:
     state: ExecutorState
     message: Optional[str] = None
-    timestamp: int = None
+    timestamp: int = None  # timestamp this JobStatus occored, in integer nanoseconds
 
 
 @dataclass
@@ -60,7 +60,8 @@ class JobResults:
     exit_code: int
     image_id: str
     message: str = None
-    timestamp: int = None  # timestamp these results were finalized
+    # timestamp these results were finalized, in integer nanoseconds
+    timestamp: int = None
 
     # to be extracted from the image labels
     action_version: str = "unknown"

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -49,7 +49,7 @@ class ExecutorState(Enum):
 class JobStatus:
     state: ExecutorState
     message: Optional[str] = None
-    timestamp: int = None  # timestamp this JobStatus occored, in integer nanoseconds
+    timestamp: int = None  # timestamp this JobStatus occurred, in integer nanoseconds
 
 
 @dataclass

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -49,7 +49,9 @@ class ExecutorState(Enum):
 class JobStatus:
     state: ExecutorState
     message: Optional[str] = None
-    timestamp: int = None  # timestamp this JobStatus occurred, in integer nanoseconds
+    timestamp_ns: int = (
+        None  # timestamp this JobStatus occurred, in integer nanoseconds
+    )
 
 
 @dataclass
@@ -61,7 +63,7 @@ class JobResults:
     image_id: str
     message: str = None
     # timestamp these results were finalized, in integer nanoseconds
-    timestamp: int = None
+    timestamp_ns: int = None
 
     # to be extracted from the image labels
     action_version: str = "unknown"

--- a/jobrunner/lib/docker.py
+++ b/jobrunner/lib/docker.py
@@ -217,7 +217,7 @@ def read_timestamp(volume_name, path, timeout=None):
             )
 
     # either output was "" or we couldn't parse it as integer
-    # fallback to filesystem metadata, to as support older volumes, and just be
+    # fallback to filesystem metadata, to support older volumes, and just be
     # robust
     try:
         response = docker(

--- a/tests/lib/test_init.py
+++ b/tests/lib/test_init.py
@@ -1,11 +1,11 @@
 import pytest
 
-from jobrunner.lib import atomic_writer
+from jobrunner import lib
 
 
 def test_atomic_writer_success(tmp_path):
     dst = tmp_path / "dst"
-    with atomic_writer(dst) as tmp:
+    with lib.atomic_writer(dst) as tmp:
         tmp.write_text("dst")
 
     assert dst.read_text() == "dst"
@@ -15,7 +15,7 @@ def test_atomic_writer_success(tmp_path):
 def test_atomic_writer_failure(tmp_path):
     dst = tmp_path / "dst"
     with pytest.raises(Exception):
-        with atomic_writer(dst) as tmp:
+        with lib.atomic_writer(dst) as tmp:
             tmp.write_text("dst")
             raise Exception("test")
 
@@ -29,10 +29,34 @@ def test_atomic_writer_overwrite_symlink(tmp_path):
     dst = tmp_path / "link"
     dst.symlink_to(target)
 
-    with atomic_writer(dst) as tmp:
+    with lib.atomic_writer(dst) as tmp:
         tmp.write_text("dst")
 
     assert dst.read_text() == "dst"
     assert not dst.is_symlink()
     assert target.read_text() == "target"
     assert not tmp.exists()
+
+
+@pytest.mark.parametrize(
+    "datestr, expected",
+    [
+        # docker datestrs, with and without ns
+        ("2022-01-01T12:34:56.123456Z", 1641040496123456000),
+        ("2022-01-01T12:34:56.123456789Z", 1641040496123456789),
+        # busybox stat datestr, with and without ns
+        ("2022-01-01 12:34:56.123456 +0000", 1641040496123456000),
+        ("2022-01-01 12:34:56.123456789 +0000", 1641040496123456789),
+        # short date
+        ("2022-01-01T12:34:56", 1641040496000000000),
+        # invalid
+        ("not-a-timestamp", None),
+        # check tz maths, just in case
+        (
+            "2022-01-01 12:34:56.123456789+02:00",
+            1641040496123456789 - int(2 * 60 * 60 * 1e9),
+        ),
+    ],
+)
+def test_datestr_to_ns_timestamp(datestr, expected):
+    assert lib.datestr_to_ns_timestamp(datestr) == expected

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -96,7 +96,7 @@ def test_prepare_success(docker_cleanup, test_repo, tmp_work_dir, volume_api, fr
     next_status = api.get_status(job)
 
     assert next_status.state == ExecutorState.PREPARED
-    assert next_status.timestamp == expected_timestamp
+    assert next_status.timestamp_ns == expected_timestamp
 
     assert volume_api.volume_exists(job)
 
@@ -341,9 +341,9 @@ def test_finalize_success(docker_cleanup, test_repo, tmp_work_dir, volume_api):
 
     # check that timestamp is as expected
     container = docker.container_inspect(local.container_name(job))
-    assert status.timestamp == datestr_to_ns_timestamp(container["State"]["FinishedAt"])
-
-    assert status.timestamp
+    assert status.timestamp_ns == datestr_to_ns_timestamp(
+        container["State"]["FinishedAt"]
+    )
 
     status = api.finalize(job)
     assert status.state == ExecutorState.FINALIZING


### PR DESCRIPTION
Using seconds meant that the  truncation to nearest second made it
possible for telemetry timestamps to move backwards in time which causes
all kinds of complexity.

This changes the semantics of JobStatus.timestamp to be integer
nanoseconds, which should mean it never goes backwards. To support this
for the PREPARED state, we write the ns timestamp into as the contents
of the .opensafely-timestamp, so we can read them out later.

Note, this doesn't change the find new files logic, which still uses the
filesystem mtime metadata for finding new files.

Also, the parsing of timestamps from docker was just completely busted,
so this fixed that and added more tests.
