### PR TITLE
chore: cleanup left-over containers from pytest runs

### DIFF
--- a/jobrunner/cli/local_run.py
+++ b/jobrunner/cli/local_run.py
@@ -65,6 +65,8 @@ DESCRIPTION = __doc__.partition("\n\n")[0]
 # local run logging format
 LOCAL_RUN_FORMAT = "{action}{message}"
 
+# allow us to monkeypatch this in order to clean-up after pytest
+DEBUG_LABEL = "job-runner-debug"
 
 STATA_ERROR_MESSGE = """
 The docker image 'stata-mp' requires a license to function.
@@ -190,7 +192,7 @@ def main(
     else:
         # In debug mode (where we don't automatically delete containers and
         # volumes) we use a consistent label to make manual clean up easier
-        docker_label = "job-runner-debug"
+        docker_label = DEBUG_LABEL
 
     log_format = LOCAL_RUN_FORMAT
     if timestamps:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,7 @@ def docker_cleanup(monkeypatch):
     label_for_tests = "jobrunner-pytest"
     monkeypatch.setattr("jobrunner.lib.docker.LABEL", label_for_tests)
     monkeypatch.setattr("jobrunner.executors.local.LABEL", label_for_tests)
+    monkeypatch.setattr("jobrunner.cli.local_run.DEBUG_LABEL", label_for_tests)
     yield
     delete_docker_entities("container", label_for_tests)
     delete_docker_entities("volume", label_for_tests)


### PR DESCRIPTION
* the docker clean-up process was leaving volumes & running containers behind with each run - tidy them up!
* but don't clean up any debug containers/volumes that were produced by other means