### PR TITLE
feat: Add ehrql to allowed images

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -76,6 +76,7 @@ else:
 ALLOWED_IMAGES = {
     "cohortextractor",
     "databuilder",
+    "ehrql",
     "stata-mp",
     "r",
     "jupyter",

--- a/jobrunner/extractors.py
+++ b/jobrunner/extractors.py
@@ -9,7 +9,7 @@ def is_extraction_command(args, require_version=None):
         if args[0].startswith("cohortextractor:"):
             version_found = 1
         # databuilder is a rebranded cohortextractor-v2.
-        elif args[0].startswith("databuilder:"):
+        elif args[0].startswith("databuilder:") or args[0].startswith("ehrql:"):
             version_found = 2
 
     # If we're not looking for a specific version then return True if any

--- a/jobrunner/lib/commands.py
+++ b/jobrunner/lib/commands.py
@@ -5,6 +5,7 @@ def requires_db_access(args):
     valid_commands = {
         "cohortextractor": ("generate_cohort", "generate_codelist_report"),
         "databuilder": ("generate-dataset",),
+        "ehrql": ("generate-dataset",),
         "sqlrunner": None,  # all commands are valid
     }
     if len(args) <= 1:

--- a/scripts/update-docker-image.sh
+++ b/scripts/update-docker-image.sh
@@ -10,4 +10,13 @@ docker pull docker-proxy.opensafely.org/opensafely-core/$1
 docker tag docker-proxy.opensafely.org/opensafely-core/$1 ghcr.io/opensafely-core/$1
 # temp b/w compat tag
 docker tag docker-proxy.opensafely.org/opensafely-core/$1 ghcr.io/opensafely/$1
+
+# If the image being updated is databuilder, make sure we get the aliased ehrql tag too
+if [[ $1 == databuilder* ]]; then
+  image=$(echo "$1" | sed -r 's/[databuilder]+/ehrql/g')
+  echo "Updating ehrql image: $image"
+  docker pull docker-proxy.opensafely.org/opensafely-core/$image
+  docker tag docker-proxy.opensafely.org/opensafely-core/$image ghcr.io/opensafely-core/$image
+fi
+
 docker image prune --force

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -9,10 +9,12 @@ from jobrunner.extractors import is_extraction_command
         (1, ["cohortextractor:latest", "generate_cohort"], True),
         (1, ["cohortextractor-v2:latest", "generate_cohort"], False),
         (1, ["databuilder:latest", "generate_dataset"], False),
+        (1, ["ehrql:v0", "generate_dataset"], False),
         (2, ["cohortextractor:latest", "generate_cohort"], False),
         # cohortextractor-v2 is no longer supported
         (2, ["cohortextractor-v2:latest", "generate_cohort"], False),
         (2, ["databuilder:latest", "generate_dataset"], True),
+        (2, ["ehrql:v0", "generate_dataset"], True),
     ],
 )
 def test_is_extraction_command_with_version(args, require_version, desired_outcome):
@@ -28,6 +30,7 @@ def test_is_extraction_command_with_version(args, require_version, desired_outco
         # cohortextractor-v2 is no longer supported
         (["cohortextractor-v2:latest", "generate_cohort"], False),
         (["databuilder:latest", "generate_dataset"], True),
+        (["ehrql:v0", "generate_dataset"], True),
         (["test"], False),
         (["test", "generate_cohort"], False),
         (["test", "generate_dataset"], False),


### PR DESCRIPTION
ehrql now tags its images with both `databuilder` and `ehrql`: https://github.com/opensafely-core/ehrql/pull/1214

This means that users can use `ehrql:v0` in their project.yaml and in `opensafely exec` in place of databuilder, before we've completed the full renaming.

(Also requires an opensafely-cli PR after this one is merged)