### PR TITLE
Fix add_job cli command

### DIFF
--- a/jobrunner/cli/add_job.py
+++ b/jobrunner/cli/add_job.py
@@ -5,6 +5,7 @@ job-server
 import argparse
 import dataclasses
 import pprint
+import sys
 import textwrap
 from pathlib import Path
 from urllib.parse import urlparse
@@ -36,6 +37,7 @@ def main(
             requested_actions=actions,
             force_run_dependencies=force_run_dependencies,
             cancelled_actions=[],
+            codelists_ok=True,
         )
     )
     print("Submitting JobRequest:\n")
@@ -45,6 +47,8 @@ def main(
     print(f"Created {len(jobs)} new jobs:\n")
     for job in jobs:
         display_obj(job)
+
+    return job_request, jobs
 
 
 def display_obj(obj):
@@ -57,7 +61,10 @@ def display_obj(obj):
     print()
 
 
-def run():
+def run(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
     configure_logging()
     parser = argparse.ArgumentParser(description=__doc__.partition("\n\n")[0])
     parser.add_argument("repo_url", help="URL (or local path) of git repository")
@@ -82,8 +89,8 @@ def run():
     )
     parser.add_argument("-f", "--force-run-dependencies", action="store_true")
 
-    args = parser.parse_args()
-    main(**vars(args))
+    args = parser.parse_args(argv)
+    return main(**vars(args))
 
 
 if __name__ == "__main__":

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -114,7 +114,8 @@ def create_jobs(job_request):
 
 
 def validate_job_request(job_request):
-    if config.ALLOWED_GITHUB_ORGS:
+    # http prefix allows local git repos, useful for tests
+    if job_request.repo_url.startswith("http") and config.ALLOWED_GITHUB_ORGS:
         validate_repo_url(job_request.repo_url, config.ALLOWED_GITHUB_ORGS)
     if not job_request.requested_actions:
         raise JobRequestError("At least one action must be supplied")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dynamic_context = "test_function"
 source = ["jobrunner"]
 
 [tool.coverage.report]
-fail_under = 80
+fail_under = 82
 show_missing = true
 skip_covered = true
 

--- a/tests/cli/test_add_job.py
+++ b/tests/cli/test_add_job.py
@@ -1,0 +1,14 @@
+from jobrunner.cli import add_job
+from jobrunner.lib import database
+from jobrunner.models import Job
+
+
+def test_add_job(tmp_work_dir, db, test_repo):
+    job_request, jobs = add_job.run([str(test_repo.path), "generate_dataset"])
+
+    assert len(jobs) == 1
+    assert jobs[0].action == "generate_dataset"
+
+    db_jobs = database.find_where(Job, job_request_id=job_request.id)
+    assert len(db_jobs) == 1
+    assert db_jobs[0].action == "generate_dataset"


### PR DESCRIPTION
This was not previously covered in tests, and it broke with the codelist
checking changes.  It's used in the backed-server test suite, which is
how I noticed.

If fixed, and added test coverage, which allowed me to bump the coverge
minimum a bit.
