### PR TITLE
feat: record the high water mark for cpu/memory for a job

### DIFF
--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -158,6 +158,9 @@ class Job:
             completed_at INT,
             trace_context TEXT,
             status_code_updated_at INT,
+            -- resource high water marks --
+            cpu_hwm INT,
+            memory_hwm INT,
 
             PRIMARY KEY (id)
         );
@@ -177,6 +180,7 @@ class Job:
         """
         ALTER TABLE job ADD COLUMN trace_context TEXT;
         ALTER TABLE job ADD COLUMN status_code_updated_at INT;
+        ALTER TABLE job ADD COLUMN cpu_hwm INT, memory_hwm INT;
         """,
     )
 
@@ -237,6 +241,10 @@ class Job:
     status_code_updated_at: int = None
     # used to track the OTel trace context for this job
     trace_context: dict = None
+
+    # resource usage high water marks
+    cpu_hwm: int = 0
+    memory_hwm: int = 0
 
     # used to cache the job_request json by the tracing code
     _job_request = None


### PR DESCRIPTION
We don't do anything with it right now, but maybe in future we will,
e.g. displaying it to users, or using it to schedule jobs better.

There's a bit of wrinkle here though: we're kinda of breaking the
scheduler/executor layering a bit, by storing these values directly in
the job-runner db.

Ideally, the executor would be responsible for tracking resource usage,
both for live metrics and for high-water-marks. But the current executor
was not designed with this in mind.

So this takes the easy option, and makes the current record_stats thread
handle it. With the caveat that its specific to the local docker
executor.
