### PR TITLE
Remove old database names and add new ones

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -20,16 +20,7 @@ MEDIUM_PRIVACY_STORAGE_BASE=/workdir/workspaces
 # A Github developer token that has read access to private repos
 PRIVATE_REPO_ACCESS_TOKEN=
 
-# A database containing dummy data; results from this could be freely
-# published without review
-DUMMY_DATABASE_URL=mssql+pyodbc://xxxx
-
-# A database containing a slice of the full data; useful for checking
-# or debuggin real data without potentially having to wait for hours
-# for completion
-SLICE_DATABASE_URL=mssql+pyodbc://xxxx
-
-# The full database
+# The DSN for accessing the database
 FULL_DATABASE_URL=mssql+pyodbc://xxxx
 
 # Database in which we can create temporary tables

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -88,8 +88,6 @@ DOCKER_REGISTRY = os.environ.get("DOCKER_REGISTRY", "ghcr.io/opensafely-core")
 
 DATABASE_URLS = {
     "full": os.environ.get("FULL_DATABASE_URL"),
-    "slice": os.environ.get("SLICE_DATABASE_URL"),
-    "dummy": os.environ.get("DUMMY_DATABASE_URL"),
 }
 
 TEMP_DATABASE_NAME = os.environ.get("TEMP_DATABASE_NAME")

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -86,8 +86,14 @@ ALLOWED_IMAGES = {
 
 DOCKER_REGISTRY = os.environ.get("DOCKER_REGISTRY", "ghcr.io/opensafely-core")
 
+db_names = ["full", "default", "include_t1oo"]
 DATABASE_URLS = {
-    "full": os.environ.get("FULL_DATABASE_URL"),
+    db_name: db_url
+    for db_name, db_url in [
+        (db_name, os.environ.get("{db_name.upper()}_DATABASE_URL"))
+        for db_name in db_names
+    ]
+    if db_url
 }
 
 TEMP_DATABASE_NAME = os.environ.get("TEMP_DATABASE_NAME")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -59,7 +59,7 @@ def add_maintenance_command(mock_subprocess_run, current):
     )
 
 
-def test_maintenance_mode_off(mock_subprocess_run, db):
+def test_maintenance_mode_off(mock_subprocess_run, db, db_config):
     ps = add_maintenance_command(mock_subprocess_run, current=None)
     ps.stdout = ""
     assert service.maintenance_mode() is None
@@ -70,7 +70,7 @@ def test_maintenance_mode_off(mock_subprocess_run, db):
     assert service.maintenance_mode() is None
 
 
-def test_maintenance_mode_on(mock_subprocess_run, db):
+def test_maintenance_mode_on(mock_subprocess_run, db, db_config):
     ps = add_maintenance_command(mock_subprocess_run, current=None)
     ps.stdout = "db-maintenance"
     ps.stderr = "other stuff"
@@ -83,7 +83,7 @@ def test_maintenance_mode_on(mock_subprocess_run, db):
     assert service.maintenance_mode() == "db-maintenance"
 
 
-def test_maintenance_mode_error(mock_subprocess_run, db):
+def test_maintenance_mode_error(mock_subprocess_run, db, db_config):
     ps = add_maintenance_command(mock_subprocess_run, current=None)
     ps.returncode = 1
     ps.stdout = ""
@@ -91,3 +91,8 @@ def test_maintenance_mode_error(mock_subprocess_run, db):
 
     with pytest.raises(subprocess.CalledProcessError):
         service.maintenance_mode()
+
+
+@pytest.fixture
+def db_config(monkeypatch):
+    monkeypatch.setitem(config.DATABASE_URLS, "full", "mssql://localhost")


### PR DESCRIPTION
This is preparatory as the new ones are not yet in use. We also change the configuration behaviour so that database names are now only added to the config if a value for them exists in the environment. This means that job-runner instances will refuse to accept job requests for databases they have not been configured to run, rather than accepting the job and then throwing an error later.