### PR TITLE
fix: use correct docker label for mount-job-volume

### DIFF
--- a/scripts/mount-job-volume.sh
+++ b/scripts/mount-job-volume.sh
@@ -29,7 +29,7 @@ fi
 volume_list="$(
   docker volume ls \
     --filter "name=$name_search" \
-    --filter 'label=job-runner' \
+    --filter 'label=jobrunner-local' \
     --format='{{.Name}}'
 )"
 volume_array=($volume_list)


### PR DESCRIPTION
* this was found on the production service