### PR TITLE
Implement agent handle_cancel_job_task

### DIFF
--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -110,6 +110,9 @@ def handle_cancel_job_task(task, api):
     # a dummy JobDefinition to use with the executor API. job ID is all we
     # need to find out the current status and do the actions required to
     # cancel and clean up
+    # TODO: finalize() writes job logs, and will be missing some expected information
+    # if only job_id is passed (from job definition fields, it expects to write
+    # job id, job_request_id, created_at, database_name and commit)
     job = JobDefinition.from_job_id(task.definition["job_id"], cancelled=True)
 
     job_status = api.get_status(job)

--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -9,6 +9,7 @@ from jobrunner.agent import task_api, tracing
 from jobrunner.executors import get_executor_api
 from jobrunner.job_executor import ExecutorAPI, ExecutorState, JobDefinition, JobStatus
 from jobrunner.lib.log_utils import configure_logging, set_log_context
+from jobrunner.schema import TaskType
 
 
 log = logging.getLogger(__name__)
@@ -91,7 +92,13 @@ def trace_handle_task(task, api):
     with tracer.start_as_current_span("LOOP_TASK") as span:
         tracing.set_task_span_metadata(span, task)
         try:
-            handle_run_job_task(task, api)
+            match task.type:
+                case TaskType.RUNJOB:
+                    handle_run_job_task(task, api)
+                case TaskType.CANCELJOB:
+                    handle_cancel_job_task(task, api)
+                case _:
+                    assert False, f"Unknown task type {task.type}"
         except Exception as exc:
             span.set_status(trace.Status(trace.StatusCode.ERROR, str(exc)))
             span.record_exception(exc)
@@ -99,34 +106,47 @@ def trace_handle_task(task, api):
 
 
 def handle_cancel_job_task(task, api):
-    # TODO: make it work!
-    # CODE DUMP - not working, just preserving all bits of cancellation logic
-    # from handle_run_job_task for fixing up later
-    job = JobDefinition.from_dict(task.definition)
+    # A CANCELJOB task just sends a job_id in its task definition; construct
+    # a dummy JobDefinition to use with the executor API. job ID is all we
+    # need to find out the current status and do the actions required to
+    # cancel and clean up
+    job = JobDefinition.from_job_id(task.definition["job_id"], cancelled="user")
 
     job_status = api.get_status(job)
 
-    # TODO: check logic here
-    # if job_status.state == ExecutorState.EXECUTED the job has already finished, so we
-    # don't need to do anything here
-    if job_status.state == ExecutorState.EXECUTING:
-        api.terminate(job)  # synchronous operation
-        new_status = api.get_status(job)  # Executed (if no error)
-        update_controller(task, new_status.state, new_status.timestamp_ns)
-        return
-    if job_status.state == ExecutorState.PREPARED:
-        # Nb. no need to actually run finalize() in this case. The FINALIZED
-        # state will be handled and cleaned up further down the loop
-        update_controller(task, ExecutorState.FINALIZED)
-        return
-    if job_status.state == ExecutorState.UNKNOWN:
-        update_controller(task, ExecutorState.UNKNOWN)
-        return
+    span = trace.get_current_span()
+    span.set_attributes({"id": job.id, "initial_job_status": job_status.state.name})
 
-    # Cancelled jobs that have had cleanup() should now be again set to cancelled here to ensure
-    # they finish in the FAILED state
-    api.cleanup(job)
-    update_controller(task, job_status.state, complete=True)
+    with set_log_context(job_definition=job):
+        match job_status.state:
+            case ExecutorState.UNKNOWN | ExecutorState.FINALIZED:
+                # The job hasn't started or has already finished
+                final_status = job_status
+            case ExecutorState.PREPARED:
+                # Nb. no need to actually run finalize() in this case.
+                final_status = JobStatus(ExecutorState.FINALIZED)
+            case ExecutorState.EXECUTING:
+                new_status = api.terminate(job)
+                update_controller(task, new_status)
+                # call finalize to write the job logs
+                final_status = api.finalize(job)
+            case ExecutorState.EXECUTED | ExecutorState.ERROR:
+                # job has finished or errored, call finalize to write the job logs
+                final_status = api.finalize(job)
+            case _:  # pragma: no cover
+                raise InvalidTransition(
+                    f"unexpected state of job {job.id}: {job_status.state}"
+                )
+
+        if job_status.state in [
+            ExecutorState.EXECUTING,
+            ExecutorState.EXECUTED,
+            ExecutorState.FINALIZED,
+            ExecutorState.ERROR,
+        ]:
+            api.cleanup(job)
+
+        update_controller(task, final_status, complete=True)
 
 
 def handle_run_job_task(task, api):
@@ -135,7 +155,7 @@ def handle_run_job_task(task, api):
     This contains the main state machine logic for a task. For the most part,
     state transitions follow the same logic, which is abstracted. Some
     transitions require special logic, mainly the initial and final states, as
-    well as supporting cancellation and various operational modes.
+    well as various operational modes.
     """
     job = JobDefinition.from_dict(task.definition)
     with set_log_context(job_definition=job):

--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -110,7 +110,7 @@ def handle_cancel_job_task(task, api):
     # a dummy JobDefinition to use with the executor API. job ID is all we
     # need to find out the current status and do the actions required to
     # cancel and clean up
-    job = JobDefinition.from_job_id(task.definition["job_id"], cancelled="user")
+    job = JobDefinition.from_job_id(task.definition["job_id"], cancelled=True)
 
     job_status = api.get_status(job)
 

--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -113,7 +113,7 @@ def handle_cancel_job_task(task, api):
     # TODO: finalize() writes job logs, and will be missing some expected information
     # if only job_id is passed (from job definition fields, it expects to write
     # job id, job_request_id, created_at, database_name and commit)
-    job = JobDefinition.from_job_id(task.definition["job_id"], cancelled=True)
+    job = JobDefinition.from_dict(task.definition)
 
     job_status = api.get_status(job)
 

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -544,7 +544,7 @@ def cancel_job(job):
     canceljob_task = Task(
         id=f"{runjob_task.id}-cancel",
         type=TaskType.CANCELJOB,
-        definition={"job_id": job.id},
+        definition=job_to_job_definition(job).to_dict(),
         # TODO: Uncomment this when Job grows a `backend` field
         backend="",  # job.backend,
     )

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -321,8 +321,7 @@ def job_to_job_definition(job):
         level4_max_filesize=config.LEVEL4_MAX_FILESIZE,
         level4_max_csv_rows=config.LEVEL4_MAX_CSV_ROWS,
         level4_file_types=list(config.LEVEL4_FILE_TYPES),
-        # Vestigial attribute which can be removed when we update JobDefinition
-        cancelled=None,
+        cancelled=job.cancelled,
     )
 
 

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -501,7 +501,10 @@ def get_job_metadata(job_definition, outputs, container_metadata, results):
     job_metadata["status_message"] = results.message
     job_metadata["container_metadata"] = container_metadata
     job_metadata["outputs"] = outputs
-    job_metadata["commit"] = job_definition.study.commit
+    if job_definition.study is not None:
+        job_metadata["commit"] = job_definition.study.commit
+    else:
+        job_metadata["commit"] = None
     job_metadata["database_name"] = job_definition.database_name
     job_metadata["hint"] = results.unmatched_hint
     # all calculated results

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -251,9 +251,7 @@ class LocalDockerAPI(ExecutorAPI):
 
         docker.kill(container_name(job_definition))
 
-        return JobStatus(
-            ExecutorState.EXECUTED, f"Job terminated by {job_definition.cancelled}"
-        )
+        return JobStatus(ExecutorState.EXECUTED, "Job terminated by user")
 
     def cleanup(self, job_definition):
         if config.CLEAN_UP_DOCKER_OBJECTS:
@@ -442,7 +440,7 @@ def finalize_job(job_definition):
             )
 
     elif exit_code == 137 and job_definition.cancelled:
-        message = f"Job cancelled by {job_definition.cancelled}"
+        message = "Job cancelled by user"
     # Nb. this flag has been observed to be unreliable on some versions of Linux
     elif (
         container_metadata["State"]["ExitCode"] == 137

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -58,29 +58,6 @@ class JobDefinition:
         # Create the JobDefinition instance with the Study object
         return cls(study=study, **{k: v for k, v in data.items()})
 
-    @classmethod
-    def from_job_id(cls, job_id, **kwargs):
-        # Create a JobDefinition with empty values for everything except id
-        defaults = dict(
-            job_request_id=None,
-            study=None,
-            workspace=None,
-            action=None,
-            created_at=None,
-            image=None,
-            args=None,
-            env=None,
-            inputs=None,
-            output_spec=None,
-            allow_database_access=None,
-            level4_max_csv_rows=None,
-            level4_max_filesize=None,
-            cancelled=False,
-        )
-        defaults.update(**kwargs)
-
-        return cls(id=job_id, **defaults)
-
 
 class ExecutorState(Enum):
     # Job is currently preparing to run: creating volumes,copying files, etc

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -39,8 +39,7 @@ class JobDefinition:
     cpu_count: str = None  # number of CPUs to be allocated
     memory_limit: str = None  # memory limit to apply
     level4_file_types: list = field(default_factory=lambda: [".csv"])
-    # if a job has been cancelled, the name of the canceller - either "user" or "admin"
-    cancelled: str = None
+    cancelled: bool = False
 
     def to_dict(self):
         return asdict(self)
@@ -76,7 +75,7 @@ class JobDefinition:
             allow_database_access=None,
             level4_max_csv_rows=None,
             level4_max_filesize=None,
-            cancelled=None,
+            cancelled=False,
         )
         defaults.update(**kwargs)
 

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -59,6 +59,29 @@ class JobDefinition:
         # Create the JobDefinition instance with the Study object
         return cls(study=study, **{k: v for k, v in data.items()})
 
+    @classmethod
+    def from_job_id(cls, job_id, **kwargs):
+        # Create a JobDefinition with empty values for everything except id
+        defaults = dict(
+            job_request_id=None,
+            study=None,
+            workspace=None,
+            action=None,
+            created_at=None,
+            image=None,
+            args=None,
+            env=None,
+            inputs=None,
+            output_spec=None,
+            allow_database_access=None,
+            level4_max_csv_rows=None,
+            level4_max_filesize=None,
+            cancelled=None,
+        )
+        defaults.update(**kwargs)
+
+        return cls(id=job_id, **defaults)
+
 
 class ExecutorState(Enum):
     # Job is currently preparing to run: creating volumes,copying files, etc

--- a/tests/agent/stubs.py
+++ b/tests/agent/stubs.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 from jobrunner.job_executor import ExecutorState, JobDefinition, JobStatus
 from jobrunner.schema import AgentTask
-from tests.factories import runjob_db_task_factory
+from tests.factories import canceljob_db_task_factory, runjob_db_task_factory
 
 
 class StubExecutorAPI:
@@ -40,7 +40,7 @@ class StubExecutorAPI:
         self.deleted = defaultdict(lambda: defaultdict(list))
         self.last_time = int(time.time())
 
-    def add_test_task(
+    def add_test_runjob_task(
         self,
         executor_state,
         timestamp=None,
@@ -50,6 +50,16 @@ class StubExecutorAPI:
 
         task = AgentTask.from_task(runjob_db_task_factory(**kwargs))
         job = JobDefinition.from_dict(task.definition)
+        self.set_job_status(job.id, executor_state)
+        return task, job.id
+
+    def add_test_canceljob_task(
+        self,
+        executor_state,
+        **kwargs,
+    ) -> AgentTask:
+        task = AgentTask.from_task(canceljob_db_task_factory(**kwargs))
+        job = JobDefinition.from_job_id(task.definition["job_id"], cancelled="user")
         self.set_job_status(job.id, executor_state)
         return task, job.id
 

--- a/tests/agent/stubs.py
+++ b/tests/agent/stubs.py
@@ -59,7 +59,7 @@ class StubExecutorAPI:
         **kwargs,
     ) -> AgentTask:
         task = AgentTask.from_task(canceljob_db_task_factory(**kwargs))
-        job = JobDefinition.from_job_id(task.definition["job_id"], cancelled="user")
+        job = JobDefinition.from_dict(task.definition)
         self.set_job_status(job.id, executor_state)
         return task, job.id
 

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -97,3 +97,98 @@ def test_handle_job_with_error(mock_update_controller, db):
     # exception info has been added to the span
     assert span.status.status_code.name == "ERROR"
     assert span.status.description == "Exception: foo"
+
+
+
+def test_handle_prepared_job_cancelled(db, monkeypatch):
+    api = StubExecutorAPI()
+
+    job = api.add_test_job(ExecutorState.UNKNOWN, State.PENDING, StatusCode.CREATED)
+
+    assert job.id not in api.tracker["prepare"]
+    run.handle_job(job, api)
+    assert job.id in api.tracker["prepare"]
+    assert job.state == State.RUNNING
+    assert job.status_code == StatusCode.PREPARING
+
+    api.set_job_status_from_executor_state(job, ExecutorState.PREPARED)
+
+    job.cancelled = True
+
+    run.handle_job(job, api)
+
+    # executor state
+    job_definition = run.job_to_job_definition(job)
+
+    # StubExecutorAPI needs state setting to FINALIZED, local executor is able to
+    # determine this for itself based on the presence of volume & absence of container
+    api.set_job_status_from_executor_state(job, ExecutorState.FINALIZED)
+
+    # put this here for completeness so that we can compare to other executors
+    assert api.get_status(job_definition).state == ExecutorState.FINALIZED
+    assert job.status_code == StatusCode.FINALIZED
+    assert job.state == State.RUNNING
+
+    assert job.id not in api.tracker["cleanup"]
+    run.handle_job(job, api)
+    assert job.id in api.tracker["cleanup"]
+
+    assert job.id in api.tracker["prepare"]
+    assert job.id not in api.tracker["terminate"]
+    assert job.id not in api.tracker["finalize"]
+    assert job.id in api.tracker["cleanup"]
+
+    # our state
+    assert job.state == State.FAILED
+    assert job.status_message == "Cancelled by user"
+    assert job.status_code == StatusCode.CANCELLED_BY_USER
+
+
+def test_handle_running_job_cancelled(db, monkeypatch):
+    api = StubExecutorAPI()
+
+    job = api.add_test_job(ExecutorState.UNKNOWN, State.PENDING, StatusCode.CREATED)
+
+    assert job.id not in api.tracker["prepare"]
+    run.handle_job(job, api)
+    assert job.id in api.tracker["prepare"]
+    assert job.state == State.RUNNING
+    assert job.status_code == StatusCode.PREPARING
+
+    api.set_job_status_from_executor_state(job, ExecutorState.PREPARED)
+
+    assert job.id not in api.tracker["execute"]
+    run.handle_job(job, api)
+    assert job.id in api.tracker["execute"]
+    assert job.state == State.RUNNING
+    assert job.status_code == StatusCode.EXECUTING
+
+    job.cancelled = True
+
+    assert job.id not in api.tracker["terminate"]
+    run.handle_job(job, api)
+    assert job.id in api.tracker["terminate"]
+
+    # executor state
+    job_definition = run.job_to_job_definition(job)
+    assert api.get_status(job_definition).state == ExecutorState.EXECUTED
+
+    assert job.state == State.RUNNING
+    assert job.status_code == StatusCode.EXECUTED
+
+    assert job.id not in api.tracker["finalize"]
+    run.handle_job(job, api)
+    assert job.id in api.tracker["finalize"]
+
+    api.set_job_status_from_executor_state(job, ExecutorState.FINALIZED)
+
+    assert job.state == State.RUNNING
+    assert job.status_code == StatusCode.FINALIZING
+
+    assert job.id not in api.tracker["cleanup"]
+    run.handle_job(job, api)
+    assert job.id in api.tracker["cleanup"]
+
+    assert job.state == State.FAILED
+    assert job.status_message == "Cancelled by user"
+    assert job.status_code == StatusCode.CANCELLED_BY_USER

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -15,7 +15,7 @@ def test_handle_job_full_execution(db, freezer):
 
     api = StubExecutorAPI()
 
-    task, job_id = api.add_test_task(ExecutorState.UNKNOWN)
+    task, job_id = api.add_test_runjob_task(ExecutorState.UNKNOWN)
 
     freezer.tick(1)
 
@@ -71,7 +71,7 @@ def test_handle_job_full_execution(db, freezer):
 def test_handle_job_with_error(mock_update_controller, db):
     api = StubExecutorAPI()
 
-    task, job_id = api.add_test_task(ExecutorState.UNKNOWN)
+    task, job_id = api.add_test_runjob_task(ExecutorState.UNKNOWN)
 
     api.set_job_transition(
         job_id, ExecutorState.PREPARED, hook=Mock(side_effect=Exception("foo"))

--- a/tests/agent/test_tracing.py
+++ b/tests/agent/test_tracing.py
@@ -7,7 +7,7 @@ from tests.conftest import get_trace
 def test_tracing_state_change_attributes(db):
     api = StubExecutorAPI()
 
-    task, job_id = api.add_test_task(ExecutorState.UNKNOWN)
+    task, job_id = api.add_test_runjob_task(ExecutorState.UNKNOWN)
     # prepare is synchronous
     api.set_job_transition(job_id, ExecutorState.PREPARED)
     main.handle_single_task(task, api)
@@ -55,7 +55,7 @@ def test_tracing_state_change_attributes(db):
 def test_tracing_final_state_attributes(db):
     api = StubExecutorAPI()
 
-    task, job_id = api.add_test_task(ExecutorState.EXECUTED)
+    task, job_id = api.add_test_runjob_task(ExecutorState.EXECUTED)
     api.set_job_transition(
         job_id, ExecutorState.FINALIZED, hook=lambda job_id: api.set_job_result(job_id)
     )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -134,6 +134,19 @@ def runjob_db_task_factory(*args, state=State.RUNNING, **kwargs):
     return task
 
 
+def canceljob_db_task_factory(*args, state=State.RUNNING, **kwargs):
+    """Set up a job and corresponding task"""
+    job = job_factory(*args, state=state, cancelled=True, **kwargs)
+    task = Task(
+        id=job.id,
+        backend="test",
+        type=TaskType.CANCELJOB,
+        definition={"job_id": job.id},
+    )
+    task_api.insert_task(task)
+    return task
+
+
 class StubExecutorAPI:
     """Dummy implementation of the ExecutorAPI, for use in tests.
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -141,7 +141,7 @@ def canceljob_db_task_factory(*args, state=State.RUNNING, **kwargs):
         id=job.id,
         backend="test",
         type=TaskType.CANCELJOB,
-        definition={"job_id": job.id},
+        definition=job_to_job_definition(job).to_dict(),
     )
     task_api.insert_task(task)
     return task


### PR DESCRIPTION
Implements cancelling jobs in the agent. Note that the controller only includes job id in the CANCELJOB task definition, which means that if we need to write job logs, there will be some information that we don't have. We could always have the controller send this too, but I haven't done that yet and have left a TODO.

Testing locally is a bit tricky, this is what I did:

1) Edit `main()` in `agent/main.py` so that the agent only runs one loop at a time:
```
def main(exit_callback=lambda _: True):
    ...
```
2) Add a job with `just add-job`
```
just add-job https://github.com/opensafely/test-age-distribution generate_dataset -f
```
Make a note of the job id

3)  `just run-controller`
You should see the job get picked up and log that it's executing. Leave it running for the rest of the steps.

4) In another terminal, `just run-agent`
This will run one loop and move the runjob task into PREPARED
Repeat to move it into EXECUTING

5) In a shell, cancel the job:
```
In [1]: from jobrunner.models import Job
In [2]: from jobrunner.lib.database import update_where
In [3]: update_where(Job, {"cancelled": True}, id=<job id>)
```
You should see the controller register that the job has been cancelled by user.

6) `just run-agent`
You should see the agent pick up the CANCELJOB task


