### PR TITLE
chore: get the correct volume api for a job

### DIFF
--- a/jobrunner/cli/kill_job.py
+++ b/jobrunner/cli/kill_job.py
@@ -37,7 +37,7 @@ def main(partial_job_ids, cleanup=False):
 
         if cleanup:
             docker.delete_container(container)
-            local.volume_api.delete_volume(job)
+            local.get_volume_api(job).delete_volume(job)
 
 
 def get_jobs(partial_job_ids):

--- a/jobrunner/cli/prepare_for_reboot.py
+++ b/jobrunner/cli/prepare_for_reboot.py
@@ -4,7 +4,7 @@ automatically re-run after a reboot.
 """
 import argparse
 
-from jobrunner.executors.local import container_name, docker, volume_api
+from jobrunner.executors.local import container_name, docker, get_volume_api
 from jobrunner.lib.database import find_where
 from jobrunner.models import Job, State, StatusCode
 from jobrunner.run import set_code
@@ -34,7 +34,7 @@ def main(pause=True):
         # these are idempotent
         docker.kill(container_name(job))
         docker.delete_container(container_name(job))
-        volume_api.delete_volume(job)
+        get_volume_api(job).delete_volume(job)
 
 
 def run():

--- a/tests/cli/test_kill_job.py
+++ b/tests/cli/test_kill_job.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from jobrunner.cli import kill_job
-from jobrunner.executors import local
+from jobrunner.executors import local, volumes
 from jobrunner.lib import database
 from jobrunner.models import Job, State, StatusCode
 from tests.factories import job_factory
@@ -15,7 +15,7 @@ def test_kill_job(cleanup, tmp_work_dir, db, monkeypatch):
     job = job_factory(state=State.RUNNING, status_code=StatusCode.EXECUTING)
 
     mocker = mock.MagicMock(spec=local.docker)
-    mockume_api = mock.MagicMock(spec=local.volume_api)
+    mockume_api = mock.MagicMock(spec=volumes.DEFAULT_VOLUME_API)
 
     def mock_get_jobs(partial_job_ids):
         return [job]
@@ -29,7 +29,7 @@ def test_kill_job(cleanup, tmp_work_dir, db, monkeypatch):
     # set both the docker module names used to the mocker version
     monkeypatch.setattr(kill_job, "docker", mocker)
     monkeypatch.setattr(local, "docker", mocker)
-    monkeypatch.setattr(kill_job.local, "volume_api", mockume_api)
+    monkeypatch.setattr(volumes, "DEFAULT_VOLUME_API", mockume_api)
     monkeypatch.setattr(kill_job, "get_jobs", mock_get_jobs)
 
     kill_job.main(job.id, cleanup=cleanup)


### PR DESCRIPTION
This means that a job that was PREPARED with one volume API will be
finalized with the same volume API. This will facilitate switching it on
bind mount API in production.

Fixes #522
