### PR TITLE
chore: integration test for bindmountapi

### DIFF
--- a/jobrunner/cli/kill_job.py
+++ b/jobrunner/cli/kill_job.py
@@ -38,7 +38,7 @@ def main(partial_job_ids, cleanup=False):
         if cleanup:
             docker.delete_container(container)
             # nb. `job` could potentially be a Job or a JobDefinition
-            local.get_volume_api(job).delete_volume(job)
+            local.volumes.get_volume_api(job).delete_volume(job)
 
 
 def get_jobs(partial_job_ids):

--- a/jobrunner/cli/prepare_for_reboot.py
+++ b/jobrunner/cli/prepare_for_reboot.py
@@ -4,7 +4,8 @@ automatically re-run after a reboot.
 """
 import argparse
 
-from jobrunner.executors.local import container_name, docker, get_volume_api
+from jobrunner.executors.local import container_name, docker
+from jobrunner.executors.volumes import get_volume_api
 from jobrunner.lib.database import find_where
 from jobrunner.models import Job, State, StatusCode
 from jobrunner.run import set_code

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import tempfile
 from collections import deque
 from dataclasses import dataclass, field
@@ -12,6 +13,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 import jobrunner.executors.local
 from jobrunner import config, tracing
+from jobrunner.executors import volumes
 from jobrunner.job_executor import Study
 from jobrunner.lib import database
 from jobrunner.lib.subprocess_utils import subprocess_run
@@ -225,3 +227,9 @@ def mock_subprocess_run():
     assert (
         len(stub.calls) == 0
     ), f"subprocess_run expected the following calls: {stub.calls}"
+
+
+if sys.platform == "linux" or sys.platform == "darwin":
+    SUPPORTED_VOLUME_APIS = [volumes.BindMountVolumeAPI, volumes.DockerVolumeAPI]
+else:
+    SUPPORTED_VOLUME_APIS = [volumes.DockerVolumeAPI]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,24 +5,17 @@ loops to run entire pipeline
 """
 import json
 import logging
-import sys
 
 import pytest
 
 import jobrunner.run
 import jobrunner.sync
-from jobrunner.executors import get_executor_api, volumes
-from tests.conftest import get_trace
+from jobrunner.executors import get_executor_api
+from tests.conftest import SUPPORTED_VOLUME_APIS, get_trace
 from tests.factories import ensure_docker_images_present
 
 
 log = logging.getLogger(__name__)
-
-# TODO: share this with elsewhere in the codebase?
-if sys.platform == "linux" or sys.platform == "darwin":
-    SUPPORTED_VOLUME_APIS = [volumes.BindMountVolumeAPI, volumes.DockerVolumeAPI]
-else:
-    SUPPORTED_VOLUME_APIS = [volumes.DockerVolumeAPI]
 
 
 # this is parametized fixture, and test using it will run multiple times, once

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,23 +5,40 @@ loops to run entire pipeline
 """
 import json
 import logging
+import sys
 
 import pytest
 
 import jobrunner.run
 import jobrunner.sync
-from jobrunner.executors import get_executor_api
+from jobrunner.executors import get_executor_api, volumes
 from tests.conftest import get_trace
 from tests.factories import ensure_docker_images_present
 
 
 log = logging.getLogger(__name__)
 
+# TODO: share this with elsewhere in the codebase?
+if sys.platform == "linux" or sys.platform == "darwin":
+    SUPPORTED_VOLUME_APIS = [volumes.BindMountVolumeAPI, volumes.DockerVolumeAPI]
+else:
+    SUPPORTED_VOLUME_APIS = [volumes.DockerVolumeAPI]
+
+
+# this is parametized fixture, and test using it will run multiple times, once
+# for each volume api implementation
+@pytest.fixture(params=SUPPORTED_VOLUME_APIS)
+def volume_api(request, monkeypatch):
+    monkeypatch.setattr(
+        jobrunner.executors.local.volumes, "DEFAULT_VOLUME_API", request.param
+    )
+    return request.param
+
 
 @pytest.mark.slow_test
 @pytest.mark.needs_docker
 def test_integration_with_cohortextractor(
-    tmp_work_dir, docker_cleanup, requests_mock, monkeypatch, test_repo
+    tmp_work_dir, docker_cleanup, requests_mock, monkeypatch, test_repo, volume_api
 ):
     # TODO: add the following parametrize decorator back to this test:
     #
@@ -207,7 +224,7 @@ def test_integration_with_cohortextractor(
 @pytest.mark.slow_test
 @pytest.mark.needs_docker
 def test_integration_with_databuilder(
-    tmp_work_dir, docker_cleanup, requests_mock, monkeypatch, test_repo
+    tmp_work_dir, docker_cleanup, requests_mock, monkeypatch, test_repo, volume_api
 ):
     # TODO: merge this test into test_integration
     #

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -8,13 +8,8 @@ from jobrunner import config
 from jobrunner.executors import local, volumes
 from jobrunner.job_executor import ExecutorState, JobDefinition, Privacy, Study
 from jobrunner.lib import datestr_to_ns_timestamp, docker
+from tests.conftest import SUPPORTED_VOLUME_APIS
 from tests.factories import ensure_docker_images_present
-
-
-if sys.platform == "linux" or sys.platform == "darwin":
-    SUPPORTED_VOLUME_APIS = [volumes.BindMountVolumeAPI, volumes.DockerVolumeAPI]
-else:
-    SUPPORTED_VOLUME_APIS = [volumes.DockerVolumeAPI]
 
 
 # this is parametized fixture, and test using it will run multiple times, once


### PR DESCRIPTION
The integration tests currently only run using one of the APIs that we support. We should run the tests on both APIs, which will hopefully catch more bugs more quickly. 