### PR TITLE
feat: Alias ehrql to databduilder

### DIFF
--- a/jobrunner/cli/local_run.py
+++ b/jobrunner/cli/local_run.py
@@ -37,7 +37,7 @@ from pathlib import Path
 from pipeline import RUN_ALL_COMMAND, ProjectValidationError, load_pipeline
 
 from jobrunner import config, executors, tracing
-from jobrunner.actions import UnknownActionError
+from jobrunner.actions import UnknownActionError, resolve_aliases
 from jobrunner.create_or_update_jobs import (
     JobRequestError,
     NothingToDoError,
@@ -490,6 +490,7 @@ def create_job_request_and_jobs(project_dir, actions, force_run_dependencies):
         e.valid_actions = [RUN_ALL_COMMAND] + pipeline_config.all_actions
         raise e
     assert_new_jobs_created(job_request, new_jobs, latest_jobs_with_files_present)
+    resolve_aliases(new_jobs)
     resolve_reusable_action_references(new_jobs)
     insert_into_database(job_request, new_jobs)
     return job_request, new_jobs

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -76,11 +76,18 @@ else:
 ALLOWED_IMAGES = {
     "cohortextractor",
     "databuilder",
+    "ehrql",
     "stata-mp",
     "r",
     "jupyter",
     "python",
     "sqlrunner",
+}
+
+IMAGE_ALIASES = {
+    # Alias ehrql to databuilder
+    # This should be removed when the databuilder -> ehrql renaming work is complete
+    "ehrql": "databuilder"
 }
 
 DOCKER_REGISTRY = os.environ.get("DOCKER_REGISTRY", "ghcr.io/opensafely-core")

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -13,7 +13,7 @@ import time
 from pipeline import RUN_ALL_COMMAND, ProjectValidationError, load_pipeline
 
 from jobrunner import config, tracing
-from jobrunner.actions import get_action_specification
+from jobrunner.actions import get_action_specification, resolve_aliases
 from jobrunner.lib.database import exists_where, insert, transaction, update_where
 from jobrunner.lib.git import GitError, GitFileNotFoundError, read_file_from_repo
 from jobrunner.lib.github_validators import (
@@ -89,6 +89,7 @@ def create_jobs(job_request):
     )
     new_jobs = get_new_jobs_to_run(job_request, pipeline_config, latest_jobs)
     assert_new_jobs_created(job_request, new_jobs, latest_jobs)
+    resolve_aliases(new_jobs)
     resolve_reusable_action_references(new_jobs)
     # There is a delay between getting the current jobs (which we fetch from
     # the database and the disk) and inserting our new jobs below. This means

--- a/jobrunner/extractors.py
+++ b/jobrunner/extractors.py
@@ -9,7 +9,7 @@ def is_extraction_command(args, require_version=None):
         if args[0].startswith("cohortextractor:"):
             version_found = 1
         # databuilder is a rebranded cohortextractor-v2.
-        elif args[0].startswith("databuilder:"):
+        elif args[0].startswith("databuilder:") or args[0].startswith("ehrql:"):
             version_found = 2
 
     # If we're not looking for a specific version then return True if any

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -9,6 +9,8 @@ from jobrunner.extractors import is_extraction_command
         (1, ["cohortextractor:latest", "generate_cohort"], True),
         (1, ["cohortextractor-v2:latest", "generate_cohort"], False),
         (1, ["databuilder:latest", "generate_dataset"], False),
+        # ehrql is aliased to databuilder
+        (2, ["ehrql:v0", "generate_dataset"], True),
         (2, ["cohortextractor:latest", "generate_cohort"], False),
         # cohortextractor-v2 is no longer supported
         (2, ["cohortextractor-v2:latest", "generate_cohort"], False),
@@ -28,6 +30,8 @@ def test_is_extraction_command_with_version(args, require_version, desired_outco
         # cohortextractor-v2 is no longer supported
         (["cohortextractor-v2:latest", "generate_cohort"], False),
         (["databuilder:latest", "generate_dataset"], True),
+        # ehrql is aliased to databuilder
+        (["ehrql:v0", "generate_dataset"], True),
         (["test"], False),
         (["test", "generate_cohort"], False),
         (["test", "generate_dataset"], False),


### PR DESCRIPTION
This is a temporary measure until the work to rename databuilder to ehrql is complete. It means that users can write ehrql:v0 in their project.yaml and opensafely exec commands now

See also https://github.com/opensafely-core/opensafely-cli/pull/201 (which depends on this PR, and updated vendored code)