### PR TITLE
fix: stop job traces picking up loop trace as parent

### DIFF
--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -71,7 +71,7 @@ def initialise_trace(job):
     # create a root span in order to have a parent for all subsequent spans.
     # However, we do not annotate or emit this span object now. We do this when
     # the job has completed; see complete_job() for details.
-    root = tracer.start_span("JOB")
+    root = tracer.start_span("JOB", context={})
 
     # TraceContextTextMapPropagator only works with the current span, so set it as such.
     with trace.use_span(root, end_on_exit=False):
@@ -87,7 +87,7 @@ def _traceable(job):
     running that pre-existed it.
     """
     if job.trace_context is None or job.status_code is None:
-        logger.info(f"not tracing job {job.id} as not initialised")
+        logger.info(f"not tracing job {job.id} as not initialised for tracing")
         return False
 
     return True

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -110,7 +110,7 @@ def test_trace_attributes_missing(db, monkeypatch):
     )
 
 
-def test_initialise_trace1(db):
+def test_initialise_trace(db):
     job = job_factory()
     # clear factories default context
     job.trace_context = None


### PR DESCRIPTION
This just means giving it an explicit empty context.
