### PR TITLE
Use uri=True for db connections

### DIFF
--- a/jobrunner/lib/database.py
+++ b/jobrunner/lib/database.py
@@ -168,7 +168,7 @@ def get_connection(filename=None):
     # Looks icky but is documented `threading.local` usage
     cache = CONNECTION_CACHE.__dict__
     if filename not in cache:
-        conn = sqlite3.connect(filename)
+        conn = sqlite3.connect(filename, uri=True)
         # Enable autocommit so changes made outside of a transaction still get
         # persisted to disk. We can use explicit transactions when we need
         # atomicity.


### PR DESCRIPTION
Ensure that sqlite3 always uses URIs for db connections.

Different versions of sqlite3 may or may not set the [USE_URI compile time option](https://www.sqlite.org/compile.html#:~:text=SQLITE_USE_URI), so make sure it's always used, irrespective. 

