### PR TITLE
Strip quotes from OTEL_EXPORTER_OTLP_HEADERS value

### DIFF
--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -52,7 +52,7 @@ def setup_default_tracing(set_global=True):
     if "OTEL_EXPORTER_OTLP_HEADERS" in os.environ:
         # workaround for env file parsing issues
         cleaned_headers = os.environ["OTEL_EXPORTER_OTLP_HEADERS"].strip("\"'")
-        # put back into env to be parsed properlh
+        # put back into env to be parsed properly
         os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = cleaned_headers
 
         if "OTEL_EXPORTER_OTLP_ENDPOINT" not in os.environ:

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -50,9 +50,15 @@ def setup_default_tracing(set_global=True):
     provider = get_provider()
 
     if "OTEL_EXPORTER_OTLP_HEADERS" in os.environ:
+        # workaround for env file parsing issues
+        cleaned_headers = os.environ["OTEL_EXPORTER_OTLP_HEADERS"].strip("\"'")
+        # put back into env to be parsed properlh
+        os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = cleaned_headers
+
         if "OTEL_EXPORTER_OTLP_ENDPOINT" not in os.environ:
             os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://api.honeycomb.io"
 
+        # now we can created OTLP exporter
         add_exporter(provider, OTLPSpanExporter())
 
     if "OTEL_EXPORTER_CONSOLE" in os.environ:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -28,7 +28,7 @@ def test_setup_default_tracing_console(monkeypatch):
 
 
 def test_setup_default_tracing_otlp_defaults(monkeypatch):
-    env = {"OTEL_EXPORTER_OTLP_HEADERS": "foo=bar"}
+    env = {"OTEL_EXPORTER_OTLP_HEADERS": "'foo=bar'"}
     monkeypatch.setattr(os, "environ", env)
     monkeypatch.setattr(
         opentelemetry.exporter.otlp.proto.http.trace_exporter, "environ", env


### PR DESCRIPTION
Workaround for a bug in docker-compose
