### PR TITLE
chore: only set & test user on platforms that require it

### DIFF
--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -139,10 +139,15 @@ class LocalDockerAPI(ExecutorAPI):
             extra_args.extend(["--memory", job.memory_limit])
 
         if not volume_api.requires_root:
+            if config.DOCKER_USER_ID and config.DOCKER_GROUP_ID:
+                extra_args.extend(
+                    [
+                        "--user",
+                        f"{config.DOCKER_USER_ID}:{config.DOCKER_GROUP_ID}",
+                    ]
+                )
             extra_args.extend(
                 [
-                    "--user",
-                    f"{config.DOCKER_USER_ID}:{config.DOCKER_GROUP_ID}",
                     "-e",
                     "HOME=/tmp",  # set home dir to something writable by non-root user
                 ]

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -270,10 +270,13 @@ def test_execute_user_bindmount(
     )
 
     container_config = docker.container_inspect(local.container_name(job_definition))
-    assert (
-        container_config["Config"]["User"]
-        == f"{config.DOCKER_USER_ID}:{config.DOCKER_GROUP_ID}"
-    )
+
+    # do not test that this config is set on platforms that do not require this config
+    if config.DOCKER_USER_ID and config.DOCKER_GROUP_ID:
+        assert (
+            container_config["Config"]["User"]
+            == f"{config.DOCKER_USER_ID}:{config.DOCKER_GROUP_ID}"
+        )
     assert container_config["State"]["ExitCode"] == 0
 
 


### PR DESCRIPTION
* if it's set in config.py, use it. if it's not set, don't use garbage (it's always invalid to do `--user None:None`, obviously it's currently guarded elsewhere but I'm hoping to relax that in a follow-up)