### PR TITLE
Sort jobs by if they need db or not

### DIFF
--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -82,6 +82,8 @@ def handle_jobs(api: Optional[ExecutorAPI]):
                 # workspace. This gives a fairer allocation of capacity among
                 # workspaces.
                 running_for_workspace[job.workspace],
+                # DB jobs are more important than cpu jobs
+                0 if job.requires_db else 1,
                 # Finally use job age as a tie-breaker
                 job.created_at,
             )


### PR DESCRIPTION
This adds a natural priority to db jobs, ensuring they will always be
considered before cpu jobs.

Currently, enough cpu jobs to hit MAX_WORKERS will block db jobs from
starting, as they will be considered first.

Note, this is still sorted *after* workspace, so the fairness is still
preserved.

There are not tests for this, as this code currently has no test
coverage, as its a bit fiddly to implement.

Pulling in the bug fix from other branch, as its affect tests here, but am waiting on review for that branch
