### PR TITLE
Collect, store and send aggregate metrics, take 2

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -46,6 +46,7 @@ if GIT_SHA == "unknown":
 
 WORKDIR = Path(os.environ.get("WORKDIR", default_work_dir)).resolve()
 DATABASE_FILE = WORKDIR / "db.sqlite"
+METRICS_FILE = WORKDIR / "metrics.sqlite"
 GIT_REPO_DIR = WORKDIR / "repos"
 
 # valid archive formats

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from pipeline.legacy import get_all_output_patterns_from_project_file
 
-from jobrunner import config
+from jobrunner import config, record_stats
 from jobrunner.executors import volumes
 from jobrunner.job_executor import (
     ExecutorAPI,
@@ -241,16 +241,24 @@ class LocalDockerAPI(ExecutorAPI):
                 f"docker timed out after {timeout}s inspecting container {name}"
             )
 
+        metrics = record_stats.read_job_metrics(job_definition.id)
+
         if container is None:  # container doesn't exist
             if job_definition.cancelled:
                 if volumes.get_volume_api(job_definition).volume_exists(job_definition):
                     # jobs prepared but not running do not need to finalize, so we
                     # proceed directly to the FINALIZED state here
                     return JobStatus(
-                        ExecutorState.FINALIZED, "Prepared job was cancelled"
+                        ExecutorState.FINALIZED,
+                        "Prepared job was cancelled",
+                        metrics=metrics,
                     )
                 else:
-                    return JobStatus(ExecutorState.UNKNOWN, "Pending job was cancelled")
+                    return JobStatus(
+                        ExecutorState.UNKNOWN,
+                        "Pending job was cancelled",
+                        metrics=metrics,
+                    )
 
             # timestamp file presence means we have finished preparing
             timestamp_ns = volumes.get_volume_api(job_definition).read_timestamp(
@@ -261,24 +269,31 @@ class LocalDockerAPI(ExecutorAPI):
             # re-prepare it anyway.
             if timestamp_ns is None:
                 # we are Jon Snow
-                return JobStatus(ExecutorState.UNKNOWN)
+                return JobStatus(ExecutorState.UNKNOWN, metrics={})
             else:
                 # we've finish preparing
-                return JobStatus(ExecutorState.PREPARED, timestamp_ns=timestamp_ns)
+                return JobStatus(
+                    ExecutorState.PREPARED, timestamp_ns=timestamp_ns, metrics=metrics
+                )
 
         if container["State"]["Running"]:
             timestamp_ns = datestr_to_ns_timestamp(container["State"]["StartedAt"])
-            return JobStatus(ExecutorState.EXECUTING, timestamp_ns=timestamp_ns)
+            return JobStatus(
+                ExecutorState.EXECUTING, timestamp_ns=timestamp_ns, metrics=metrics
+            )
         elif job_definition.id in RESULTS:
             return JobStatus(
                 ExecutorState.FINALIZED,
                 timestamp_ns=RESULTS[job_definition.id].timestamp_ns,
+                metrics=metrics,
             )
         else:
             # container present but not running, i.e. finished
             # Nb. this does not include prepared jobs, as they have a volume but not a container
             timestamp_ns = datestr_to_ns_timestamp(container["State"]["FinishedAt"])
-            return JobStatus(ExecutorState.EXECUTED, timestamp_ns=timestamp_ns)
+            return JobStatus(
+                ExecutorState.EXECUTED, timestamp_ns=timestamp_ns, metrics=metrics
+            )
 
     def get_results(self, job_definition):
         if job_definition.id not in RESULTS:

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -67,6 +67,7 @@ class JobStatus:
     timestamp_ns: int = (
         None  # timestamp this JobStatus occurred, in integer nanoseconds
     )
+    metrics: dict = field(default_factory=dict)
 
 
 @dataclass

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -14,6 +14,7 @@ import hashlib
 import secrets
 import shlex
 from enum import Enum
+from functools import total_ordering
 
 from jobrunner.lib.commands import requires_db_access
 from jobrunner.lib.database import databaseclass, migration
@@ -36,6 +37,7 @@ class State(Enum):
 # affordances in the web, cli and telemetry.
 
 
+@total_ordering
 class StatusCode(Enum):
     # PENDING states
     #
@@ -76,6 +78,10 @@ class StatusCode(Enum):
     @property
     def is_final_code(self):
         return self in StatusCode._FINAL_STATUS_CODES
+
+    def __lt__(self, other):
+        order = list(self.__class__)
+        return order.index(self) < order.index(other)
 
 
 # used for tracing to know if a state is final or not
@@ -245,6 +251,7 @@ class Job:
     # used to track the OTel trace context for this job
     trace_context: dict = None
 
+    # map of file -> error
     level4_excluded_files: dict = None
 
     # used to cache the job_request json by the tracing code

--- a/jobrunner/record_stats.py
+++ b/jobrunner/record_stats.py
@@ -9,6 +9,7 @@ import sys
 import threading
 import time
 from collections import defaultdict
+from pathlib import Path
 
 from opentelemetry import trace
 
@@ -38,9 +39,10 @@ def get_connection(readonly=True):
 
     # developer check against using memory dbs, which cannot be used with this
     # function, as we need to set mode ourselves
-    assert not db_file.startswith(
+    assert isinstance(db_file, Path), "config.METRICS_FILE db must be file path"
+    assert not str(db_file).startswith(
         "file:"
-    ), "urls not supported for metrics db - must be path"
+    ), "config.METRICS_FILE db must be file path, not url"
 
     if readonly:
         db = f"file:{db_file}?mode=ro"

--- a/jobrunner/record_stats.py
+++ b/jobrunner/record_stats.py
@@ -1,10 +1,12 @@
 """
 Super crude docker/system stats logger
 """
+import json
 import logging
 import subprocess
 import sys
 import time
+from collections import defaultdict
 
 from opentelemetry import trace
 
@@ -17,12 +19,62 @@ from jobrunner.lib.log_utils import configure_logging
 log = logging.getLogger(__name__)
 tracer = trace.get_tracer("ticks")
 
+# Simplest possible table. We're only storing aggregate data
+DDL = """
+CREATE TABLE IF NOT EXISTS jobs (
+    id TEXT,
+    metrics TEXT,
+    PRIMARY KEY (id)
+)
+"""
+
+_conn = None
+
+
+def ensure_metrics_db():
+    global _conn
+    _conn = database.get_connection(config.METRICS_FILE)
+    _conn.execute("PRAGMA journal_mode = WAL")
+    _conn.execute(DDL)
+
+
+def read_job_metrics(job_id, **metrics):
+    if _conn is None:
+        ensure_metrics_db()
+
+    raw_metrics = _conn.execute(
+        "SELECT metrics FROM jobs WHERE id = ?",
+        (job_id,),
+    ).fetchone()
+    if raw_metrics is None:
+        metrics = {}
+    else:
+        metrics = json.loads(raw_metrics["metrics"])
+    return defaultdict(float, metrics)
+
+
+def write_job_metrics(job_id, metrics):
+    if _conn is None:
+        ensure_metrics_db()
+
+    raw_metrics = json.dumps(metrics)
+    _conn.execute(
+        """
+        INSERT INTO jobs (id, metrics) VALUES (?, ?)
+        ON CONFLICT(id) DO UPDATE set metrics = ?
+        """,
+        (job_id, raw_metrics, raw_metrics),
+    )
+
 
 def main():
     last_run = None
     while True:
         before = time.time()
-        last_run = record_tick_trace(last_run)
+        active_jobs = database.find_where(
+            models.Job, state__in=[models.State.PENDING, models.State.RUNNING]
+        )
+        last_run = record_tick_trace(last_run, active_jobs)
 
         # record_tick_trace might have take a while, so sleep the remainding interval
         # enforce a minimum time of 3s to ensure we don't hammer honeycomb or
@@ -31,7 +83,7 @@ def main():
         time.sleep(max(2, config.STATS_POLL_INTERVAL - elapsed))
 
 
-def record_tick_trace(last_run):
+def record_tick_trace(last_run, active_jobs):
     """Record a period tick trace of current jobs.
 
     This will give us more realtime information than the job traces, which only
@@ -69,10 +121,7 @@ def record_tick_trace(last_run):
     # every span has the same timings
     start_time = last_run
     end_time = now
-
-    active_jobs = database.find_where(
-        models.Job, state__in=[models.State.PENDING, models.State.RUNNING]
-    )
+    duration_s = int((end_time - start_time) / 1e9)
 
     with tracer.start_as_current_span(
         "TICK", start_time=start_time, attributes=trace_attrs
@@ -82,20 +131,59 @@ def record_tick_trace(last_run):
             root.add_event("stats_error", attributes=error_attrs, timestamp=start_time)
 
         for job in active_jobs:
-            span = tracer.start_span(job.status_code.name, start_time=start_time)
+            # we are using seconds for our metric calculations
+
+            metrics = stats.get(job.id, {})
 
             # set up attributes
             job_span_attrs = {}
             job_span_attrs.update(trace_attrs)
-            metrics = stats.get(job.id, {})
             job_span_attrs["has_metrics"] = metrics != {}
             job_span_attrs.update(metrics)
 
+            # this means the job is running
+            if metrics:
+                runtime_s = int(now / 1e9) - job.started_at
+                # protect against unexpected runtimes
+                if runtime_s > 0:
+                    job_metrics = update_job_metrics(
+                        job,
+                        metrics,
+                        duration_s,
+                        runtime_s,
+                    )
+                    job_span_attrs.update(job_metrics)
+                else:
+                    job_span_attrs.set("bad_tick_runtime", runtime_s)
+
             # record span
+            span = tracer.start_span(job.status_code.name, start_time=start_time)
             tracing.set_span_metadata(span, job, **job_span_attrs)
             span.end(end_time)
 
     return end_time
+
+
+def update_job_metrics(job, raw_metrics, duration_s, runtime_s):
+    """Update and persist per-job aggregate stats in the metrics db"""
+
+    job_metrics = read_job_metrics(job.id)
+
+    cpu = raw_metrics["cpu_percentage"]
+    mem = raw_metrics["memory_used"]
+
+    job_metrics["cpu_sample"] = cpu
+    job_metrics["cpu_cumsum"] += duration_s * cpu
+    job_metrics["cpu_mean"] = job_metrics["cpu_cumsum"] / runtime_s
+    job_metrics["cpu_peak"] = max(job_metrics["cpu_peak"], cpu)
+    job_metrics["mem_sample"] = mem
+    job_metrics["mem_cumsum"] += duration_s * mem
+    job_metrics["mem_mean"] = job_metrics["mem_cumsum"] / runtime_s
+    job_metrics["mem_peak"] = max(job_metrics["mem_peak"], mem)
+
+    write_job_metrics(job.id, job_metrics)
+
+    return job_metrics
 
 
 if __name__ == "__main__":

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -9,7 +9,7 @@ import time
 
 import requests
 
-from jobrunner import config, queries
+from jobrunner import config, queries, record_stats
 from jobrunner.create_or_update_jobs import create_or_update_jobs
 from jobrunner.lib.database import find_where, select_values
 from jobrunner.lib.log_utils import configure_logging, set_log_context
@@ -143,19 +143,21 @@ def job_to_remote_format(job):
     Convert our internal representation of a Job into whatever format the
     job-server expects
     """
+
     return {
         "identifier": job.id,
         "job_request_id": job.job_request_id,
         "action": job.action,
         "run_command": job.run_command,
         "status": job.state.value,
-        "status_code": job.status_code.value if job.status_code else "",
+        "status_code": job.status_code.value,
         "status_message": job.status_message or "",
         "created_at": job.created_at_isoformat,
         "updated_at": job.updated_at_isoformat,
         "started_at": job.started_at_isoformat,
         "completed_at": job.completed_at_isoformat,
         "trace_context": job.trace_context,
+        "metrics": record_stats.read_job_metrics(job.id),
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,14 +196,15 @@ def db(monkeypatch, request):
 
 
 @pytest.fixture(autouse=True)
-def metrics_db(monkeypatch, request):
-    """Create a throwaway metrics db."""
-    record_stats._conn = None
-    database_file = f"file:metrics-{request.node.name}?mode=memory&cache=shared"
-    monkeypatch.setattr(config, "METRICS_FILE", database_file)
+def metrics_db(monkeypatch, tmp_path, request):
+    """Create a throwaway metrics db.
+
+    It must be a file, not memory, because we use readonly connections.
+    """
+    db_path = tmp_path / "metrics.db"
+    monkeypatch.setattr(config, "METRICS_FILE", str(db_path))
     yield
-    database.CONNECTION_CACHE.__dict__.pop(database_file, None)
-    record_stats._conn = None
+    record_stats.CONNECTION_CACHE.__dict__.clear()
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,7 +202,7 @@ def metrics_db(monkeypatch, tmp_path, request):
     It must be a file, not memory, because we use readonly connections.
     """
     db_path = tmp_path / "metrics.db"
-    monkeypatch.setattr(config, "METRICS_FILE", str(db_path))
+    monkeypatch.setattr(config, "METRICS_FILE", db_path)
     yield
     record_stats.CONNECTION_CACHE.__dict__.clear()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 import jobrunner.executors.local
-from jobrunner import config, tracing
+from jobrunner import config, record_stats, tracing
 from jobrunner.executors import volumes
 from jobrunner.job_executor import Study
 from jobrunner.lib import database
@@ -193,6 +193,17 @@ def db(monkeypatch, request):
     database.ensure_db(database_file)
     yield
     del database.CONNECTION_CACHE.__dict__[database_file]
+
+
+@pytest.fixture(autouse=True)
+def metrics_db(monkeypatch, request):
+    """Create a throwaway metrics db."""
+    record_stats._conn = None
+    database_file = f"file:metrics-{request.node.name}?mode=memory&cache=shared"
+    monkeypatch.setattr(config, "METRICS_FILE", database_file)
+    yield
+    database.CONNECTION_CACHE.__dict__.pop(database_file, None)
+    record_stats._conn = None
 
 
 @dataclass

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -4,7 +4,7 @@ import time
 from collections import defaultdict
 from copy import deepcopy
 
-from jobrunner import config, tracing
+from jobrunner import config, record_stats, tracing
 from jobrunner.job_executor import ExecutorState, JobResults, JobStatus
 from jobrunner.lib import docker
 from jobrunner.lib.database import insert
@@ -78,6 +78,12 @@ def job_factory(job_request=None, **kwargs):
         values["created_at"] = int(timestamp)
     if "updated_at" not in kwargs:
         values["updated_at"] = int(timestamp)
+
+    if "started_at" not in kwargs:
+        status_code = kwargs.get("status_code", values["status_code"])
+        if status_code and status_code >= StatusCode.EXECUTING:
+            values["started_at"] = int(timestamp)
+
     if "status_code_updated_at" not in kwargs:
         values["status_code_updated_at"] = int(timestamp * 1e9)
     values.update(kwargs)
@@ -101,6 +107,15 @@ def job_results_factory(timestamp_ns=None, **kwargs):
     values = deepcopy(JOB_RESULTS_DEFAULTS)
     values.update(kwargs)
     return JobResults(timestamp_ns=timestamp_ns, **values)
+
+
+def metrics_factory(job=None, metrics=None):
+    if job is None:
+        job = job_factory()
+    if metrics is None:
+        metrics = {}
+
+    record_stats.write_job_metrics(job.id, metrics)
 
 
 class StubExecutorAPI:

--- a/tests/lib/test_database.py
+++ b/tests/lib/test_database.py
@@ -9,12 +9,19 @@ from jobrunner.lib.database import (
     ensure_db,
     ensure_valid_db,
     find_one,
+    get_connection,
     insert,
     migrate_db,
     select_values,
     update,
 )
 from jobrunner.models import Job, State
+
+
+def test_get_connection():
+    db = "file:test_get_connection?mode=memory&cache=shared"
+    conn = get_connection(db)
+    assert conn is get_connection(db)
 
 
 def test_basic_roundtrip(tmp_work_dir):

--- a/tests/test_record_stats.py
+++ b/tests/test_record_stats.py
@@ -4,7 +4,7 @@ import time
 from jobrunner import record_stats
 from jobrunner.models import State, StatusCode
 from tests.conftest import get_trace
-from tests.factories import job_factory
+from tests.factories import job_factory, metrics_factory
 
 
 def test_record_tick_trace(db, freezer, monkeypatch):
@@ -28,12 +28,12 @@ def test_record_tick_trace(db, freezer, monkeypatch):
     # this should not be tick'd
     job_factory(state=State.SUCCEEDED, status_code=StatusCode.SUCCEEDED)
 
-    last_run1 = record_stats.record_tick_trace(None)
+    last_run1 = record_stats.record_tick_trace(None, jobs)
     assert len(get_trace("ticks")) == 0
 
     freezer.tick(10)
 
-    last_run2 = record_stats.record_tick_trace(last_run1)
+    last_run2 = record_stats.record_tick_trace(last_run1, jobs)
     assert last_run2 == last_run1 + 10 * 1e9
 
     spans = get_trace("ticks")
@@ -56,7 +56,17 @@ def test_record_tick_trace(db, freezer, monkeypatch):
         if job is running_job:
             assert span.attributes["has_metrics"] is True
             assert span.attributes["cpu_percentage"] == 50.0
+            assert span.attributes["cpu_sample"] == 50.0
+            assert span.attributes["cpu_sample"] == 50.0
+            assert span.attributes["cpu_peak"] == 50.0
+            assert span.attributes["cpu_cumsum"] == 500.0  # 50% * 10s
+            assert span.attributes["cpu_mean"] == 50.0
+
             assert span.attributes["memory_used"] == 1000
+            assert span.attributes["mem_sample"] == 1000
+            assert span.attributes["mem_peak"] == 1000
+            assert span.attributes["mem_cumsum"] == 10000  # 1000 * 10s
+            assert span.attributes["mem_mean"] == 1000
         else:
             assert span.attributes["has_metrics"] is False
 
@@ -64,7 +74,7 @@ def test_record_tick_trace(db, freezer, monkeypatch):
 
 
 def test_record_tick_trace_stats_timeout(db, freezer, monkeypatch):
-    job_factory(status_code=StatusCode.EXECUTING)
+    job = job_factory(status_code=StatusCode.EXECUTING)
 
     def timeout():
         raise subprocess.TimeoutExpired("cmd", 10)
@@ -74,7 +84,7 @@ def test_record_tick_trace_stats_timeout(db, freezer, monkeypatch):
     last_run = time.time()
     freezer.tick(10)
 
-    record_stats.record_tick_trace(last_run)
+    record_stats.record_tick_trace(last_run, [job])
     assert len(get_trace("ticks")) == 2
 
     spans = get_trace("ticks")
@@ -82,13 +92,14 @@ def test_record_tick_trace_stats_timeout(db, freezer, monkeypatch):
 
     assert "cpu_percentage" not in span.attributes
     assert "memory_used" not in span.attributes
+    assert "mem_peak" not in span.attributes
     assert span.attributes["has_metrics"] is False
     assert span.attributes["stats_timeout"] is True
     assert span.attributes["stats_error"] is False
 
 
 def test_record_tick_trace_stats_error(db, freezer, monkeypatch):
-    job_factory(status_code=StatusCode.EXECUTING)
+    job = job_factory(status_code=StatusCode.EXECUTING)
 
     def error():
         raise subprocess.CalledProcessError(
@@ -98,7 +109,7 @@ def test_record_tick_trace_stats_error(db, freezer, monkeypatch):
     monkeypatch.setattr(record_stats, "get_job_stats", error)
 
     last_run = time.time()
-    record_stats.record_tick_trace(last_run)
+    record_stats.record_tick_trace(last_run, [job])
     assert len(get_trace("ticks")) == 2
 
     spans = get_trace("ticks")
@@ -106,6 +117,7 @@ def test_record_tick_trace_stats_error(db, freezer, monkeypatch):
 
     assert "cpu_percentage" not in span.attributes
     assert "memory_used" not in span.attributes
+    assert "mem_peak" not in span.attributes
     assert span.attributes["has_metrics"] is False
     assert span.attributes["stats_timeout"] is False
     assert span.attributes["stats_error"] is True
@@ -117,3 +129,73 @@ def test_record_tick_trace_stats_error(db, freezer, monkeypatch):
     assert root.events[0].attributes["cmd"] == "test cmd"
     assert root.events[0].attributes["output"] == "stderr\n\nstdout"
     assert root.events[0].name == "stats_error"
+
+
+def test_update_job_metrics(db):
+
+    job = job_factory(status_code=StatusCode.EXECUTING)
+    metrics_factory(job)
+
+    metrics = record_stats.read_job_metrics(job.id)
+
+    assert metrics == {}
+
+    # 50%/100m for 1s
+    record_stats.update_job_metrics(
+        job,
+        {"cpu_percentage": 50, "memory_used": 100},
+        duration_s=1.0,
+        runtime_s=1.0,
+    )
+
+    metrics = record_stats.read_job_metrics(job.id)
+    assert metrics == {
+        "cpu_cumsum": 50.0,
+        "cpu_mean": 50.0,
+        "cpu_peak": 50,
+        "cpu_sample": 50,
+        "mem_cumsum": 100.0,
+        "mem_mean": 100.0,
+        "mem_peak": 100,
+        "mem_sample": 100,
+    }
+
+    # 100%/1000m for 1s
+    record_stats.update_job_metrics(
+        job,
+        {"cpu_percentage": 100, "memory_used": 1000},
+        duration_s=1.0,
+        runtime_s=2.0,
+    )
+
+    metrics = record_stats.read_job_metrics(job.id)
+    assert metrics == {
+        "cpu_cumsum": 150.0,
+        "cpu_mean": 75.0,
+        "cpu_peak": 100,
+        "cpu_sample": 100,
+        "mem_cumsum": 1100.0,
+        "mem_mean": 550.0,
+        "mem_peak": 1000,
+        "mem_sample": 1000,
+    }
+
+    # 100%/1000m for 8s
+    record_stats.update_job_metrics(
+        job,
+        {"cpu_percentage": 100, "memory_used": 1000},
+        duration_s=8.0,
+        runtime_s=10.0,
+    )
+
+    metrics = record_stats.read_job_metrics(job.id)
+    assert metrics == {
+        "cpu_cumsum": 950.0,
+        "cpu_mean": 95.0,
+        "cpu_peak": 100,
+        "cpu_sample": 100,
+        "mem_cumsum": 9100.0,
+        "mem_mean": 910.0,
+        "mem_peak": 1000,
+        "mem_sample": 1000,
+    }


### PR DESCRIPTION
This PR contains the 3 reverted commits https://github.com/opensafely-core/job-runner/pull/686, and then an additional commit to fix the use of a global variable to cache the connection string in multithreaded application.  This is known to be Bad Juju, and I regret the error.

The sync, run and stats thread *all* have a db connection to the metrics
db, so this cause sqlite to barf.

This was not caught in the test suite because we do not currently have
a functional test that runs the full multithreaded service and tries to
run a job with it.  This is in theory possible (it's what the
a backend-server tests for the test backend do), but its also hard to
set up and slow and requires lxc currently, so I have not done that
here.

Once this lands, I will test it does fix the multithreaded issue by
using the backend-server functional tests to fully exercise it.

The commit message for the fix is:

This removes the use of a process global, and adds support for readonly
connections to help reduce contention on the metrics db with
multithreaded access.

Adding readonly mode, and the initial PR feedback, led to a re-working
of the connection management. Rather than re-use
`lib.database.get_connection()`, we instead implement our own version.
This gives us control, and allows us to efficiently assure appropriate
set up as well as cleanly handle readonly connections.

One small chnage with this - we cannot use an in-memory db in testing
for the metrics db, as `mode=memory` is not compatible with setting
`mode=ro`. Each test still gets their own db, but its on disk.
