### PR TITLE
Add telemetry to the stats collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dynamic_context = "test_function"
 source = ["jobrunner"]
 
 [tool.coverage.report]
-fail_under = 78
+fail_under = 80
 show_missing = true
 skip_covered = true
 


### PR DESCRIPTION
We're sometimes seeing missing metrics for some jobs. This addes a lot
more data to the tick traces so we can try diagnose why we have missing
metrics.

Part of #634
