### PR TITLE
Remove cancelled flag on JobDefinition

### DIFF
--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -132,10 +132,10 @@ def handle_cancel_job_task(task, api):
                 new_status = api.terminate(job)
                 update_controller(task, new_status)
                 # call finalize to write the job logs
-                final_status = api.finalize(job)
+                final_status = api.finalize(job, cancelled=True)
             case ExecutorState.EXECUTED | ExecutorState.ERROR:
                 # job has finished or errored, call finalize to write the job logs
-                final_status = api.finalize(job)
+                final_status = api.finalize(job, cancelled=True)
             case _:  # pragma: no cover
                 raise InvalidTransition(
                     f"unexpected state of job {job.id}: {job_status.state}"

--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -117,27 +117,35 @@ def handle_cancel_job_task(task, api):
     span = trace.get_current_span()
     span.set_attributes({"id": job.id, "initial_job_status": job_status.state.name})
 
+    # tell the controller what stage we're at now
+    update_controller(task, job_status)
+
     with set_log_context(job_definition=job):
         match job_status.state:
-            case ExecutorState.UNKNOWN | ExecutorState.FINALIZED:
-                # The job hasn't started or has already finished
+            case ExecutorState.FINALIZED:
+                # The job has already finished and been finalized, nothing to do here
                 final_status = job_status
-            case ExecutorState.PREPARED:
-                # Nb. no need to actually run finalize() in this case.
-                final_status = JobStatus(ExecutorState.FINALIZED)
+            case (
+                ExecutorState.UNKNOWN
+                | ExecutorState.PREPARED
+                | ExecutorState.EXECUTED
+                | ExecutorState.ERROR
+            ):
+                # States wehere we need to run finalize()
+                # If the job hasn't started; we run finalize() to record metadata, including
+                # its cancelled state. If it's finished or errored, finalize() will also write the job logs
+                final_status = api.finalize(job, cancelled=True)
             case ExecutorState.EXECUTING:
                 new_status = api.terminate(job)
                 update_controller(task, new_status)
                 # call finalize to write the job logs
-                final_status = api.finalize(job, cancelled=True)
-            case ExecutorState.EXECUTED | ExecutorState.ERROR:
-                # job has finished or errored, call finalize to write the job logs
                 final_status = api.finalize(job, cancelled=True)
             case _:  # pragma: no cover
                 raise InvalidTransition(
                     f"unexpected state of job {job.id}: {job_status.state}"
                 )
 
+        # Clean up based on the starting job state
         if job_status.state in [
             ExecutorState.EXECUTING,
             ExecutorState.EXECUTED,

--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -106,16 +106,13 @@ def trace_handle_task(task, api):
 
 
 def handle_cancel_job_task(task, api):
-    # A CANCELJOB task just sends a job_id in its task definition; construct
-    # a dummy JobDefinition to use with the executor API. job ID is all we
-    # need to find out the current status and do the actions required to
-    # cancel and clean up
-    # TODO: finalize() writes job logs, and will be missing some expected information
-    # if only job_id is passed (from job definition fields, it expects to write
-    # job id, job_request_id, created_at, database_name and commit)
+    """
+    Handle cancelling a job. The actions required to terminate, finalize and clean
+    up a job depend on its state at the point of cancellation
+    """
     job = JobDefinition.from_dict(task.definition)
 
-    job_status = api.get_status(job)
+    job_status = api.get_status(job, cancelled=True)
 
     span = trace.get_current_span()
     span.set_attributes({"id": job.id, "initial_job_status": job_status.state.name})

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -321,7 +321,6 @@ def job_to_job_definition(job):
         level4_max_filesize=config.LEVEL4_MAX_FILESIZE,
         level4_max_csv_rows=config.LEVEL4_MAX_CSV_ROWS,
         level4_file_types=list(config.LEVEL4_FILE_TYPES),
-        cancelled=job.cancelled,
     )
 
 

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -283,7 +283,10 @@ class LocalDockerAPI(ExecutorAPI):
         metrics = record_stats.read_job_metrics(job_definition.id)
 
         if container is None:  # container doesn't exist
-            if cancelled:
+            # cancelled=True indicates that we are in the process of cancelling this
+            # job. If we're not, the job may have been previously cancelled; look up
+            # its cancelled status in job metadata, if it exists
+            if cancelled or (self.get_metadata(job_definition) or {}).get("cancelled"):
                 if volumes.volume_exists(job_definition):
                     # jobs prepared but not running still need to finalize, in order
                     # to record their cancelled state

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -263,7 +263,7 @@ class LocalDockerAPI(ExecutorAPI):
 
         return JobStatus(ExecutorState.UNKNOWN)
 
-    def get_status(self, job_definition, timeout=15):
+    def get_status(self, job_definition, timeout=15, cancelled=False):
         name = container_name(job_definition)
         try:
             container = docker.container_inspect(
@@ -279,7 +279,7 @@ class LocalDockerAPI(ExecutorAPI):
         metrics = record_stats.read_job_metrics(job_definition.id)
 
         if container is None:  # container doesn't exist
-            if job_definition.cancelled:
+            if cancelled:
                 if volumes.volume_exists(job_definition):
                     # jobs prepared but not running do not need to finalize, so we
                     # proceed directly to the FINALIZED state here

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -523,10 +523,7 @@ def get_job_metadata(
     job_metadata["status_message"] = results.message
     job_metadata["container_metadata"] = container_metadata
     job_metadata["outputs"] = outputs
-    if job_definition.study is not None:
-        job_metadata["commit"] = job_definition.study.commit
-    else:
-        job_metadata["commit"] = None
+    job_metadata["commit"] = job_definition.study.commit
     job_metadata["database_name"] = job_definition.database_name
     job_metadata["hint"] = results.unmatched_hint
     # all calculated results

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -73,6 +73,12 @@ def read_job_metadata(job_definition):
     return None
 
 
+def write_job_metadata(job_definition, job_metadata):
+    metadata_path = get_log_dir(job_definition) / METADATA_FILE
+    metadata_path.parent.mkdir(exist_ok=True, parents=True)
+    metadata_path.write_text(json.dumps(job_metadata, indent=2))
+
+
 def job_metadata_path(job_definition):
     """Return the expected path for the metadata for a job.
 
@@ -562,12 +568,6 @@ def write_job_logs(
                 workspace_log_file,
                 medium_privacy_dir / METADATA_DIR / f"{job_definition.action}.log",
             )
-
-
-def write_job_metadata(job_definition, job_metadata):
-    metadata_path = get_log_dir(job_definition) / METADATA_FILE
-    metadata_path.parent.mkdir(exist_ok=True, parents=True)
-    metadata_path.write_text(json.dumps(job_metadata, indent=2))
 
 
 def persist_outputs(job_definition, outputs, job_metadata):

--- a/jobrunner/executors/logging.py
+++ b/jobrunner/executors/logging.py
@@ -40,8 +40,8 @@ class LoggingExecutor(ExecutorAPI):
         return getattr(self._wrapped, "synchronous_transitions", [])
 
     def _add_logging(self, method: Callable[[JobDefinition], JobStatus]):
-        def wrapper(job_definition: JobDefinition) -> JobStatus:
-            status = method(job_definition)
+        def wrapper(job_definition: JobDefinition, **kwargs) -> JobStatus:
+            status = method(job_definition, **kwargs)
             if self._is_new_state(job_definition, status.state):
                 self._write_log(job_definition, status)
                 self._state_cache[job_definition.id] = status.state

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -242,7 +242,9 @@ class ExecutorAPI:
 
         """
 
-    def finalize(self, job_definition: JobDefinition) -> JobStatus:
+    def finalize(
+        self, job_definition: JobDefinition, cancelled: bool = False
+    ) -> JobStatus:
         """
         Launch the finalization of a job, transitioning from EXECUTED to FINALIZING.
 
@@ -356,7 +358,7 @@ class NullExecutorAPI(ExecutorAPI):
     def execute(self, job_definition):  # pragma: nocover
         raise NotImplementedError
 
-    def finalize(self, job_definition):  # pragma: nocover
+    def finalize(self, job_definition, cancelled=False):  # pragma: nocover
         raise NotImplementedError
 
     def terminate(self, job_definition):  # pragma: nocover

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -46,13 +46,10 @@ class JobDefinition:
     @classmethod
     def from_dict(cls, data: dict):
         # Create the nested Study instance
-        study_data = data.pop("study", None)
-        if study_data:
-            study = Study(
-                git_repo_url=study_data["git_repo_url"], commit=study_data["commit"]
-            )
-        else:
-            study = None
+        study_data = data.pop("study", {})
+        study = Study(
+            git_repo_url=study_data.get("git_repo_url"), commit=study_data.get("commit")
+        )
 
         # Create the JobDefinition instance with the Study object
         return cls(study=study, **{k: v for k, v in data.items()})

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -309,7 +309,7 @@ class ExecutorAPI:
         out-of-band mechanisms for cleaning up resources associated with such failures.
         """
 
-    def get_status(self, job_definition: JobDefinition) -> JobStatus:
+    def get_status(self, job_definition: JobDefinition, cancelled=False) -> JobStatus:
         """
         Return the current status of a job.
 
@@ -364,7 +364,7 @@ class NullExecutorAPI(ExecutorAPI):
     def terminate(self, job_definition):  # pragma: nocover
         raise NotImplementedError
 
-    def get_status(self, job_definition):  # pragma: nocover
+    def get_status(self, job_definition, cancelled=False):  # pragma: nocover
         raise NotImplementedError
 
     def get_results(self, job_definition):  # pragma: nocover

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -39,7 +39,6 @@ class JobDefinition:
     cpu_count: str = None  # number of CPUs to be allocated
     memory_limit: str = None  # memory limit to apply
     level4_file_types: list = field(default_factory=lambda: [".csv"])
-    cancelled: bool = False
 
     def to_dict(self):
         return asdict(self)

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -533,11 +533,6 @@ def job_to_job_definition(job):
         for name, pattern in named_patterns.items():
             outputs[pattern] = privacy_level
 
-    if job.cancelled:
-        job_definition_cancelled = "user"
-    else:
-        job_definition_cancelled = None
-
     return JobDefinition(
         id=job.id,
         job_request_id=job.job_request_id,
@@ -559,7 +554,6 @@ def job_to_job_definition(job):
         level4_max_filesize=config.LEVEL4_MAX_FILESIZE,
         level4_max_csv_rows=config.LEVEL4_MAX_CSV_ROWS,
         level4_file_types=list(config.LEVEL4_FILE_TYPES),
-        cancelled=job_definition_cancelled,
     )
 
 

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -215,7 +215,7 @@ def handle_job(job, api, mode=None, paused=None):
     is_synchronous = False
 
     # only consider these modes if we are not about to cancel the job
-    if not job_definition.cancelled:
+    if not job.cancelled:
         # handle special modes before considering executor state, as they ignore it
         if paused:
             if job.state == State.PENDING:
@@ -257,7 +257,7 @@ def handle_job(job, api, mode=None, paused=None):
         EXECUTOR_RETRIES.pop(job.id, None)
 
     # cancelled is driven by user request, so is handled explicitly first
-    if job_definition.cancelled:
+    if job.cancelled:
         # if initial_status.state == ExecutorState.EXECUTED the job has already finished, so we
         # don't need to do anything here
         if initial_status.state == ExecutorState.EXECUTING:
@@ -374,7 +374,7 @@ def handle_job(job, api, mode=None, paused=None):
     elif initial_status.state == ExecutorState.FINALIZED:  # pragma: no branch
         # Cancelled jobs that have had cleanup() should now be again set to cancelled here to ensure
         # they finish in the FAILED state
-        if job_definition.cancelled:
+        if job.cancelled:
             mark_job_as_failed(job, StatusCode.CANCELLED_BY_USER, "Cancelled by user")
             api.cleanup(job_definition)
             return

--- a/tests/agent/stubs.py
+++ b/tests/agent/stubs.py
@@ -131,15 +131,16 @@ class StubExecutorAPI:
             job, ExecutorState.PREPARED, ExecutorState.EXECUTING, "execute"
         )
 
-    def finalize(self, job):
-        if self.get_status(job).state == ExecutorState.UNKNOWN:
-            # job was cancelled before it started running
-            return self.get_status(job)
-
+    def finalize(self, job, cancelled=False):
+        if cancelled:
+            # a finalize can be called from any status if we're cancelling a job
+            executor_state = self.get_status(job).state
+        else:
+            executor_state = ExecutorState.EXECUTED
         self.tracker["finalize"].add(job.id)
 
         return self.do_transition(
-            job, ExecutorState.EXECUTED, ExecutorState.FINALIZED, "finalize"
+            job, executor_state, ExecutorState.FINALIZED, "finalize"
         )
 
     def terminate(self, job):

--- a/tests/agent/stubs.py
+++ b/tests/agent/stubs.py
@@ -180,7 +180,7 @@ class StubExecutorAPI:
             job, ExecutorState.ERROR, ExecutorState.UNKNOWN, "cleanup"
         )
 
-    def get_status(self, job):
+    def get_status(self, job, cancelled=False):
         return self.job_statuses.get(job.id, JobStatus(ExecutorState.UNKNOWN))
 
     def get_metadata(self, job):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -281,7 +281,7 @@ class StubExecutorAPI:
             job_definition, ExecutorState.PREPARED, ExecutorState.EXECUTING, "execute"
         )
 
-    def finalize(self, job_definition):
+    def finalize(self, job_definition, cancelled=False):
         if self.get_status(job_definition).state == ExecutorState.UNKNOWN:
             # job was cancelled before it started running
             assert job_definition.cancelled

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -335,7 +335,7 @@ class StubExecutorAPI:
             job_definition, ExecutorState.ERROR, ExecutorState.UNKNOWN, "cleanup"
         )
 
-    def get_status(self, job_definition):
+    def get_status(self, job_definition, cancelled=False):
         return self.job_statuses.get(
             job_definition.id, JobStatus(ExecutorState.UNKNOWN)
         )


### PR DESCRIPTION
Fixes #860 

- removes the cancelled flag from JobDefinition
- adds a cancelled arg to the executor api `get_status()` and `finalize()`, True when these methods are called from a canceljob task in the agent
-  persists the cancelled status in the job metadata so that subsequent calls to get_status can know if a job was already cancelled
- this means that we now call finalize() on all cancelled jobs, even if they haven't started, so that we can persist the metadata, including the created_at/cancelled status.