### PR TITLE
fix: set HOME=/tmp for executing with BindMount volume api

### DIFF
--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -140,7 +140,12 @@ class LocalDockerAPI(ExecutorAPI):
 
         if not volume_api.requires_root:
             extra_args.extend(
-                ["--user", f"{config.DOCKER_USER_ID}:{config.DOCKER_GROUP_ID}"]
+                [
+                    "--user",
+                    f"{config.DOCKER_USER_ID}:{config.DOCKER_GROUP_ID}",
+                    "-e",
+                    "HOME=/tmp",  # set home dir to something writable by non-root user
+                ]
             )
 
         try:


### PR DESCRIPTION
Otherwise, HOME=/, and any code which tries to write to $HOME will fail
when not running as root.

We do set HOME=/tmp in `opensafely exec` for this reason too.
