### PR TITLE
Task API tweaks

### DIFF
--- a/jobrunner/agent/task_api.py
+++ b/jobrunner/agent/task_api.py
@@ -1,6 +1,6 @@
 from jobrunner.lib import database  # cheating!
 from jobrunner.models import Task as ControllerTask  # cheating!
-from jobrunner.schema import AgentTask, TaskStage
+from jobrunner.schema import AgentTask
 
 
 def get_active_tasks() -> list[AgentTask]:
@@ -9,6 +9,7 @@ def get_active_tasks() -> list[AgentTask]:
     return [
         AgentTask(
             id=t.id,
+            backend=t.backend,
             type=t.type,
             definition=t.definition,
             created_at=t.created_at,
@@ -19,16 +20,15 @@ def get_active_tasks() -> list[AgentTask]:
 
 def update_controller(
     task: AgentTask,
-    stage: TaskStage,
-    timestamp: int,
+    stage: str,
     results: dict = None,
     complete: bool = False,
 ):
     """Update the controller with the current state of the task.
 
     stage: the current stage of the task from the agent's perspective
-    timestamp: ns timestamp of current stage was acheived (for accurate telemetry)
     results: optional dictionary of completed results of this task, expected to be immutable
+    complete: if the agent considers this task complete
     """
     # cheating for now - should be HTTP API call, which ends up updating the
     # controller db, but we just update the db directly
@@ -40,7 +40,6 @@ def update_controller(
     # we have currently is the loop, so we'll do that logic there for step 1
     db_task = database.find_one(ControllerTask, id=task.id)
     db_task.agent_stage = stage
-    db_task.agent_stage_ns = timestamp
     db_task.agent_results = results
     db_task.agent_complete = complete
     database.update(db_task)

--- a/jobrunner/controller/task_api.py
+++ b/jobrunner/controller/task_api.py
@@ -21,7 +21,7 @@ def mark_task_inactive(task):
     it, and records the completion time.
     """
     task.active = False
-    task.completed_at = int(time.time())
+    task.finished_at = int(time.time())
     database.update(task)
 
 

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -19,7 +19,7 @@ from functools import total_ordering
 
 from jobrunner.lib.database import databaseclass, migration
 from jobrunner.lib.string_utils import slugify
-from jobrunner.schema import TaskStage, TaskType
+from jobrunner.schema import TaskType
 
 
 # this is the overall high level state the job-runner uses to decide how to
@@ -384,13 +384,13 @@ class Task:
     __tableschema__ = """
         CREATE TABLE tasks (
             id TEXT,
+            backend TEST,
             type TEXT,
             definition TEXT,
             active BOOLEAN,
             created_at int,
-            completed_at int,
+            finished_at int,
             agent_stage TEXT,
-            agent_stage_ns INT,
             agent_complete BOOLEAN,
             agent_results TEXT,
             PRIMARY KEY (id)
@@ -399,25 +399,18 @@ class Task:
 
     # controller set fields
     id: str  # noqa: A003
+    backend: str
     type: TaskType  # noqa: A003
     definition: dict
+    active: bool = True
     # these timestamps are from the controller's POV
     # default second resolution
     created_at: int = None
-    completed_at: int = None
-    # maybe we don't need this, and can use completed_at is None?
-    active: bool = True
+    finished_at: int = None
 
     # state sent from the agent
-    agent_stage: TaskStage = None
-    # timestamp of the stage
-    # ns resolution, because:
-    # a) we need subsecond precision
-    # b) that's what otel wants natively
-    # c) it's what we're already using in tracing code
-    agent_stage_ns: int = None
-    # the results of the task
+    agent_stage: str = None
     # the task is complete from the agent's POV once this is set
     agent_complete: bool = False
-    # results of the task
+    # results of the task, inlcuding any error information
     agent_results: dict = None

--- a/jobrunner/schema.py
+++ b/jobrunner/schema.py
@@ -1,29 +1,11 @@
 from dataclasses import dataclass
 from enum import Enum
 
-from jobrunner.job_executor import ExecutorState
-
 
 class TaskType(Enum):
     RUNJOB = "runjob"
+    CANCELJOB = "canceljob"
     # TODO: delete job
-
-
-class TaskStage(Enum):
-    """Valid stage of any tasks
-
-    A big merge of multiple types of TaskType's stages
-    """
-
-    # RUNJOB stages
-    PREPARING = ExecutorState.PREPARING.value
-    PREPARED = ExecutorState.PREPARED.value
-    EXECUTING = ExecutorState.EXECUTING.value
-    EXECUTED = ExecutorState.EXECUTED.value
-    FINALIZING = ExecutorState.FINALIZING.value
-    # Final stages
-    FINALIZED = ExecutorState.FINALIZED.value
-    ERROR = ExecutorState.ERROR.value
 
 
 @dataclass(frozen=True)
@@ -38,6 +20,7 @@ class AgentTask:
     """
 
     id: str  # noqa: A003
+    backend: str
     type: TaskType  # noqa: A003
     definition: dict
     created_at: int = None

--- a/tests/agent/test_task_api.py
+++ b/tests/agent/test_task_api.py
@@ -1,8 +1,5 @@
-import time
-
 from jobrunner.agent import task_api
 from jobrunner.controller import task_api as controller_api
-from jobrunner.schema import TaskStage
 from tests.factories import runjob_task_factory
 
 
@@ -19,48 +16,39 @@ def test_get_active_jobs(db):
 def test_update_controller(db):
     task = runjob_task_factory()
 
-    timestamp_ns = int(time.time())
     task_api.update_controller(
         task,
-        stage=TaskStage.FINALIZED,
-        timestamp=timestamp_ns,
+        stage="FINALIZED",
         results={"test": "test"},
         complete=True,
     )
 
     db_task = controller_api.get_task(task.id)
-    assert db_task.agent_stage == TaskStage.FINALIZED
-    assert db_task.agent_stage_ns == timestamp_ns
+    assert db_task.agent_stage == "FINALIZED"
     assert db_task.agent_results == {"test": "test"}
     assert bool(db_task.agent_complete) is True
 
 
 def test_full_job_stages(db):
     task = runjob_task_factory()
-    timestamp_ns = int(time.time() * 1e9)
 
     stages = [
-        TaskStage.PREPARING,
-        TaskStage.PREPARED,
-        TaskStage.EXECUTING,
-        TaskStage.EXECUTED,
-        TaskStage.FINALIZING,
+        "PREPARING",
+        "PREPARED",
+        "EXECUTING",
+        "EXECUTED",
     ]
 
     for stage in stages:
-        timestamp_ns += int(1e6)  # 1ms
-        task_api.update_controller(task, stage, timestamp_ns)
+        task_api.update_controller(task, stage)
         db_task = controller_api.get_task(task.id)
         assert db_task.agent_stage == stage
-        assert db_task.agent_stage_ns == timestamp_ns
         assert bool(db_task.agent_complete) is False
 
-    timestamp_ns += int(1e6)
     task_api.update_controller(
-        task, TaskStage.FINALIZED, timestamp_ns, results={"test": "test"}, complete=True
+        task, "FINALIZED", results={"test": "test"}, complete=True
     )
     db_task = controller_api.get_task(task.id)
-    assert db_task.agent_stage == TaskStage.FINALIZED
-    assert db_task.agent_stage_ns == timestamp_ns
+    assert db_task.agent_stage == "FINALIZED"
     assert db_task.agent_results == {"test": "test"}
     assert bool(db_task.agent_complete) is True

--- a/tests/controller/test_task_api.py
+++ b/tests/controller/test_task_api.py
@@ -9,7 +9,10 @@ def test_insert_runjob_task(db):
     job = job_factory()
 
     task = Task(
-        id=job.id, type=TaskType.RUNJOB, definition=job_to_job_definition(job).to_dict()
+        id=job.id,
+        backend="test",
+        type=TaskType.RUNJOB,
+        definition=job_to_job_definition(job).to_dict(),
     )
 
     task_api.insert_task(task)
@@ -24,7 +27,10 @@ def test_mark_inactive(db):
     job = job_factory()
 
     task = Task(
-        id=job.id, type=TaskType.RUNJOB, definition=job_to_job_definition(job).to_dict()
+        id=job.id,
+        backend="test",
+        type=TaskType.RUNJOB,
+        definition=job_to_job_definition(job).to_dict(),
     )
 
     task_api.insert_task(task)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -125,7 +125,10 @@ def runjob_task_factory(*args, state=State.RUNNING, **kwargs):
     """Set up a job and corresponding task"""
     job = job_factory(*args, state=state, **kwargs)
     task = Task(
-        id=job.id, type=TaskType.RUNJOB, definition=job_to_job_definition(job).to_dict()
+        id=job.id,
+        backend="test",
+        type=TaskType.RUNJOB,
+        definition=job_to_job_definition(job).to_dict(),
     )
     task_api.insert_task(task)
     return task


### PR DESCRIPTION
- no timestamps - agents gonna do its own telemetry, at least for now
- add backend field, as controller needs to support multiple
- get rid of TaskStage - the controller doesn't care, just use a string
- renamed completed_at to finished_at, as semantically different
   from completed flag

