### PR TITLE
Use custom network to restrict network access for db jobs

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -277,3 +277,10 @@ if sys.platform == "linux":
 else:
     DOCKER_USER_ID = None
     DOCKER_GROUP_ID = None
+
+
+# The name of a Docker network configured to allow access to just the database and
+# nothing else. Setup and configuration of this network is expected to be managed
+# externally. See:
+# https://github.com/opensafely-core/backend-server/pull/105
+DATABASE_ACCESS_NETWORK = os.environ.get("DATABASE_ACCESS_NETWORK", "jobrunner-db")

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -139,6 +139,10 @@ class LocalDockerAPI(ExecutorAPI):
             extra_args.extend(["--cpus", str(job_definition.cpu_count)])
         if job_definition.memory_limit:
             extra_args.extend(["--memory", job_definition.memory_limit])
+        # We use a custom Docker network configured so that database jobs can access the
+        # database and nothing else
+        if job_definition.allow_database_access and config.DATABASE_ACCESS_NETWORK:
+            extra_args.extend(["--network", config.DATABASE_ACCESS_NETWORK])
 
         if not volume_api.requires_root:
             if config.DOCKER_USER_ID and config.DOCKER_GROUP_ID:


### PR DESCRIPTION
For the mechanism which creates and configures this network see:
 * https://github.com/opensafely-core/backend-server/pull/105
