### PR TITLE
Update otel config

### DIFF
--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -219,7 +219,7 @@ def complete_job(job, timestamp_ns, error=None, results=None, **attrs):
     # to send it.
 
     # this effectively starts a new trace
-    root_span = tracer.start_span("JOB", start_time=job_start_time)
+    root_span = tracer.start_span("JOB", context={}, start_time=job_start_time)
 
     # replace the context with the one from the original root span
     root_span._context = root_ctx


### PR DESCRIPTION
We want to have jobrunner and airlock both emitting telemetry from a backend, but they share the same env var config.

The motivation for this change was to encode a default OTEL_SERVICE_NAME in the job-runner so we don't end up mixing their data in Honeycomb

Along the way, I fixed a couple of otel related issues
- use a top level Resource to provide some of the static metadata, including tagging with backend name
- fixed a visualisation issue in honeycomb that shows a missing root span (it was annoying me).


