### PR TITLE
Test under python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
   test-job:
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, windows-2019, macos-12]
         # Python 3.8 is what we currently support for running cohortextractor
         # locally, and 3.9 is what we required for databuilder so we need to make
         # sure we can run with those

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         # Python 3.8 is what we currently support for running cohortextractor
         # locally, and 3.9 is what we required for databuilder so we need to make
         # sure we can run with those
-        python: [3.8, 3.9]
+        python: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     name: Run test suite
     steps:


### PR DESCRIPTION
Whilst we are still not running job-server inside docker, we need
job-runner to work under the system python. Currently, TPP is on
20.04/pyh38, andw e want to upgrade to 22.04/py3.10

job-runner does work on 3.10, as its bundled in opensafely-cli, and
that's been running on 3.10 fine for anyone on 22.04 for ages.

But this formalises it in CI.
