### PR TITLE
feat: run tests on MacOS 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
   test-job:
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-20.04, windows-2019, macos-12]
         # Python 3.8 is what we currently support for running cohortextractor
         # locally, and 3.9 is what we required for databuilder so we need to make
         # sure we can run with those
@@ -46,6 +46,22 @@ jobs:
           cache: "pip"
           cache-dependency-path: requirements.*.txt
 
+      - name: Set up default Python 3.8 for MacOS
+        if: ${{ matrix.os == 'macos-12' && matrix.python != '3.8' }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          cache: "pip"
+          cache-dependency-path: requirements.*.txt
+
+      - name: install Docker/Colima on MacOS
+        if: ${{ matrix.os == 'macos-12' }}
+        run: brew install docker
+
+      - name: start Colima on MacOS
+        if: ${{ matrix.os == 'macos-12' }}
+        run: colima start
+
       - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # 1.4
 
       - name: Run actual tests on ${{ matrix.os }}
@@ -53,7 +69,7 @@ jobs:
         run: just test -vvv
 
       - name: Run actual tests on ${{ matrix.os }}
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2019' || matrix.os == 'macos-12' }}
         run: just test-no-docker -vvv
 
   test-package-build:


### PR DESCRIPTION
* even when running `just test-no-docker` some tests failed because they expected the presence of a docker executable
* use brew to install docker/[colima](https://github.com/abiosoft/colima) which allows these tests to pass
* use macos-12, because when I tried macos-13 I waited 40mins for a GHA runner to become available 😱 