### PR TITLE
Capture status_code_update_at timestamp.

### DIFF
--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -302,6 +302,8 @@ def trace_attributes(job, results=None):
         # convert float seconds to ns integer
         created_at=int(job.created_at * 1e9),
         started_at=int(job.started_at * 1e9) if job.started_at else None,
+        # when did the state last change?
+        status_code_updated_at=job.status_code_updated_at,
         requires_db=job.requires_db,
     )
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -107,6 +107,7 @@ def test_trace_attributes(db):
         message="message",
         created_at=int(job.created_at * 1e9),
         started_at=None,
+        status_code_updated_at=job.status_code_updated_at,
         reusable_action="action_repo:commit",
         requires_db=False,
         outputs=2,
@@ -156,6 +157,7 @@ def test_trace_attributes_missing(db):
         message="message",
         created_at=int(job.created_at * 1e9),
         started_at=None,
+        status_code_updated_at=job.status_code_updated_at,
         requires_db=False,
     )
 


### PR DESCRIPTION
This will allow us to calculate for each tick how long a job has been in
a certain state, and drive alerts from that
