### PR TITLE
Save job results to disk and not in memory

### DIFF
--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -28,6 +28,9 @@ from jobrunner.lib.string_utils import tabulate
 # Directory inside working directory where manifest and logs are created
 METADATA_DIR = "metadata"
 
+# Records information about job that's finished running
+METADATA_FILE = "metadata.json"
+
 # Records details of which action created each file
 MANIFEST_FILE = "manifest.json"
 
@@ -61,6 +64,11 @@ def get_log_dir(job_definition):
     # Split log directory up by month to make things slightly more manageable
     month_dir = datetime.date.today().strftime("%Y-%m")
     return config.JOB_LOG_DIR / month_dir / container_name(job_definition)
+
+
+def read_job_metadata(job_definition):
+    path = get_log_dir(job_definition) / METADATA_FILE
+    return json.loads(path.read_text())
 
 
 class LocalDockerError(Exception):
@@ -485,7 +493,7 @@ def write_job_logs(
     # Dump useful info in log directory
     log_dir = get_log_dir(job_definition)
     write_log_file(job_definition, job_metadata, log_dir / "logs.txt", excluded)
-    with open(log_dir / "metadata.json", "w") as f:
+    with open(log_dir / METADATA_FILE, "w") as f:
         json.dump(job_metadata, f, indent=2)
 
     if copy_log_to_workspace:

--- a/tests/cli/test_kill_job.py
+++ b/tests/cli/test_kill_job.py
@@ -143,7 +143,7 @@ def test_kill_job(
     # persist_outputs needs this
     mocker.container_inspect.return_value = {
         "Image": "image",
-        "State": {"ExitCode": 137},
+        "State": {"ExitCode": 137, "OOMKilled": False},
     }
 
     # set both the docker module names used to the mocker version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ import pytest
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-import jobrunner.executors.local
 from jobrunner import config, record_stats, tracing
 from jobrunner.job_executor import Study
 from jobrunner.lib import database
@@ -33,8 +32,6 @@ def pytest_configure(config):
 @pytest.fixture(autouse=True)
 def clear_state():
     yield
-    # local docker API maintains results cache as a module global, so clear it.
-    jobrunner.executors.local.RESULTS.clear()
     database.CONNECTION_CACHE.__dict__.clear()
     # clear any exported spans
     test_exporter.clear()

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -361,20 +361,20 @@ def test_finalize_success(docker_cleanup, job_definition, tmp_work_dir):
     level4_dir = local.get_medium_privacy_workspace(job_definition.workspace)
     manifest = local.read_manifest_file(level4_dir, job_definition)
 
-    metadata = manifest["outputs"]["output/summary.csv"]
-    assert metadata["level"] == "moderately_sensitive"
-    assert metadata["job_id"] == job_definition.id
-    assert metadata["job_request"] == job_definition.job_request_id
-    assert metadata["action"] == job_definition.action
-    assert metadata["commit"] == job_definition.study.commit
-    assert metadata["excluded"] is False
-    assert metadata["size"] == 0
+    csv_metadata = manifest["outputs"]["output/summary.csv"]
+    assert csv_metadata["level"] == "moderately_sensitive"
+    assert csv_metadata["job_id"] == job_definition.id
+    assert csv_metadata["job_request"] == job_definition.job_request_id
+    assert csv_metadata["action"] == job_definition.action
+    assert csv_metadata["commit"] == job_definition.study.commit
+    assert csv_metadata["excluded"] is False
+    assert csv_metadata["size"] == 0
     assert (
-        metadata["content_hash"]
+        csv_metadata["content_hash"]
         == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     )
-    assert metadata["row_count"] == 0
-    assert metadata["col_count"] == 0
+    assert csv_metadata["row_count"] == 0
+    assert csv_metadata["col_count"] == 0
 
     txt_metadata = manifest["outputs"]["output/summary.txt"]
     assert txt_metadata["excluded"] is False

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -925,14 +925,6 @@ def test_running_job_terminated_finalized(docker_cleanup, job_definition, tmp_wo
 
 
 @pytest.mark.needs_docker
-def test_get_results_not_finalized(docker_cleanup, job_definition, tmp_work_dir):
-    api = local.LocalDockerAPI()
-    results = api.get_results(job_definition)
-    assert results.state == ExecutorState.ERROR
-    assert results.message == "job has not been finalized"
-
-
-@pytest.mark.needs_docker
 def test_cleanup_success(docker_cleanup, job_definition, tmp_work_dir):
     populate_workspace(job_definition.workspace, "output/input.csv")
 

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -54,7 +54,7 @@ def populate_workspace(workspace, filename, content=None, privacy="high"):
 
 
 # used for tests and debugging
-def get_log(job_definition):
+def get_docker_log(job_definition):
     result = docker.docker(
         ["container", "logs", local.container_name(job_definition)],
         check=True,
@@ -342,7 +342,7 @@ def test_finalize_success(docker_cleanup, job_definition, tmp_work_dir):
     assert job_definition.id in local.RESULTS
 
     # for test debugging if any asserts fail
-    print(get_log(job_definition))
+    print(get_docker_log(job_definition))
     results = api.get_results(job_definition)
     assert results.exit_code == 0
     assert results.outputs == {
@@ -407,7 +407,7 @@ def test_finalize_failed(docker_cleanup, job_definition, tmp_work_dir):
     assert job_definition.id in local.RESULTS
 
     # for test debugging if any asserts fail
-    print(get_log(job_definition))
+    print(get_docker_log(job_definition))
     results = api.get_results(job_definition)
     assert results.exit_code == 1
     assert results.outputs == {}
@@ -457,7 +457,7 @@ def test_finalize_unmatched(docker_cleanup, job_definition, tmp_work_dir):
     assert job_definition.id in local.RESULTS
 
     # for test debugging if any asserts fail
-    print(get_log(job_definition))
+    print(get_docker_log(job_definition))
     results = api.get_results(job_definition)
     assert results.exit_code == 0
     assert results.outputs == {}
@@ -500,7 +500,7 @@ def test_finalize_unmatched_output(docker_cleanup, job_definition, tmp_work_dir)
     assert job_definition.id in local.RESULTS
 
     # for test debugging if any asserts fail
-    print(get_log(job_definition))
+    print(get_docker_log(job_definition))
     results = api.get_results(job_definition)
     assert results.exit_code == 0
     assert results.outputs == {}

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from unittest import mock
@@ -102,6 +103,25 @@ def workspace_log_file_exists(job_definition):
         / f"{job_definition.action}.log"
     )
     return workspace_log_file.exists()
+
+
+def test_read_metadata_path(job_definition):
+    assert local.read_job_metadata(job_definition) is None
+
+    globbed_path = (
+        config.JOB_LOG_DIR
+        / "last-month"
+        / local.container_name(job_definition)
+        / local.METADATA_FILE
+    )
+    globbed_path.parent.mkdir(parents=True)
+    globbed_path.write_text(json.dumps({"test": "globbed"}))
+    assert local.read_job_metadata(job_definition) == {"test": "globbed"}
+
+    actual_path = local.get_log_dir(job_definition) / local.METADATA_FILE
+    actual_path.parent.mkdir(parents=True)
+    actual_path.write_text(json.dumps({"test": "actual"}))
+    assert local.read_job_metadata(job_definition) == {"test": "actual"}
 
 
 @pytest.mark.needs_docker

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -381,6 +381,19 @@ def test_finalize_success(docker_cleanup, job_definition, tmp_work_dir):
     assert txt_metadata["row_count"] is None
     assert txt_metadata["col_count"] is None
 
+    job_metadata = local.read_job_metadata(job_definition)
+    for key in {
+        "exit_code",
+        "completed_at",
+        "commit",
+        "docker_image_id",
+        "status_message",
+        "outputs",
+        "job_definition_id",
+        "job_definition_request_id",
+    }:
+        assert key in job_metadata.keys()
+
 
 @pytest.mark.needs_docker
 def test_finalize_failed(docker_cleanup, job_definition, tmp_work_dir):


### PR DESCRIPTION
This is a prerequisite for doing the agent-controller split.