### PR TITLE
Bump to pipeline 2024.10.08.124104

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v2024.09.27.131013",
+  "opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v2024.10.08.124104",
   "ruyaml",
   "requests",
   "opentelemetry-exporter-otlp-proto-http",

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -18,7 +18,7 @@ googleapis-common-protos==1.56.4
     # via opentelemetry-exporter-otlp-proto-http
 idna==2.10
     # via requests
-opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v2024.09.27.131013
+opensafely-pipeline @ git+https://github.com/opensafely-core/pipeline@v2024.10.08.124104
     # via opensafely-jobrunner (pyproject.toml)
 opentelemetry-api==1.12.0
     # via


### PR DESCRIPTION
Make version 4 of pipeline available for choosing. 
It ceases supporting cohort extractor actions and does not use an `expectations` section in the `project.yaml` file.