### PR TITLE
fix: run as non-root user with BindMountVolumeAPI

### DIFF
--- a/jobrunner/cli/local_run.py
+++ b/jobrunner/cli/local_run.py
@@ -280,6 +280,8 @@ def create_and_run_jobs(
     config.HIGH_PRIVACY_STORAGE_BASE = None
     config.MEDIUM_PRIVACY_STORAGE_BASE = None
     config.MEDIUM_PRIVACY_WORKSPACES_DIR = None
+    # Support using the BindMount api locally for dev testing
+    config.HIGH_PRIVACY_VOLUME_DIR = project_dir / "metadata" / "volumes"
 
     configure_logging(
         fmt=log_format,

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -260,3 +260,9 @@ HIGH_PRIVACY_VOLUME_DIR = HIGH_PRIVACY_STORAGE_BASE / "volumes"
 # needs to point to the path to the HIGH_PRIVACY_VOLUME_DIR from the *hosts*
 # perspective, as that's what docker will be looking for.
 DOCKER_HOST_VOLUME_DIR = os.environ.get("DOCKER_HOST_VOLUME_DIR")
+
+# These are currently only used with the BindMountVolumeAPI.
+# It could work with DockerVolumeAPI if we can workaround docker cp only
+# writing files into containers as root.
+DOCKER_USER_ID = os.environ.get("DOCKER_USER_ID", str(os.geteuid()))
+DOCKER_GROUP_ID = os.environ.get("DOCKER_GROUP_ID", str(os.getegid()))

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -2,6 +2,7 @@ import configparser
 import os
 import re
 import subprocess
+import sys
 from multiprocessing import cpu_count
 from pathlib import Path
 
@@ -264,5 +265,9 @@ DOCKER_HOST_VOLUME_DIR = os.environ.get("DOCKER_HOST_VOLUME_DIR")
 # These are currently only used with the BindMountVolumeAPI.
 # It could work with DockerVolumeAPI if we can workaround docker cp only
 # writing files into containers as root.
-DOCKER_USER_ID = os.environ.get("DOCKER_USER_ID", str(os.geteuid()))
-DOCKER_GROUP_ID = os.environ.get("DOCKER_GROUP_ID", str(os.getegid()))
+if sys.platform == "linux":
+    DOCKER_USER_ID = os.environ.get("DOCKER_USER_ID", str(os.geteuid()))
+    DOCKER_GROUP_ID = os.environ.get("DOCKER_GROUP_ID", str(os.getegid()))
+else:
+    DOCKER_USER_ID = None
+    DOCKER_GROUP_ID = None

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -255,7 +255,12 @@ DOCKER_EXIT_CODES = {
 # BindMountVolumeAPI config
 #
 # used to store directories to be mounted into jobs with the BindMountVolumeAPI
-HIGH_PRIVACY_VOLUME_DIR = HIGH_PRIVACY_STORAGE_BASE / "volumes"
+HIGH_PRIVACY_VOLUME_DIR = Path(
+    os.environ.get(
+        "HIGH_PRIVACY_VOLUME_DIR",
+        HIGH_PRIVACY_STORAGE_BASE / "volumes",
+    )
+)
 
 # when running inside a docker container and using the BindMountVolumeAPI, this
 # needs to point to the path to the HIGH_PRIVACY_VOLUME_DIR from the *hosts*

--- a/jobrunner/executors/volumes.py
+++ b/jobrunner/executors/volumes.py
@@ -2,6 +2,7 @@ import importlib
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import time
 from collections import defaultdict
@@ -34,6 +35,7 @@ class DockerVolumeAPI:
 
     # don't run with UIDs for now. We maybe be able to support this in future.
     requires_root = True
+    supported_platforms = ("linux", "win32", "darwin")
 
     def volume_name(job):
         return docker_volume_name(job)
@@ -90,6 +92,7 @@ class BindMountVolumeAPI:
 
     # Only works running jobs with uid:gid
     requires_root = False
+    supported_platforms = ("linux",)
 
     def volume_name(job):
         """Return the absolute path to the volume directory.
@@ -205,7 +208,13 @@ class BindMountVolumeAPI:
 def default_volume_api():
     module_name, cls = config.LOCAL_VOLUME_API.split(":", 1)
     module = importlib.import_module(module_name)
-    return getattr(module, cls)
+    api = getattr(module, cls)
+    if sys.platform not in api.supported_platforms:
+        raise Exception(
+            f"LOCAL_VOLUME_API={config.LOCAL_VOLUME_API} is not supported on this machine ({sys.platform})"
+        )
+
+    return api
 
 
 DEFAULT_VOLUME_API = default_volume_api()

--- a/jobrunner/executors/volumes.py
+++ b/jobrunner/executors/volumes.py
@@ -31,6 +31,10 @@ def docker_volume_name(job):
 
 
 class DockerVolumeAPI:
+
+    # don't run with UIDs for now. We maybe be able to support this in future.
+    requires_root = True
+
     def volume_name(job):
         return docker_volume_name(job)
 
@@ -83,6 +87,10 @@ def host_volume_path(job, create=True):
 
 
 class BindMountVolumeAPI:
+
+    # Only works running jobs with uid:gid
+    requires_root = False
+
     def volume_name(job):
         """Return the absolute path to the volume directory.
 


### PR DESCRIPTION
Current, delete_volume() doesn't work properly with the
BindMountVolumeAPI. Because the containers are run as root, files they
create are owned by root, and this prevents jobrunner from deleting
them, and we currently manually have to delete them.

This change runs jobs with the jobrunner uid/gid when using
BindMountVolumeAPI, which solves the problem.

I have tested that all our current images work when run as non-root with
some sample studies, so I think this is good to go.
