### PR TITLE
feat: preserve logs of user cancelled jobs

### DIFF
--- a/docs/local_executor_run.md
+++ b/docs/local_executor_run.md
@@ -1,0 +1,165 @@
+# Local Executor state diagram
+
+This state diagram describes the amalgamation of `local_executor.py` and `run.py` to facilitate understanding changes that cut across both of them, this was really useful for @madwort when working on the intricacies of cancellation. Details should be verified with the current version of the code, and also cross-referenced with StubExecutor & the pytests.
+
+```mermaid
+stateDiagram
+    state1: Pending
+    state2: Prepared
+    state3: Executing
+    state4: Executed
+    state5: Finalized
+    state6: Job Succeeded
+    state7: Error
+    state8: Cancelled (Prepared)
+    state9: Cancelled (Executing)
+    state10: Job Failed
+    state11: Cancelled (Pending)
+    state12: Waiting (Various)
+    state13: Finalized (cancelled prepared)
+
+    note right of state2
+        volume exists
+        container does not exist
+        job.state RUNNING
+        job.status_code (should be) PREPARED
+        status.ExecutorState PREPARED
+        get_status().ExecutorState PREPARED
+        cancelled falsey
+    end note
+
+    note left of state3
+        volume exists
+        container exists
+        job.state RUNNING
+        job.status_code EXECUTING
+        status.ExecutorState EXECUTING
+        get_status().ExecutorState EXECUTING
+        cancelled falsey
+    end note
+
+    note left of state4
+        volume exists
+        container exists
+        job.state RUNNING
+        job.status_code EXECUTED
+        status.ExecutorState N/A
+        get_status().ExecutorState EXECUTED
+        cancelled falsey
+    end note
+
+    note left of state5
+        volume exists
+        container exists
+        job.state RUNNING
+        job.status_code FINALIZED
+        status.ExecutorState FINALIZED
+        get_status().ExecutorState FINALIZED
+    end note
+
+    note right of state6
+        volume does not exist
+        container does not exist
+        job.state SUCCEEDED
+        job.status_code SUCCEEDED
+        status.ExecutorState UNKNOWN?
+        get_status().ExecutorState UNKNOWN?
+        cancelled falsey
+    end note
+
+    note right of state7
+        volume exists
+        container exists
+        job.state RUNNING
+        job.status_code EXECUTED
+        status.ExecutorState N/A
+        get_status().ExecutorState EXECUTED
+        cancelled falsey
+    end note
+
+   note right of state8
+        volume exists
+        container does not exist
+        job.state RUNNING
+        job.status_code PREPARED
+        status.ExecutorState N/A
+        get_status().ExecutorState PREPARED
+        cancelled truthy
+    end note
+
+    note right of state9
+        volume exists
+        container exists
+        job.state RUNNING
+        job.status_code EXECUTING
+        status.ExecutorState EXECUTING
+        get_status().ExecutorState EXECUTING
+        cancelled truthy
+    end note
+
+    note right of state10
+        volume does not exist
+        container does not exist
+        job.state FAILED
+        job.status_code CANCELLED_BY_USER
+        status.ExecutorState UNKNOWN
+        get_status().ExecutorState UNKNOWN
+        cancelled truthy
+    end note
+
+    note right of state11
+        volume does not exist
+        container does not exists
+        job.state FAILED
+        job.status_code CANCELLED_BY_USER
+        status.ExecutorState UNKNOWN
+        get_status().ExecutorState UNKNOWN
+        cancelled truthy
+    end note
+
+    note right of state13
+        volume exists
+        container does not exists
+        job.state RUNNING
+        job.status_code FINALIZED
+        status.ExecutorState N/A
+        get_status().ExecutorState FINALIZED
+        cancelled truthy
+    end note
+    [*] --> state1: job created
+    state1 --> state12
+    state12 --> state1
+
+    state1 --> state2: prepare()
+
+    state2 --> state3: execute()
+    state2 --> state8: set cancelled
+
+
+    state execution_fail_fork_state <<choice>>
+    state3 --> execution_fail_fork_state
+    execution_fail_fork_state --> state4: job runs to completion
+    execution_fail_fork_state --> state7: job errors
+    state3 --> state9: set cancelled & run loop
+
+    state7 --> state4
+    state8 --> state13: job loop
+    state9 --> state4: terminate()
+    state4 --> state5: finalize()
+
+    state pre_cleanup <<join>>
+    state13 --> pre_cleanup
+    state5 --> pre_cleanup
+
+    state post_cleanup_fork <<choice>>
+    pre_cleanup --> post_cleanup_fork: cleanup()
+    post_cleanup_fork --> state6: cancelled is falsey
+    post_cleanup_fork --> state10: cancelled is truthy
+
+    state1 --> state11: set cancelled & run loop
+
+    state6 --> [*]
+    state10 --> [*]
+    state11 --> [*]
+
+```

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -248,9 +248,11 @@ TMP_DIR = WORKDIR / "temp"
 # docker specific exit codes we understand
 DOCKER_EXIT_CODES = {
     # 137 = 128+9, which means was killed by signal 9, SIGKILL
-    # Note: this can also mean killed by OOM killer, but that's explicitly
-    # handled already.
-    137: "Killed by an OpenSAFELY admin",
+    # This could be killed externally by an admin, or terminated through the
+    # cancellation process.
+    # Note: this can also mean killed by OOM killer, if the value of OOMKilled
+    # is incorrect (as sometimes recently observed)
+    137: "Job killed by OpenSAFELY admin or memory limits",
 }
 
 # BindMountVolumeAPI config

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -380,16 +380,16 @@ def finalize_job(job_definition):
     # that have db access
     message = None
 
+    if exit_code == 137 and job_definition.cancelled:
+        message = f"Job cancelled by {job_definition.cancelled}"
     # special case OOMKilled
     # Nb. this flag has been observed to be unreliable on some versions of Linux
-    if container_metadata["State"]["OOMKilled"]:
+    elif container_metadata["State"]["OOMKilled"]:
         message = "Ran out of memory"
         memory_limit = container_metadata.get("HostConfig", {}).get("Memory", 0)
         if memory_limit > 0:
             gb_limit = memory_limit / (1024**3)
             message += f" (limit for this job was {gb_limit:.2f}GB)"
-    elif exit_code == 137 and job_definition.cancelled:
-        message = f"Job cancelled by {job_definition.cancelled}"
     else:
         message = config.DOCKER_EXIT_CODES.get(exit_code)
 

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -86,6 +86,20 @@ def workspace_is_archived(workspace):
     return False
 
 
+def was_oomkilled(container):
+    # Nb. this flag has been observed to be unreliable on some versions of Linux
+    return container["State"]["ExitCode"] == 137 and container["State"]["OOMKilled"]
+
+
+def oomkilled_message(container):
+    message = "Job ran out of memory"
+    memory_limit = container.get("HostConfig", {}).get("Memory", 0)
+    if memory_limit > 0:
+        gb_limit = memory_limit / (1024**3)
+        message += f" (limit was {gb_limit:.2f}GB)"
+    return message
+
+
 class LocalDockerAPI(ExecutorAPI):
     """ExecutorAPI implementation using local docker service."""
 
@@ -282,14 +296,13 @@ class LocalDockerAPI(ExecutorAPI):
                     ExecutorState.EXECUTED,
                     f"Job cancelled by {job_definition.cancelled}",
                 )
+            if was_oomkilled(container):
+                return JobStatus(ExecutorState.ERROR, oomkilled_message(container))
             if container["State"]["ExitCode"] == 137:
-                if container["State"]["OOMKilled"]:
-                    return JobStatus(ExecutorState.ERROR, "Job ran out of memory")
-                else:
-                    return JobStatus(
-                        ExecutorState.ERROR,
-                        "Job either ran out of memory or was killed by an admin",
-                    )
+                return JobStatus(
+                    ExecutorState.ERROR,
+                    "Job either ran out of memory or was killed by an admin",
+                )
 
             timestamp_ns = datestr_to_ns_timestamp(container["State"]["FinishedAt"])
             return JobStatus(ExecutorState.EXECUTED, timestamp_ns=timestamp_ns)
@@ -392,14 +405,8 @@ def finalize_job(job_definition):
 
     if exit_code == 137 and job_definition.cancelled:
         message = f"Job cancelled by {job_definition.cancelled}"
-    # special case OOMKilled
-    # Nb. this flag has been observed to be unreliable on some versions of Linux
-    elif container_metadata["State"]["OOMKilled"]:
-        message = "Ran out of memory"
-        memory_limit = container_metadata.get("HostConfig", {}).get("Memory", 0)
-        if memory_limit > 0:
-            gb_limit = memory_limit / (1024**3)
-            message += f" (limit for this job was {gb_limit:.2f}GB)"
+    elif was_oomkilled(container_metadata):
+        message = oomkilled_message(container_metadata)
     else:
         message = config.DOCKER_EXIT_CODES.get(exit_code)
 

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -207,11 +207,15 @@ class ExecutorAPI:
 
     def terminate(self, job_definition: JobDefinition) -> JobStatus:
         """
-        Terminate a running job, transitioning to the ERROR state.
+        Terminate a running job, transitioning to the EXECUTED state.
 
         1. If any task for this job is running, terminate it, do not wait for it to complete.
 
-        2. Return ERROR state with a message.
+        2. Return EXECUTED state with a message.
+
+        Terminating a running job is considered an expected state, not an error state. This decision
+        also makes it easier for current executor implementations to cleanup after termination, and
+        is consistent with the handling of programs that exit of their own accord with a return code.
 
         """
 

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -32,6 +32,8 @@ class JobDefinition:
     allow_database_access: bool  # whether this job should have access to the database
     cpu_count: str = None  # number of CPUs to be allocated
     memory_limit: str = None  # memory limit to apply
+    # if a job has been cancelled, the name of the canceller - either "user" or "admin"
+    cancelled: str = None
 
 
 class ExecutorState(Enum):
@@ -192,6 +194,8 @@ class ExecutorAPI:
 
         The action log file and any useful metadata from the job run should also be written to a separate log storage
         area in long-term storage.
+
+        If the job has been cancelled, it should only preserve the action log file.
 
         When the finalize task finishes, the get_status() call should now return FINALIZED for this job, and
         get_results() call should return the JobResults for this job.

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -459,7 +459,10 @@ def test_finalize_failed_oomkilled(docker_cleanup, job_definition, tmp_work_dir)
     status = api.execute(job_definition)
 
     wait_for_state(api, job_definition, ExecutorState.ERROR)
-    assert api.get_status(job_definition).message == "Job ran out of memory"
+    assert (
+        api.get_status(job_definition).message
+        == "Job ran out of memory (limit was 0.01GB)"
+    )
 
     status = api.finalize(job_definition)
     assert status.state == ExecutorState.FINALIZED
@@ -471,7 +474,7 @@ def test_finalize_failed_oomkilled(docker_cleanup, job_definition, tmp_work_dir)
     # Note, 6MB is rounded to 0.01GBM by the formatter
     assert (
         local.RESULTS[job_definition.id].message
-        == "Ran out of memory (limit for this job was 0.01GB)"
+        == "Job ran out of memory (limit was 0.01GB)"
     )
 
     assert log_dir_log_file_exists(job_definition)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -160,17 +160,16 @@ def test_handle_pending_job_cancelled(db):
     api = StubExecutorAPI()
     job = api.add_test_job(ExecutorState.UNKNOWN, State.PENDING, cancelled=True)
 
-    assert job.id not in api.tracker["terminate"]
-    assert job.id not in api.tracker["finalize"]
-    assert job.id not in api.tracker["cleanup"]
-
     run.handle_job(job, api)
 
     # executor state
+    assert api.get_status(job).state == ExecutorState.UNKNOWN
+
+    assert job.id not in api.tracker["prepare"]
     assert job.id in api.tracker["terminate"]
     assert job.id not in api.tracker["finalize"]
+    assert job.id not in api.tracker["finalize_log_only"]
     assert job.id in api.tracker["cleanup"]
-    assert api.get_status(job).state == ExecutorState.UNKNOWN
 
     # our state
     assert job.state == State.FAILED
@@ -182,19 +181,16 @@ def test_handle_running_job_cancelled(db, monkeypatch):
     api = StubExecutorAPI()
     job = api.add_test_job(ExecutorState.EXECUTING, State.RUNNING, cancelled=True)
 
-    assert job.id not in api.tracker["terminate"]
-    assert job.id not in api.tracker["finalize"]
-    assert job.id not in api.tracker["cleanup"]
-
     run.handle_job(job, api)
 
     # executor state
-    assert job.id in api.tracker["terminate"]
-    assert job.id not in api.tracker["finalize"]
-    assert job.id in api.tracker["cleanup"]
-
     job_definition = run.job_to_job_definition(job)
     assert api.get_status(job_definition).state == ExecutorState.UNKNOWN
+
+    assert job.id in api.tracker["terminate"]
+    assert job.id not in api.tracker["finalize"]
+    assert job.id in api.tracker["finalize_log_only"]
+    assert job.id in api.tracker["cleanup"]
 
     # our state
     assert job.state == State.FAILED


### PR DESCRIPTION
* make lots of executor states more consistent, in two ways:
  * between different but related pathways (e.g. killed & cancelled jobs)
  * between statuses returned from action methods (e.g. `finalize()` and statuses returned from `get_status()`
* enable finalize to run in a "logs_only" mode for jobs that have been cancelled
 