### PR TITLE
add telemetry for the agent loop and runjob tasks

### DIFF
--- a/jobrunner/agent/tracing.py
+++ b/jobrunner/agent/tracing.py
@@ -1,0 +1,83 @@
+import logging
+
+from jobrunner.job_executor import JobDefinition
+from jobrunner.schema import AgentTask
+from jobrunner.tracing import set_span_attributes
+
+
+logger = logging.getLogger(__name__)
+
+
+OTEL_ATTR_TYPES = (bool, str, bytes, int, float)
+
+
+def set_task_span_metadata(span, task: AgentTask, **attrs):
+    """Set span metadata with everything we know about a task."""
+    attributes = {}
+
+    if attrs:
+        attributes.update(attrs)
+    attributes.update(trace_task_attributes(task))
+
+    set_span_attributes(span, attributes)
+
+
+def trace_task_attributes(task: AgentTask):
+    """These attributes are added to every span in order to slice and dice by
+    each as needed.
+    Note that task definition is not set on the task trace; we assume that the
+    definition contains task-type-specific info that will be set on the releavent
+    task type (e.g. a RUNJOB task will set job metadata)
+    """
+    attrs = dict(
+        backend=task.backend,
+        task=task.id,
+        task_type=task.type.name,
+        # convert seconds to ns integer
+        task_created_at=int(task.created_at * 1e9),
+    )
+
+    return attrs
+
+
+def set_job_span_metadata(span, job: JobDefinition, **attrs):
+    """Set span metadata with everything we know about a job."""
+    attributes = {}
+
+    if attrs:
+        attributes.update(attrs)
+
+    attributes.update(trace_job_attributes(job))
+
+    set_span_attributes(span, attributes)
+
+
+def trace_job_attributes(job: JobDefinition):
+    """These attributes are added to every span in order to slice and dice by
+    each as needed.
+    """
+    if job.study:
+        repo_url = job.study.git_repo_url or ""
+        commit = job.study.commit or ""
+    else:
+        repo_url = ""
+        commit = ""
+
+    attrs = dict(
+        job=job.id,
+        job_request=job.job_request_id,
+        workspace=job.workspace,
+        repo_url=repo_url,
+        commit=commit,
+        action=job.action,
+        # convert seconds to ns integer
+        job_created_at=int(job.created_at * 1e9),
+        image=job.image,
+        args=",".join(job.args or []),
+        inputs=",".join(job.inputs or []),
+        allow_database_access=job.allow_database_access,
+        cpu_count=job.cpu_count,
+        memory_limit=job.memory_limit,
+    )
+
+    return attrs

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -253,6 +253,15 @@ def set_span_metadata(span, job, error=None, results=None, **attrs):
         attributes.update(attrs)
     attributes.update(trace_attributes(job, results))
 
+    set_span_attributes(span, attributes)
+
+    if error:
+        span.set_status(trace.Status(trace.StatusCode.ERROR, str(error)))
+    if isinstance(error, Exception):
+        span.record_exception(error)
+
+
+def set_span_attributes(span, attributes):
     # opentelemetry can only handle serializing certain attribute types
     clean_attrs = {}
     for k, v in attributes.items():
@@ -268,11 +277,6 @@ def set_span_metadata(span, job, error=None, results=None, **attrs):
         clean_attrs[k] = v
 
     span.set_attributes(clean_attrs)
-
-    if error:
-        span.set_status(trace.Status(trace.StatusCode.ERROR, str(error)))
-    if isinstance(error, Exception):
-        span.record_exception(error)
 
 
 def trace_attributes(job, results=None):

--- a/tests/agent/test_tracing.py
+++ b/tests/agent/test_tracing.py
@@ -1,0 +1,107 @@
+from jobrunner.agent import main
+from jobrunner.job_executor import ExecutorState
+from tests.agent.stubs import StubExecutorAPI
+from tests.conftest import get_trace
+
+
+def test_tracing_state_change_attributes(db):
+    api = StubExecutorAPI()
+
+    task, job_id = api.add_test_task(ExecutorState.UNKNOWN)
+    # prepare is synchronous
+    api.set_job_transition(job_id, ExecutorState.PREPARED)
+    main.handle_single_task(task, api)
+
+    spans = get_trace("agent_loop")
+    # one span each time we called main.handle_single_task
+    assert len(spans) == 1
+    span = spans[0]
+
+    # check we have the keys we expect
+    assert set(span.attributes.keys()) == {
+        "backend",
+        "task_type",
+        "task",
+        "task_created_at",
+        "initial_job_status",
+        "job",
+        "job_request",
+        "workspace",
+        "repo_url",
+        "commit",
+        "action",
+        "job_created_at",
+        "image",
+        "args",
+        "inputs",
+        "allow_database_access",
+        "cpu_count",
+        "memory_limit",
+        "final_job_status",
+        "complete",
+    }
+    # attributes added from the task
+    assert span.attributes["backend"] == "test"
+    assert span.attributes["task_type"] == "RUNJOB"
+    assert span.attributes["task"] == task.id
+    assert span.attributes["task_created_at"] == task.created_at * 1e9
+    # attributes added from the job
+    assert span.attributes["job"] == job_id
+    assert spans[0].attributes["initial_job_status"] == "UNKNOWN"
+    assert spans[0].attributes["final_job_status"] == "PREPARED"
+    assert not spans[0].attributes["complete"]
+
+
+def test_tracing_final_state_attributes(db):
+    api = StubExecutorAPI()
+
+    task, job_id = api.add_test_task(ExecutorState.EXECUTED)
+    api.set_job_transition(
+        job_id, ExecutorState.FINALIZED, hook=lambda job_id: api.set_job_result(job_id)
+    )
+    main.handle_single_task(task, api)
+
+    spans = get_trace("agent_loop")
+    # one span each time we called main.handle_single_task
+    assert len(spans) == 1
+    span = spans[0]
+
+    # check we have the keys we expect
+    assert set(span.attributes.keys()) == {
+        "backend",
+        "task_type",
+        "task",
+        "task_created_at",
+        "initial_job_status",
+        "job",
+        "job_request",
+        "workspace",
+        "repo_url",
+        "commit",
+        "action",
+        "job_created_at",
+        "image",
+        "args",
+        "inputs",
+        "allow_database_access",
+        "cpu_count",
+        "memory_limit",
+        "final_job_status",
+        "complete",
+        # results included on the final span
+        "unmatched_patterns",
+        "image_id",
+        "unmatched_outputs",
+        "message",
+        "exit_code",
+    }
+    # attributes added from the task
+    assert span.attributes["backend"] == "test"
+    assert span.attributes["task_type"] == "RUNJOB"
+    assert span.attributes["task"] == task.id
+    assert span.attributes["task_created_at"] == task.created_at * 1e9
+    # attributes added from the job
+    assert span.attributes["job"] == job_id
+    assert spans[0].attributes["initial_job_status"] == "EXECUTED"
+    assert spans[0].attributes["final_job_status"] == "FINALIZED"
+    assert spans[0].attributes["complete"]


### PR DESCRIPTION
Add tracing for the agent loop.

Sets common attributes from the task (which later may not be job-related), and then attributes from the job. I didn't add all job attributes, and this is a job definition rather than a job, so it doesn't have quite the same things as the main jobrunner.tracing module has for a job.  We may need to revisit what's actually useful to include.
  
On each update_controller call, we also add the final job status and results/error attributes if there are any.
