### PR TITLE
Use (hopefully) fairer job processing order

### DIFF
--- a/jobrunner/cli/local_run.py
+++ b/jobrunner/cli/local_run.py
@@ -251,8 +251,6 @@ def create_and_run_jobs(
 ):
     # Fiddle with the configuration to suit what we need for running local jobs
     docker.LABEL = docker_label
-    # It's more helpful in this context to have things consistent
-    config.RANDOMISE_JOB_ORDER = False
     config.HIGH_PRIVACY_WORKSPACES_DIR = project_dir.parent
     config.DATABASE_FILE = project_dir / "metadata" / "db.sqlite"
     config.TMP_DIR = temp_dir

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -127,12 +127,6 @@ MAX_WORKERS = int(os.environ.get("MAX_WORKERS") or max(cpu_count() - 1, 1))
 MAX_DB_WORKERS = int(os.environ.get("MAX_DB_WORKERS") or MAX_WORKERS)
 MAX_RETRIES = int(os.environ.get("MAX_RETRIES", 0))
 
-# This is a crude mechanism for preventing a single large JobRequest with lots
-# of associated Jobs from hogging all the resources. We want this configurable
-# because it's useful to be able to disable this during tests and when running
-# locally
-RANDOMISE_JOB_ORDER = True
-
 
 STATA_LICENSE = os.environ.get("STATA_LICENSE")
 STATA_LICENSE_REPO = os.environ.get(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -55,8 +55,6 @@ def test_integration_with_cohortextractor(
     )
     # Disable repo URL checking so we can run using a local test repo
     monkeypatch.setattr("jobrunner.config.ALLOWED_GITHUB_ORGS", None)
-    # Make job execution order deterministic
-    monkeypatch.setattr("jobrunner.config.RANDOMISE_JOB_ORDER", False)
 
     if extraction_tool == "cohortextractor":
         image = "cohortextractor"
@@ -234,8 +232,6 @@ def test_integration_with_databuilder(
     )
     # Disable repo URL checking so we can run using a local test repo
     monkeypatch.setattr("jobrunner.config.ALLOWED_GITHUB_ORGS", None)
-    # Make job execution order deterministic
-    monkeypatch.setattr("jobrunner.config.RANDOMISE_JOB_ORDER", False)
 
     ensure_docker_images_present("databuilder:v0.36.0", "python")
 


### PR DESCRIPTION
Instead of randomising we now order jobs by how many jobs are already running in that jobs workspace, and then by age.

There are many things other than workspace we could partition on (e.g. user, project, organisation) but workspace is directly available on the job object, is easy to explain, and doesn't have the effect of penalising users who have to work on several different things.

Note that this doesn't prevent a large job request from grabbing all available slots if nothing else is running when it is submitted. But it does mean that the next slot that becomes free will go to a job from a different workspace.

Because the number of running jobs will change as we work our way through the set of active jobs we have to update the counts and re-sort the jobs on each iteration. This is not the most beautiful code, but I think it does the job.

In order for this to work correctly, we need job processing to happen in two phases. First, check up on all the running jobs, see if any have finished, and establish how much capacity we have. Then distribute this capacity fairly among the pending jobs. We achieve this by sorting first on `status == RUNNING`. This ensures that we handle all running jobs before we handle any pending jobs.