### PR TITLE
fix: delete as many files as we can

### DIFF
--- a/jobrunner/executors/volumes.py
+++ b/jobrunner/executors/volumes.py
@@ -132,11 +132,24 @@ class BindMountVolumeAPI:
         copy_file(path, dst)
 
     def delete_volume(job):
+
+        failed_files = {}
+
+        # if we logged each file error directly, it would spam the logs, so we collect them
+        def onerror(function, path, excinfo):
+            failed_files[path] = str(excinfo[1])
+
         path = host_volume_path(job)
         try:
-            shutil.rmtree(path)
+            shutil.rmtree(path, onerror=onerror)
         except Exception:
             logger.exception(f"Failed to cleanup job volume {path}")
+
+        if failed_files:
+            relative_paths = [str(p.relative_to(path)) for p in failed_files]
+            logger.error(
+                f"could not remove {len(failed_files)} files from {path}: {','.join(relative_paths)}"
+            )
 
     def write_timestamp(job, path, timeout=None):
         (host_volume_path(job) / path).write_text(str(time.time_ns()))


### PR DESCRIPTION
Currently, the bindmount api's delete_volume method errors on TPP once
it errors on one file. This needs fixing, but may take a bit of time.

To handle it better in the meantime, record but don't error on these
files, and log them. That way, we delete all the files we can, and leave
only those we can't.
