### PR TITLE
Set MAX_DB_WORKER limit in `local_run`

### DIFF
--- a/jobrunner/cli/local_run.py
+++ b/jobrunner/cli/local_run.py
@@ -259,6 +259,7 @@ def create_and_run_jobs(
     config.USING_DUMMY_DATA_BACKEND = True
     config.CLEAN_UP_DOCKER_OBJECTS = clean_up_docker_objects
     config.MAX_WORKERS = concurrency
+    config.MAX_DB_WORKERS = concurrency
     config.DEFAULT_JOB_MEMORY_LIMIT = memory
     config.DEFAULT_JOB_CPU_COUNT = cpus
 


### PR DESCRIPTION
We allow the user to set the number of concurrent jobs using the `--concurrency` argument and use this to update the worker limit, but we didn't update the database worker limit.

The distinction is meaningless for local jobs in any case because these jobs are just generating dummy data, but it meant that jobs ran with less parallelism than expected. It also lead to "Waiting on available database workers" messages appearing in the log output which caused confusion and anxiety.