### PR TITLE
chore: remove unused force_run_failed

### DIFF
--- a/jobrunner/cli/local_run.py
+++ b/jobrunner/cli/local_run.py
@@ -450,9 +450,6 @@ def create_job_request_and_jobs(project_dir, actions, force_run_dependencies):
         workspace=project_dir.name,
         database_name="dummy",
         force_run_dependencies=force_run_dependencies,
-        # The default behaviour of refusing to run if a dependency has failed
-        # makes for an awkward workflow when iterating in development
-        force_run_failed=True,
         branch="",
         original={"created_by": getuser()},
     )

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -103,7 +103,6 @@ class JobRequest:
     workspace: str
     database_name: str
     force_run_dependencies: bool = False
-    force_run_failed: bool = False
     branch: str = None
     original: dict = None
 


### PR DESCRIPTION
* this is redundant as of https://github.com/opensafely-core/job-runner/pull/657