### PR TITLE
Use tmp_path for test dbs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,9 +188,9 @@ def test_repo(tmp_work_dir):
 
 
 @pytest.fixture()
-def db(monkeypatch, request):
+def db(monkeypatch, tmp_path, request):
     """Create a throwaway db."""
-    database_file = f"file:db-{request.node.name}?mode=memory&cache=shared"
+    database_file = tmp_path / f"file:db-{request.node.name}?mode=memory&cache=shared"
     monkeypatch.setattr(config, "DATABASE_FILE", database_file)
     database.ensure_db(database_file)
     yield

--- a/tests/lib/test_database.py
+++ b/tests/lib/test_database.py
@@ -18,8 +18,8 @@ from jobrunner.lib.database import (
 from jobrunner.models import Job, State
 
 
-def test_get_connection():
-    db = "file:test_get_connection?mode=memory&cache=shared"
+def test_get_connection(tmp_path):
+    db = tmp_path / "file:test_get_connection?mode=memory&cache=shared"
     conn = get_connection(db)
     assert conn is get_connection(db)
 
@@ -111,8 +111,8 @@ def test_ensure_db_verbose(tmp_path, caplog):
     assert "Applied migration 2" in caplog.records[-1].msg
 
 
-def test_ensure_db_new_db_memory():
-    db = "file:test?mode=memory&cached=shared"
+def test_ensure_db_new_db_memory(tmp_path):
+    db = tmp_path / "file:test?mode=memory&cached=shared"
     conn = ensure_db(db, {1: "should not run"})
     assert CONNECTION_CACHE.__dict__[db] is conn
     assert conn.execute("PRAGMA user_version").fetchone()[0] == 1


### PR DESCRIPTION
This ensures that files created as throwaway dbs in tests don't hang around causing the next test run to error.