### PR TITLE
chore: rename variables to be more consistent

### DIFF
--- a/jobrunner/cli/kill_job.py
+++ b/jobrunner/cli/kill_job.py
@@ -37,6 +37,7 @@ def main(partial_job_ids, cleanup=False):
 
         if cleanup:
             docker.delete_container(container)
+            # nb. `job` could potentially be a Job or a JobDefinition
             local.get_volume_api(job).delete_volume(job)
 
 

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -67,11 +67,11 @@ class LocalDockerError(Exception):
     pass
 
 
-def get_job_labels(job: JobDefinition):
+def get_job_labels(job_definition: JobDefinition):
     """Useful metadata to label docker objects with."""
     return {
-        "workspace": job.workspace,
-        "action": job.action,
+        "workspace": job_definition.workspace,
+        "action": job_definition.action,
     }
 
 

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -103,7 +103,7 @@ class ExecutorAPI:
 
     """
 
-    def prepare(self, job: JobDefinition) -> JobStatus:
+    def prepare(self, job_definition: JobDefinition) -> JobStatus:
         """
         Launch a prepare task for a job, transitioning to the initial PREPARING state.
 
@@ -135,7 +135,7 @@ class ExecutorAPI:
 
         """
 
-    def execute(self, job: JobDefinition) -> JobStatus:
+    def execute(self, job_definition: JobDefinition) -> JobStatus:
         """
         Launch the execution of a job that has been prepared, transitioning from PREPARED to EXECUTING.
 
@@ -156,7 +156,7 @@ class ExecutorAPI:
         The specified image must be run, with the provided arguments and environment variables. The implementation
         may add environment variables to those in the job definition as necessary for the backend.
 
-        The job should be run without any network access, unless definition.allow_database_access is set to True,
+        The job should be run without any network access, unless job_definition.allow_database_access is set to True,
         in which case it should be run with a network allowing access to the database and any configuration needed to
         contact and authenticate with the database should be provided as environment variables.
 
@@ -169,7 +169,7 @@ class ExecutorAPI:
 
         """
 
-    def finalize(self, job: JobDefinition) -> JobStatus:
+    def finalize(self, job_definition: JobDefinition) -> JobStatus:
         """
         Launch the finalization of a job, transitioning from EXECUTED to FINALIZING.
 
@@ -201,7 +201,7 @@ class ExecutorAPI:
 
         """
 
-    def terminate(self, job: JobDefinition) -> JobStatus:
+    def terminate(self, job_definition: JobDefinition) -> JobStatus:
         """
         Terminate a running job, transitioning to the ERROR state.
 
@@ -211,7 +211,7 @@ class ExecutorAPI:
 
         """
 
-    def cleanup(self, job: JobDefinition) -> JobStatus:
+    def cleanup(self, job_definition: JobDefinition) -> JobStatus:
         """
         Clean up any remaining state for a finished job, transitioning to the UNKNOWN state.
 
@@ -228,7 +228,7 @@ class ExecutorAPI:
         out-of-band mechanisms for cleaning up resources associated with such failures.
         """
 
-    def get_status(self, job: JobDefinition) -> JobStatus:
+    def get_status(self, job_definition: JobDefinition) -> JobStatus:
         """
         Return the current status of a job.
 
@@ -245,7 +245,7 @@ class ExecutorAPI:
 
         """
 
-    def get_results(self, job: JobDefinition) -> JobResults:
+    def get_results(self, job_definition: JobDefinition) -> JobResults:
         """
         Return the finalized results for a job.
 
@@ -272,25 +272,25 @@ class ExecutorAPI:
 class NullExecutorAPI(ExecutorAPI):
     """Null implementation of ExecutorAPI."""
 
-    def prepare(self, job):
+    def prepare(self, job_definition):
         raise NotImplementedError
 
-    def execute(self, job):
+    def execute(self, job_definition):
         raise NotImplementedError
 
-    def finalize(self, job):
+    def finalize(self, job_definition):
         raise NotImplementedError
 
-    def terminate(self, job):
+    def terminate(self, job_definition):
         raise NotImplementedError
 
-    def get_status(self, job):
+    def get_status(self, job_definition):
         raise NotImplementedError
 
-    def get_results(self, job):
+    def get_results(self, job_definition):
         raise NotImplementedError
 
-    def cleanup(self, job):
+    def cleanup(self, job_definition):
         raise NotImplementedError
 
     def delete_files(self, workspace, privacy, paths):

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -3,27 +3,27 @@ from jobrunner.job_executor import ExecutorAPI, JobDefinition, JobStatus
 
 class RecordingExecutor(ExecutorAPI):
     def __init__(self, *statuses):
-        self.job = None
+        self.job_definition = None
         self._statuses = list(statuses)
 
-    def _record(self, job):
-        self.job = job
+    def _record(self, job_definition):
+        self.job_definition = job_definition
         return self._statuses.pop(0)
 
-    def get_status(self, job: JobDefinition) -> JobStatus:
-        return self._record(job)
+    def get_status(self, job_definition: JobDefinition) -> JobStatus:
+        return self._record(job_definition)
 
-    def prepare(self, job: JobDefinition) -> JobStatus:
-        return self._record(job)
+    def prepare(self, job_definition: JobDefinition) -> JobStatus:
+        return self._record(job_definition)
 
-    def execute(self, job: JobDefinition) -> JobStatus:
-        return self._record(job)
+    def execute(self, job_definition: JobDefinition) -> JobStatus:
+        return self._record(job_definition)
 
-    def finalize(self, job: JobDefinition) -> JobStatus:
-        return self._record(job)
+    def finalize(self, job_definition: JobDefinition) -> JobStatus:
+        return self._record(job_definition)
 
-    def terminate(self, job: JobDefinition) -> JobStatus:
-        return self._record(job)
+    def terminate(self, job_definition: JobDefinition) -> JobStatus:
+        return self._record(job_definition)
 
-    def cleanup(self, job: JobDefinition) -> JobStatus:
-        return self._record(job)
+    def cleanup(self, job_definition: JobDefinition) -> JobStatus:
+        return self._record(job_definition)

--- a/tests/test_logging_executor.py
+++ b/tests/test_logging_executor.py
@@ -24,7 +24,7 @@ def test_logs(method):
 
     executor._logger.info = record
 
-    getattr(executor, method)(job_definition("the-job-id"))
+    getattr(executor, method)(create_job_definition("the-job-id"))
 
     assert "the-job-id" in log
     assert "doing the thing" in log
@@ -36,16 +36,16 @@ def test_delegates(method):
     status = JobStatus(ExecutorState.EXECUTED)
     recording = RecordingExecutor(status)
     executor = LoggingExecutor(recording)
-    job = job_definition("the-job-id")
+    job_definition = create_job_definition("the-job-id")
 
-    returned_status = getattr(executor, method)(job)
+    returned_status = getattr(executor, method)(job_definition)
 
-    assert recording.job == job
+    assert recording.job_definition == job_definition
     assert returned_status == status
 
 
-def job_definition(job_id="a-job-id"):
-    job = JobDefinition(
+def create_job_definition(job_id="a-job-id"):
+    job_definition = JobDefinition(
         id=job_id,
         job_request_id="test_request_id",
         study=Study(git_repo_url="", commit=""),
@@ -59,4 +59,4 @@ def job_definition(job_id="a-job-id"):
         output_spec={},
         allow_database_access=False,
     )
-    return job
+    return job_definition

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -193,8 +193,8 @@ def test_handle_running_job_cancelled(db, monkeypatch):
     assert job.id not in api.tracker["finalize"]
     assert job.id in api.tracker["cleanup"]
 
-    definition = run.job_to_job_definition(job)
-    assert api.get_status(definition).state == ExecutorState.UNKNOWN
+    job_definition = run.job_to_job_definition(job)
+    assert api.get_status(job_definition).state == ExecutorState.UNKNOWN
 
     # our state
     assert job.state == State.FAILED
@@ -833,7 +833,7 @@ def test_ignores_cancelled_jobs_when_calculating_dependencies(db):
         api,
     )
 
-    assert api.job.inputs == ["output-from-completed-run"]
+    assert api.job_definition.inputs == ["output-from-completed-run"]
 
 
 def test_get_obsolete_files_nothing_to_delete(db):
@@ -847,9 +847,9 @@ def test_get_obsolete_files_nothing_to_delete(db):
         status_code=StatusCode.SUCCEEDED,
         outputs=outputs,
     )
-    definition = run.job_to_job_definition(job)
+    job_definition = run.job_to_job_definition(job)
 
-    obsolete = run.get_obsolete_files(definition, outputs)
+    obsolete = run.get_obsolete_files(job_definition, outputs)
     assert obsolete == []
 
 
@@ -869,9 +869,9 @@ def test_get_obsolete_files_things_to_delete(db):
         state=State.SUCCEEDED,
         outputs=old_outputs,
     )
-    definition = run.job_to_job_definition(job)
+    job_definition = run.job_to_job_definition(job)
 
-    obsolete = run.get_obsolete_files(definition, new_outputs)
+    obsolete = run.get_obsolete_files(job_definition, new_outputs)
     assert obsolete == ["old_high.txt", "old_medium.txt"]
 
 
@@ -887,17 +887,17 @@ def test_get_obsolete_files_case_change(db):
         state=State.SUCCEEDED,
         outputs=old_outputs,
     )
-    definition = run.job_to_job_definition(job)
+    job_definition = run.job_to_job_definition(job)
 
-    obsolete = run.get_obsolete_files(definition, new_outputs)
+    obsolete = run.get_obsolete_files(job_definition, new_outputs)
     assert obsolete == []
 
 
 def test_job_definition_limits(db):
     job = job_factory()
-    definition = run.job_to_job_definition(job)
-    assert definition.cpu_count == 2
-    assert definition.memory_limit == "4G"
+    job_definition = run.job_to_job_definition(job)
+    assert job_definition.cpu_count == 2
+    assert job_definition.memory_limit == "4G"
 
 
 def test_mark_job_as_failed_adds_error(db):


### PR DESCRIPTION
* some files use `job` to mean an instance of `JobDefinition`, others use `job` to mean `Job` and `definition` to mean `JobDefinition`
* in isolation this is fine (and makes lines shorter), but when working on issues that cut across the entire repo it adds unnecessary cognitive load
* comment the one ambiguous call for future work (could receive a `JobDefinition` or `Job`)
   