### PR TITLE
feat: preseve logs of user cancelled jobs

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -247,9 +247,11 @@ TMP_DIR = WORKDIR / "temp"
 # docker specific exit codes we understand
 DOCKER_EXIT_CODES = {
     # 137 = 128+9, which means was killed by signal 9, SIGKILL
+    # This could be killed externally by an admin, or terminated through the
+    # cancellation process.
     # Note: this can also mean killed by OOM killer, but that's explicitly
     # handled already.
-    137: "Killed by an OpenSAFELY admin",
+    137: "Job cancelled",
 }
 
 # BindMountVolumeAPI config

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -193,6 +193,8 @@ class ExecutorAPI:
         The action log file and any useful metadata from the job run should also be written to a separate log storage
         area in long-term storage.
 
+        If the job has been cancelled, it should only preserve the action log file.
+
         When the finalize task finishes, the get_status() call should now return FINALIZED for this job, and
         get_results() call should return the JobResults for this job.
 

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -195,6 +195,8 @@ def handle_job(job, api, mode=None, paused=None):
         # regardless of executor state.
         api.terminate(definition)
         mark_job_as_failed(job, StatusCode.CANCELLED_BY_USER, "Cancelled by user")
+        # finalize should detect that we are a cancelled job & just preserve the log
+        api.finalize(definition)
         api.cleanup(definition)
         return
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -162,6 +162,7 @@ def test_handle_pending_job_cancelled(db):
 
     assert job.id not in api.tracker["terminate"]
     assert job.id not in api.tracker["finalize"]
+    assert job.id not in api.tracker["finalize_log_only"]
     assert job.id not in api.tracker["cleanup"]
 
     run.handle_job(job, api)
@@ -169,6 +170,7 @@ def test_handle_pending_job_cancelled(db):
     # executor state
     assert job.id in api.tracker["terminate"]
     assert job.id not in api.tracker["finalize"]
+    assert job.id not in api.tracker["finalize_log_only"]
     assert job.id in api.tracker["cleanup"]
     assert api.get_status(job).state == ExecutorState.UNKNOWN
 
@@ -183,6 +185,7 @@ def test_handle_running_job_cancelled(db, monkeypatch):
     job = api.add_test_job(ExecutorState.EXECUTING, State.RUNNING, cancelled=True)
 
     assert job.id not in api.tracker["terminate"]
+    assert job.id not in api.tracker["finalize_log_only"]
     assert job.id not in api.tracker["finalize"]
     assert job.id not in api.tracker["cleanup"]
 
@@ -191,6 +194,7 @@ def test_handle_running_job_cancelled(db, monkeypatch):
     # executor state
     assert job.id in api.tracker["terminate"]
     assert job.id not in api.tracker["finalize"]
+    assert job.id in api.tracker["finalize_log_only"]
     assert job.id in api.tracker["cleanup"]
 
     definition = run.job_to_job_definition(job)


### PR DESCRIPTION
* make the use of ExecutorStatus.ERROR more consistent between different Executors
* use ExecutorStatus.ERROR in finalize to determine whether execution finished, and therefore whether we should just preserve logs
* there are a couple of reasons to implement this using ExecutorStatus rather than passing a parameter to the ExecutorAPI `finalize()` call, including:
  * jobs whose docker process is killed externally will currently run the finalize process, they currently attempt to store outputs & I think they should instead do the same as a process killed through the cancel process
  * adding parameters to the ExecutorAPI means reworking the [metaprogramming in the LoggingExecutor](https://github.com/opensafely-core/job-runner/blob/002939feb4260734fe3ff47a6fa13e5bd77702be/jobrunner/executors/logging.py#L40) in a very unaesthetic way
