### PR TITLE
Better targeted Github branch validation

### DIFF
--- a/jobrunner/cli/add_job.py
+++ b/jobrunner/cli/add_job.py
@@ -79,8 +79,8 @@ def run(argv=None):
     )
     parser.add_argument(
         "--branch",
-        help="Git branch or ref to use if no commit supplied (default HEAD)",
-        default="HEAD",
+        help="Git branch or ref to use if no commit supplied (default 'main')",
+        default="main",
     )
     parser.add_argument(
         "--workspace", help="Workspace ID (default 'test')", default="test"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,7 +164,10 @@ def test_repo(tmp_work_dir):
     repo_path = tmp_work_dir / "test-repo"
 
     env = {"GIT_WORK_TREE": str(directory), "GIT_DIR": repo_path}
-    subprocess_run(["git", "init", "--bare", "--quiet", repo_path], check=True)
+    subprocess_run(
+        ["git", "init", "--bare", "--initial-branch=main", "--quiet", repo_path],
+        check=True,
+    )
     subprocess_run(
         ["git", "config", "user.email", "test@example.com"], check=True, env=env
     )

--- a/tests/lib/test_github_validators.py
+++ b/tests/lib/test_github_validators.py
@@ -1,0 +1,32 @@
+import pytest
+
+from jobrunner.lib.github_validators import (
+    GithubValidationError,
+    validate_branch_and_commit,
+)
+
+
+def test_validate_branch_and_commit():
+    validate_branch_and_commit(
+        "https://github.com/opensafely-core/test-public-repository.git",
+        "983d348e3f6bfeeac0cd473d5ab950ce03b022e5",
+        "test-branch-dont-delete",
+    )
+
+
+def test_validate_branch_and_commit_rejects_pull_request_ref():
+    with pytest.raises(GithubValidationError, match="Could not find branch"):
+        validate_branch_and_commit(
+            "https://github.com/opensafely-core/test-public-repository.git",
+            "2e59c0ec8d147cb8a475596ba16d6f74ec7ee913",
+            "refs/pull/1/head",
+        )
+
+
+def test_validate_branch_and_commit_rejects_unreachable_commit():
+    with pytest.raises(GithubValidationError, match="Could not find commit"):
+        validate_branch_and_commit(
+            "https://github.com/opensafely-core/test-public-repository.git",
+            "2e59c0ec8d147cb8a475596ba16d6f74ec7ee913",
+            "main",
+        )


### PR DESCRIPTION
The previous approach of forbidding slash characters had the effect of also rejecting legitimate branch names (see issue below). A better approach, as suggested by Mike Kelly, is to check the commit against `refs/heads/{branch-name}` which naturally rejects anything which isn't a genuine branch.

Closes https://github.com/opensafely-core/job-server/issues/4998