### PR TITLE
Fix missing job metrics

### DIFF
--- a/jobrunner/lib/docker_stats.py
+++ b/jobrunner/lib/docker_stats.py
@@ -6,6 +6,13 @@ from jobrunner.lib.subprocess_utils import subprocess_run
 DEFAULT_TIMEOUT = 10
 
 
+# backport of 3.9s removeprefix
+def removeprefix(s, prefix):
+    if s.startswith(prefix):
+        return s[len(prefix) :]
+    return s
+
+
 def get_job_stats(timeout=DEFAULT_TIMEOUT):
     # TODO: add volume sizes
     return get_container_stats(DEFAULT_TIMEOUT)
@@ -20,7 +27,7 @@ def get_container_stats(timeout=DEFAULT_TIMEOUT):
     )
     data = [json.loads(line) for line in response.stdout.splitlines()]
     return {
-        row["Name"].lstrip("os-job-"): {
+        removeprefix(row["Name"], "os-job-"): {
             "cpu_percentage": float(row["CPUPerc"].rstrip("%")),
             "memory_used": _parse_size(row["MemUsage"].split()[0]),
         }

--- a/tests/lib/test_docker_stats.py
+++ b/tests/lib/test_docker_stats.py
@@ -9,3 +9,13 @@ def test_get_container_stats(docker_cleanup):
     containers = docker_stats.get_container_stats()
     assert isinstance(containers["test"]["cpu_percentage"], float)
     assert isinstance(containers["test"]["memory_used"], int)
+
+
+@pytest.mark.needs_docker
+def test_get_container_stats_regression(docker_cleanup):
+    # we had a bug where we use str.lstrip("os-job-") :facepalm"
+    # id starts with o
+    docker.run("os-job-otest", [docker.MANAGEMENT_CONTAINER_IMAGE, "sleep", "10"])
+    containers = docker_stats.get_container_stats()
+    assert isinstance(containers["otest"]["cpu_percentage"], float)
+    assert isinstance(containers["otest"]["memory_used"], int)


### PR DESCRIPTION
We use `str.lstrip("os-job-")` to filter the list of metrics. However,
strip doesnt work like that, a fact that has bitten me many times
previously.

It meant that if a job id started with any of the 'osjb' characters, it
would be stripped from the id in the dict, leadint to it not being
found.

Sadly, we're on 3.8, so we can't use removeprefix, so we fake it.

This was found by the added telemetry in earlier PR, but also needed
some cowboyed additonal bits in prod, to confirm, now undone.
