### PR TITLE
Ensure rmtree onerror handler records Paths not strings

### DIFF
--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -573,3 +573,5 @@ def test_delete_volume_error_file_bindmount_skips_and_logs(job, caplog):
     # check the error is logged
     path = str(volumes.host_volume_path(job))
     assert path in caplog.records[-1].msg
+    # *not* an exception log, just an error one
+    assert caplog.records[-1].exc_text is None


### PR DESCRIPTION
Also, ensure that this code can never cause the job to fail, by
expanding the try/except body.
