### PR TITLE
Ensure tasks table is created

### DIFF
--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -414,3 +414,6 @@ class Task:
     agent_complete: bool = False
     # results of the task, inlcuding any error information
     agent_results: dict = None
+
+    # ensure this table exists
+    migration(4, __tableschema__)


### PR DESCRIPTION
For hysterical raisins, we don't autocreate all tables. Adding an
explicit migration ensures that we will.

We expect to move this all to djagno ORM soonish anyway.

Testing migrations is hard. This was manually tested against the curret
test-backend db.

```
$ cp test-backend.db.sqlite workdir/db.sqlite
$ sqlite3 workdir/db.sqlite 'SELECT * FROM tasks'
Error: in prepare, no such table: tasks (1)
$ python3 -m jobrunner.cli.migrate
2025-04-11 10:36:43.520Z Skipping migration 1 as already applied
2025-04-11 10:36:43.521Z Skipping migration 2 as already applied
2025-04-11 10:36:43.521Z Skipping migration 3 as already applied
2025-04-11 10:36:43.522Z Applied migration 4:

        CREATE TABLE tasks (
            id TEXT,
            backend TEXT,
            type TEXT,
            definition TEXT,
            active BOOLEAN,
            created_at int,
            finished_at int,
            agent_stage TEXT,
            agent_complete BOOLEAN,
            agent_results TEXT,
            PRIMARY KEY (id)
        )

$ sqlite3 workdir/db.sqlite 'SELECT * FROM tasks'
$
```
