### PR TITLE
Set Job.completed_at when cancelling

### DIFF
--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -380,7 +380,10 @@ def set_cancelled_flag_for_actions(job_request_id, actions):
     # working.
     update_where(
         Job,
-        {"cancelled": True},
+        {
+            "cancelled": True,
+            "completed_at": int(time.time()),
+        },
         job_request_id=job_request_id,
         action__in=actions,
     )


### PR DESCRIPTION
We set this for failed and successful jobs, but not for cancelled actions, despite them being treated as failed jobs.  This fixes that.

Ref: opensafely-core/job-server#3770