### PR TITLE
Bump to pipeline 2024.09.27.131013

### DIFF
--- a/jobrunner/actions.py
+++ b/jobrunner/actions.py
@@ -81,7 +81,7 @@ def get_action_specification(config, action_id, using_dummy_data_backend=False):
     return ActionSpecification(
         run=run_command,
         needs=action_spec.needs,
-        outputs=action_spec.outputs.dict(exclude_unset=True),
+        outputs=action_spec.outputs.dict(),
         action=action_spec,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v2024.03.19.153938",
+  "opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v2024.09.27.131013",
   "ruyaml",
   "requests",
   "opentelemetry-exporter-otlp-proto-http",

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -18,7 +18,7 @@ googleapis-common-protos==1.56.4
     # via opentelemetry-exporter-otlp-proto-http
 idna==2.10
     # via requests
-opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v2024.03.19.153938
+opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v2024.09.27.131013
     # via opensafely-jobrunner (pyproject.toml)
 opentelemetry-api==1.12.0
     # via

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -13,7 +13,7 @@ from jobrunner.actions import UnknownActionError, get_action_specification
     reason="ActionSpecification is only used to build commands for Docker",
 )
 def test_get_action_specification_databuilder_has_output_flag():
-    config = Pipeline(
+    config = Pipeline.build(
         **{
             "version": 3,
             "expectations": {"population_size": 1000},
@@ -44,7 +44,7 @@ def test_get_action_specification_databuilder_has_output_flag():
     reason="ActionSpecification is only used to build commands for Docker",
 )
 def test_get_action_specification_for_cohortextractor_generate_cohort_action():
-    config = Pipeline(
+    config = Pipeline.build(
         **{
             "version": 3,
             "expectations": {"population_size": 1000},
@@ -72,7 +72,7 @@ def test_get_action_specification_for_cohortextractor_generate_cohort_action():
     reason="ActionSpecification is only used to build commands for Docker",
 )
 def test_get_action_specification_with_config():
-    config = Pipeline(
+    config = Pipeline.build(
         **{
             "version": 3,
             "expectations": {"population_size": 1_000},
@@ -115,14 +115,14 @@ def test_get_action_specification_with_dummy_data_file_flag(tmp_path):
     with dummy_data_file.open("w") as f:
         f.write("test")
 
-    config = Pipeline(
+    config = Pipeline.build(
         **{
             "version": 1,
             "actions": {
                 "generate_cohort": {
                     "run": "cohortextractor:latest generate_cohort",
                     "outputs": {"moderately_sensitive": {"cohort": "output/input.csv"}},
-                    "dummy_data_file": dummy_data_file,
+                    "dummy_data_file": str(dummy_data_file),
                 }
             },
         }
@@ -154,14 +154,14 @@ def test_get_action_specification_without_dummy_data_file_flag(tmp_path):
     with dummy_data_file.open("w") as f:
         f.write("test")
 
-    config = Pipeline(
+    config = Pipeline.build(
         **{
             "version": 1,
             "actions": {
                 "generate_cohort": {
                     "run": "cohortextractor:latest generate_cohort",
                     "outputs": {"moderately_sensitive": {"cohort": "output/input.csv"}},
-                    "dummy_data_file": dummy_data_file,
+                    "dummy_data_file": str(dummy_data_file),
                 }
             },
         }
@@ -178,7 +178,7 @@ def test_get_action_specification_without_dummy_data_file_flag(tmp_path):
     reason="ActionSpecification is only used to build commands for Docker",
 )
 def test_get_action_specification_with_unknown_action():
-    config = Pipeline(
+    config = Pipeline.build(
         **{
             "version": 1,
             "actions": {


### PR DESCRIPTION
- Bump the pipeline version to 2024.09.27.131013
- Associated changes to code: Remove use of the `exclude_unset` keyword argument which is related to Pydantic
- Associated changes to tests: Use `Pipeline.build()` and ensure `dummy_data_file` is `str` type