### PR TITLE
drop pdf from L4 file types

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -156,7 +156,6 @@ LEVEL4_FILE_TYPES = [
     ".svgz",
     # reports
     ".html",
-    ".pdf",
     ".txt",
     ".log",
     ".json",


### PR DESCRIPTION
Makes allowed file types consistent with those listed [in the output review docs](https://docs.opensafely.org/releasing-files/#allowed-file-types)