### PR TITLE
Ignore warning when running `pytest --cov`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ filterwarnings = [
     "ignore::DeprecationWarning:opentelemetry.*:",
     "ignore::DeprecationWarning:pytest_freezegun:17",
     "ignore::DeprecationWarning:pytest_responses:9",
+    "ignore:.*dynamic_context.*:pytest_cov.CentralCovContextWarning",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
The `pytest --cov` invocation is a convenient way of checking how well a given set of tests covers a given set of files and is key to a fast feedback loop when addressing coverage issues. See:
https://github.com/opensafely-core/ehrql/wiki/Tips-for-using-pytest#coverage

However, currently it fails with the error:

    pytest_cov.CentralCovContextWarning: Detected
    dynamic_context=test_function in coverage configuration. This is
    unnecessary as this plugin provides the more complete --cov-context
    option.

However we don't want to remove this setting because it's required for the `coverage run` invocation which we use in CI and we want to maintain that because it gives a nicer story for combining coverage from multiple runs. So instead we just ignore the warning.

Related Slack thread:
https://app.slack.com/client/T323MQNRY/C069YDR4NCA