### PR TITLE
Remove .tsv support for Level 4 files

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -148,7 +148,6 @@ LEVEL4_MAX_FILESIZE = int(
 LEVEL4_FILE_TYPES = [
     # tables
     ".csv",
-    ".tsv",
     # images
     ".jpg",
     ".jpeg",


### PR DESCRIPTION
In agreement with output checkers,  we are removing support for tsv
files as valid level 4 files
