### PR TITLE
Update developer docs and document how to run jobs on the test backend

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,15 +1,56 @@
 # Developer notes
 
-## Dependencies
 
-Install the development dependencies with:
+
+## Prerequisites for local development
+
+### Just
+
+We use [`just`](https://github.com/casey/just) as our command runner. It's
+a single file binary available for many platforms so should be easy to
+install.
+
+```sh
+# macOS
+brew install just
+
+# Linux
+# Install from https://github.com/casey/just/releases
+
+# Add completion for your shell. E.g. for bash:
+source <(just --completions bash)
+
+# Show all available commands
+just #  shortcut for just --list
 ```
-pip install -r requirements.dev.txt
-```
-This includes the production dependencies in `requirements.txt` which
-are intentionally kept minimal.
+
+### Python
+
+You'll need an appropriate version of Python on your PATH. Check the
+`.python-version` file for the required version.
+
+### Docker
 
 You will also need an up-to-date version of Docker Compose. Instructions to install it are [here](https://docs.docker.com/compose/install/).
+
+
+## Getting started
+
+Set up a local development environment with:
+```
+just devenv
+```
+
+This includes the production dependencies in `requirements.txt` (which
+are intentionally kept minimal) and the dev dependencies in `requirements.dev.txt`.
+
+It also creates a `.env` file from `dotenv-sample`, and populates the
+`HIGH_PRIVACY_STORAGE_BASE` and `MEDIUM_PRIVACY_STORAGE_BASE` environment
+variables.
+
+Update `.env` to add a value for `PRIVATE_REPO_ACCESS_TOKEN`; this should be a
+developer [GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#about-personal-access-tokens) with `repo` scope.
+
 
 ## Architecture
 
@@ -128,23 +169,23 @@ Or run a command inside the docker image:
 
 ## Running jobs locally
 
-Adding jobs locally is most easily done with the `jobrunner.cli.add_job`
-command e.g
+Adding jobs locally is most easily done with the `just add-job` command, which
+calls `jobrunner.cli.add_job` with a study repo and an action to run e.g.
 ```
-python -m jobrunner.cli.add_job https://github.com/opensafely/os-demo-research run_all
+just add-job https://github.com/opensafely/os-demo-research run_all
 ```
 
 As well as URLs this will accept paths to local git repos e.g.
 ```
-python -m jobrunner.cli.add_job ../os-demo-research run_all
+just add-job ../os-demo-research run_all
 ```
 
-If you now run the main loop you'll see it pick up the jobs:
+You can now run the main loop and you'll see it pick up the jobs:
 ```
-python -m jobrunner.run
+just run
 ```
 
-See the full set of options it accepts with:
+See the full set of options `add-job` will accept with:
 ```
 python -m jobrunner.cli.add_job --help
 ```

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -223,37 +223,10 @@ just jobrunner/logs-id <your-job-id>
 
 ## job-runner docker image
 
-Building the dev docker image:
+Building the docker image:
 
-    make -C docker-build                   # build base and dev image
-    make -C docker-build ENV=prod          # build base and prod image
-    make -C docker-build ARGS=--no-cache   # build without cache
-
-
-### Exposing the host's docker service
-
-By default, running the docker container will mount your host's
-`/var/run/docker.sock` into the container and use that for job-runner to run
-jobs. It does some matching of docker GIDs to do so.
-
-However, it also supports accessing docker over ssh:
-
-    make -C docker enable-docker-over-ssh
-
-The docker-compose invocations will now talk to your host docker over SSH,
-possibly on a remote machine. You can disable with:
-
-    make -C docker disable-docker-over-ssh
-
-Note: The above commands will automatically generate a local ed25519
-dev ssh key, and add it to your `~/.ssh/authorized_keys` file. You can use
-`just docker-clean` to remove this.  If you wish to use a different user/host,
-you can do so:
-
-1. Specify `SSH_USER` and `SSH_HOST` environment variables.
-2. Add an authorized ed25519 private key for that user to `docker/ssh/id_ed25519`.
-3. Run `touch docker/ssh/id_ed25519.authorized` to let Make know that it is all
-   set up.
+    just docker/build                   # build base and dev image
+    just docker/build prod              # build base and prod image
 
 
 ## Database schema and migrations
@@ -297,29 +270,10 @@ or is out of date, as a protection against misconfiguration.
 To initialise or migrate the database, you can use the migrate command:
 
 ```sh
-python -m jobrunner.cli.migrate
+just migrate
 ```
 
-
 ## Deploying
-jobrunner is currently deployed by hand because of the difficulties of adding automated deploys to backend servers.
 
-Connect to the relevant backend server:
-
-### TPP
-1. Log onto the VPN
-1. RDP onto L3
-1. SSH into the linux VM running on L3
-1. Switch to the [jobrunner user](https://github.com/opensafely-core/backend-server/blob/main/playbook.md#jobrunner-user)
-
-
-### EMIS
-1. SSH into EMIS
-
-
-When you're connected to the relevant server:
-1. [Switch to the jobrunner user](https://github.com/opensafely-core/backend-server/blob/main/playbook.md#jobrunner-user)
-1. Change to the `/srv/backend-server` directory
-1. [Deploy job-runner](https://github.com/opensafely-core/backend-server/blob/main/playbook.md#deploy-job-runner)
-  1. Note the sections on dependencies and config, if those are relevant to your deploy
-1. [Watch the logs for errors](https://github.com/opensafely-core/backend-server/blob/main/playbook.md#viewing-job-runner-logs)
+The jobrunner docker image is built by GitHub actions on merges to `main` and deployed automatically
+on backend servers.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -190,6 +190,37 @@ See the full set of options `add-job` will accept with:
 python -m jobrunner.cli.add_job --help
 ```
 
+## Running jobs on the test backend
+
+The [test backend](https://github.com/opensafely-core/backend-server/tree/main/backends/test) is
+a test version of an OpenSAFELY backend which has no access to patient data, but can be used to
+schedule and run jobs in a production-like environment.
+
+You will need ssh access to test.opensafely.org in order to add jobs using the CLI. This
+currently requires the same permissions as any non-test backend; see the
+[developer permissions documentation](https://bennett.wiki/products/developer-permissions-log/#platform-developerstesters) for further details.
+
+```
+ssh <your-username>@test.opensafely.org
+sudo su - opensafely
+
+just jobrunner/add-job https://github.com/opensafely/os-demo-research run_all
+```
+
+You will see the output of the newly created job (note that if it returns `'state': 'succeeded'`
+in the displayed json, the job has already run successfully on the test backend. Use `-f` to
+force dependencies to re-run).
+
+The jobrunner service is already running in the background on the test backend, so
+jobs should be picked up and run automatically. Check the job logs to see the progress of your
+job. From the output of `just add-job`, find the new job's `id` value.
+
+Now check the logs for this job:
+
+```
+just jobrunner/logs-id <your-job-id>
+```
+
 ## job-runner docker image
 
 Building the dev docker image:

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -9,11 +9,11 @@ JOB_SERVER_TOKEN=pass
 
 # A location where cohort CSVs (one row per patient) should be
 # stored. This folder must exist.
-HIGH_PRIVACY_STORAGE_BASE=/workdir/workspaces
+HIGH_PRIVACY_STORAGE_BASE=
 
 # A location where script outputs (some for publication) should be
 # stored
-MEDIUM_PRIVACY_STORAGE_BASE=/workdir/workspaces
+MEDIUM_PRIVACY_STORAGE_BASE=
 
 # A Github developer token that has read access to private repos
 PRIVATE_REPO_ACCESS_TOKEN=

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -246,7 +246,7 @@ OTEL_ATTR_TYPES = (bool, str, bytes, int, float)
 
 
 def set_span_metadata(span, job, error=None, results=None, **attrs):
-    """Set span metadata with everthing we know about a job."""
+    """Set span metadata with everything we know about a job."""
     attributes = {}
 
     if attrs:
@@ -258,8 +258,10 @@ def set_span_metadata(span, job, error=None, results=None, **attrs):
     for k, v in attributes.items():
         if not isinstance(v, OTEL_ATTR_TYPES):
             # log to help us notice this
-            logger.info(
-                f"Trace span {span.name} attribute {k} was set invalid type: {v}, type {type(v)}"
+            # If the span has no name attribute (e.g. NonRecordingSpans), log its type instead
+            span_name = getattr(span, "name", type(span))
+            logger.error(
+                f"Trace span {span_name} attribute {k} was set invalid type: {v}, type {type(v)}"
             )
             # coerce to string so we preserve some information
             v = str(v)

--- a/justfile
+++ b/justfile
@@ -53,6 +53,7 @@ _dotenv:
     if [[ ! -f .env ]]; then
       echo "No '.env' file found; creating a default '.env' from 'dotenv-sample'"
       cp dotenv-sample .env
+      ./local-setup.sh
     fi
 
 # Ensure dev and prod requirements installed and up to date

--- a/justfile
+++ b/justfile
@@ -150,5 +150,8 @@ fix: devenv
     just --fmt --unstable --justfile docker/justfile
 
 # Run the dev project
-run repo action: devenv
-    $BIN/python -m jobrunner.cli.add_job {{ repo }} {{ action }}
+add-job repo action *args: devenv
+    $BIN/python -m jobrunner.cli.add_job {{ repo }} {{ action }} {{ args }}
+
+run: devenv
+    $BIN/python -m jobrunner.run

--- a/justfile
+++ b/justfile
@@ -151,8 +151,8 @@ fix: devenv
     just --fmt --unstable --justfile docker/justfile
 
 # Run the dev project
-add-job repo action *args: devenv
-    $BIN/python -m jobrunner.cli.add_job {{ repo }} {{ action }} {{ args }}
+add-job *args: devenv
+    $BIN/python -m jobrunner.cli.add_job {{ args }}
 
 run: devenv
     $BIN/python -m jobrunner.run

--- a/local-setup.sh
+++ b/local-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+test -f .env|| cp dotenv_sample .env
+
+mkdir -p workdir/high_privacy
+mkdir -p workdir/medium_privacy
+
+high_privacy_dir="$PWD/workdir/high_privacy"
+med_privacy_dir="$PWD/workdir/medium_privacy"
+
+sed -i"" -e "s|^HIGH_PRIVACY_STORAGE_BASE=.*|HIGH_PRIVACY_STORAGE_BASE=\"$high_privacy_dir\"|" .env
+sed -i"" -e "s|^MEDIUM_PRIVACY_STORAGE_BASE=.*|MEDIUM_PRIVACY_STORAGE_BASE=\"$med_privacy_dir\"|" .env

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -335,3 +335,10 @@ def test_set_span_metadata_error(db):
     assert span.status.description == "test"
     assert span.events[0].name == "exception"
     assert span.events[0].attributes["exception.message"] == "test"
+
+
+def test_set_span_metadata_non_recording_span_with_invalid_attribute_type(db, caplog):
+    job = job_factory()
+    non_recording_span = trace.NonRecordingSpan({})
+    tracing.set_span_metadata(non_recording_span, job, foo=None)
+    assert "attribute foo was set invalid type: None" in caplog.text


### PR DESCRIPTION
Fixes #809 
Update developer docs to document how to run jobs in the test backend, and fix some out of date docs at the same time.
Also adds a small script to update the storage dirs based on your local paths
And a drive-by fix for a error that was being thrown when trying to log a NonRecordingSpan

Note that the docs on running jobs on the test backend depend on this [backend-server PR](https://github.com/opensafely-core/backend-server/pull/270)