### PR TITLE
Add a dedicated manual maintenance mode flag

### DIFF
--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -93,6 +93,14 @@ def maintenance_mode():
     """Check if the db is currently in maintenance mode, and set flags as appropriate."""
     # This did not seem big enough to warrant splitting into a separate module.
     log.info("checking if db undergoing maintenance...")
+
+    # manually setting this flag bypasses the automaticaly check
+    manual_db_mode = get_flag_value("manual-db-maintenance")
+    if manual_db_mode:
+        log.info("manually set db mode: db-maintenance")
+        return "db-maintenance"
+
+    # detect db mode from TPP.
     current = get_flag_value("mode")
     ps = docker(
         [

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -89,6 +89,9 @@ def maintenance_wrapper():
         time.sleep(config.MAINTENANCE_POLL_INTERVAL)
 
 
+DB_MAINTENANCE_MODE = "db-maintenance"
+
+
 def maintenance_mode():
     """Check if the db is currently in maintenance mode, and set flags as appropriate."""
     # This did not seem big enough to warrant splitting into a separate module.
@@ -97,8 +100,8 @@ def maintenance_mode():
     # manually setting this flag bypasses the automaticaly check
     manual_db_mode = get_flag_value("manual-db-maintenance")
     if manual_db_mode:
-        log.info("manually set db mode: db-maintenance")
-        return "db-maintenance"
+        log.info(f"manually set db mode: {DB_MAINTENANCE_MODE}")
+        return DB_MAINTENANCE_MODE
 
     # detect db mode from TPP.
     current = get_flag_value("mode")
@@ -119,14 +122,14 @@ def maintenance_mode():
         text=True,
     )
     last_line = ps.stdout.strip().split("\n")[-1]
-    if "db-maintenance" in last_line:
-        if current != "db-maintenance":
+    if DB_MAINTENANCE_MODE in last_line:
+        if current != DB_MAINTENANCE_MODE:
             log.warning("Enabling DB maintenance mode")
         else:
             log.warning("DB maintenance mode is currently enabled")
-        set_flag("mode", "db-maintenance")
+        set_flag("mode", DB_MAINTENANCE_MODE)
     else:
-        if current == "db-maintenance":
+        if current == DB_MAINTENANCE_MODE:
             log.info("DB maintenance mode had ended")
         set_flag("mode", None)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -93,6 +93,11 @@ def test_maintenance_mode_error(mock_subprocess_run, db, db_config):
         service.maintenance_mode()
 
 
+def test_maintenance_mode_manual(db, db_config):
+    queries.set_flag("manual-db-maintenance", "on")
+    assert service.maintenance_mode() == "db-maintenance"
+
+
 @pytest.fixture
 def db_config(monkeypatch):
     monkeypatch.setitem(config.DATABASE_URLS, "default", "mssql://localhost")


### PR DESCRIPTION
Currently, manually enabling database maintenance mode is awkward, as by
default it will just get switch off again by the regular automatic
check. So you have to remember to stop that first, which is awkward,
then restart it, for more awkwardness

Instead, this change adds an explicit flag check for
`manual-db-maintenance` - if that is set, we skip the automated check
altogether.

This will be added to the jobrunner justfile in backend-server as
a documented command in a separate PR.
