### PR TITLE
fix: don't error the job on ExecutorRetry

### DIFF
--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -194,16 +194,18 @@ class LocalDockerAPI(ExecutorAPI):
         RESULTS.pop(job.id, None)
         return JobStatus(ExecutorState.UNKNOWN)
 
-    def get_status(self, job):
+    def get_status(self, job, timeout=15):
         name = container_name(job)
         try:
             container = docker.container_inspect(
                 name,
                 none_if_not_exists=True,
-                timeout=10,
+                timeout=timeout,
             )
         except docker.DockerTimeoutError:
-            raise ExecutorRetry("timed out inspecting container {name}")
+            raise ExecutorRetry(
+                f"docker timed out after {timeout}s inspecting container {name}"
+            )
 
         if container is None:  # container doesn't exist
             # timestamp file presence means we have finished preparing

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -99,10 +99,6 @@ class LocalDockerAPI(ExecutorAPI):
     synchronous_transitions = [ExecutorState.PREPARING, ExecutorState.FINALIZING]
 
     def prepare(self, job):
-        current = self.get_status(job)
-        if current.state != ExecutorState.UNKNOWN:
-            return current
-
         # Check the workspace is not archived
         workspace_dir = get_high_privacy_workspace(job.workspace)
         if not workspace_dir.exists():
@@ -123,6 +119,10 @@ class LocalDockerAPI(ExecutorAPI):
                 ExecutorState.ERROR,
                 f"Docker image {job.image} is not currently available",
             )
+
+        current = self.get_status(job)
+        if current.state != ExecutorState.UNKNOWN:
+            return current
 
         try:
             prepare_job(job)

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -646,5 +646,10 @@ def test_get_status_timeout(tmp_work_dir, monkeypatch):
     monkeypatch.setattr(local.docker, "container_inspect", inspect)
     api = local.LocalDockerAPI()
 
-    with pytest.raises(local.ExecutorRetry):
-        api.get_status(job)
+    with pytest.raises(local.ExecutorRetry) as exc:
+        api.get_status(job, timeout=11)
+
+    assert (
+        str(exc.value)
+        == "docker timed out after 11s inspecting container os-job-test_get_status_timeout"
+    )


### PR DESCRIPTION
Instead, record that it happened, but don't fail the job. The idea is
that we can then be alerted to it happening, but when it's over, the job
continues.

Also, increase get_status timeout from 10s to 15s, we a) occasionally we
saw it in GHA CI, and b) having it slow down a bit when docker is
blocking is no bad thing

Fixes #546 
