### PR TITLE
Get errors to persist to disk and update controller with results 

### DIFF
--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -252,15 +252,9 @@ def update_controller(
         "final_job_status": status.state.name,
         "complete": complete,
     }
-
     tracing.set_job_results_metadata(span, status.results, attributes)
     log_state_change(task, status, previous_status)
-
-    controller_results = None
-    if status.results:
-        controller_results = {"results": status.results}
-
-    task_api.update_controller(task, status.state.value, controller_results, complete)
+    task_api.update_controller(task, status.state.value, status.results, complete)
 
 
 def log_state_change(task, status, previous_status):

--- a/jobrunner/agent/tracing.py
+++ b/jobrunner/agent/tracing.py
@@ -79,31 +79,27 @@ def trace_job_attributes(job: JobDefinition):
     return attrs
 
 
-def set_job_results_metadata(span, job_results, attributes=None):
+def set_job_results_metadata(span, results, attributes=None):
     attributes = attributes or {}
 
-    if job_results is not None:
-        results = job_results.get("results")
-        error = job_results.get("error")
-
-        if results:
-            attributes.update(
-                dict(
-                    exit_code=results["exit_code"],
-                    image_id=results["docker_image_id"],
-                    outputs=len(results["outputs"]),
-                    unmatched_patterns=len(results["unmatched_patterns"]),
-                    unmatched_outputs=len(results["unmatched_outputs"]),
-                    executor_message=results["status_message"],
-                    action_version=results["action_version"],
-                    action_revision=results["action_revision"],
-                    action_created=results["action_created"],
-                    base_revision=results["base_revision"],
-                    base_created=results["base_created"],
-                    cancelled=results["cancelled"],
-                )
+    if results:
+        attributes.update(
+            dict(
+                exit_code=results["exit_code"],
+                image_id=results["docker_image_id"],
+                outputs=len(results["outputs"]),
+                unmatched_patterns=len(results["unmatched_patterns"]),
+                unmatched_outputs=len(results["unmatched_outputs"]),
+                executor_message=results["status_message"],
+                action_version=results["action_version"],
+                action_revision=results["action_revision"],
+                action_created=results["action_created"],
+                base_revision=results["base_revision"],
+                base_created=results["base_created"],
+                cancelled=results["cancelled"],
             )
-        if error:
-            attributes.update(error=error)
+        )
+        if "error" in results:
+            attributes.update(error=results["error"])
 
     set_span_attributes(span, attributes)

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -224,7 +224,7 @@ def handle_job(job, mode=None, paused=None):
                 # Handled elsewhere
                 raise PlatformError(job_error)
             else:
-                job_results = JobResults.from_dict(task.agent_results["results"])
+                job_results = JobResults.from_dict(task.agent_results)
                 save_results(job, job_results)
                 # TODO: Delete obsolete files
 

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -70,7 +70,7 @@ def read_job_metadata(job_definition):
     if path:
         return json.loads(path.read_text())
 
-    return None
+    return {}
 
 
 def write_job_metadata(job_definition, job_metadata):

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -318,7 +318,7 @@ class LocalDockerAPI(ExecutorAPI):
                         metrics=metrics,
                         results=job_metadata,
                     )
-                else:
+                else:  # pragma: no cover
                     return JobStatus(
                         ExecutorState.UNKNOWN,
                         "Pending job was cancelled",

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -286,7 +286,7 @@ class LocalDockerAPI(ExecutorAPI):
 
         metrics = record_stats.read_job_metrics(job_definition.id)
 
-        if container is None:  # container doesn't exist
+        if not container:  # container doesn't exist
             # cancelled=True indicates that we are in the process of cancelling this
             # job. If we're not, the job may have been previously cancelled; look up
             # its cancelled status in job metadata, if it exists

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -346,10 +346,6 @@ class LocalDockerAPI(ExecutorAPI):
                 ExecutorState.EXECUTED, timestamp_ns=timestamp_ns, metrics=metrics
             )
 
-    def get_results(self, job_definition):
-        metadata = read_job_metadata(job_definition)
-        return JobResults.from_dict(metadata)
-
     def delete_files(self, workspace, privacy, files):
         if privacy == Privacy.HIGH:
             root = get_high_privacy_workspace(workspace)

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -523,7 +523,7 @@ def get_job_metadata(
     job_metadata["docker_image_id"] = container_metadata.get("Image")
     # convert exit code to str so 0 exit codes get logged
     job_metadata["exit_code"] = str(container_metadata.get("State", {}).get("ExitCode"))
-    job_metadata["oom_killed"] = container_metadata.get("State", {}.get("OOMKilled"))
+    job_metadata["oom_killed"] = container_metadata.get("State", {}).get("OOMKilled")
     job_metadata["status_message"] = results.message
     job_metadata["container_metadata"] = container_metadata
     job_metadata["outputs"] = outputs

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -81,6 +81,7 @@ class JobStatus:
     # timestamp this JobStatus occurred, in integer nanoseconds
     timestamp_ns: int = field(default_factory=time.time_ns)
     metrics: dict = field(default_factory=dict)
+    results: dict = field(default_factory=dict)
 
 
 @dataclass

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -241,7 +241,10 @@ class ExecutorAPI:
         """
 
     def finalize(
-        self, job_definition: JobDefinition, cancelled: bool = False
+        self,
+        job_definition: JobDefinition,
+        cancelled: bool = False,
+        error: dict | None = None,
     ) -> JobStatus:
         """
         Launch the finalization of a job, transitioning from EXECUTED to FINALIZING.

--- a/jobrunner/job_executor.py
+++ b/jobrunner/job_executor.py
@@ -268,8 +268,7 @@ class ExecutorAPI:
 
         If the job has been cancelled, it should only preserve the action log file.
 
-        When the finalize task finishes, the get_status() call should now return FINALIZED for this job, and
-        get_results() call should return the JobResults for this job.
+        When the finalize task finishes, the get_status() call should now return FINALIZED for this job.
 
         This method must be idempotent. If called with a job that is already running an finalize task, it must not
         launch a new task, and simply return successfully with FINALIZING.
@@ -300,7 +299,7 @@ class ExecutorAPI:
 
         This method must be idempotent; it will be called at least once for every finished job. The implementation
         may defer resource cleanup to this method if necessary in order to correctly implement idempotency of
-        get_status() or get_results(). If the job is unknown, it should still return UNKNOWN successfully.
+        get_status(). If the job is unknown, it should still return UNKNOWN successfully.
 
         This method will not be called for a job that raises an unexpected exception from ExecutorAPI in order
         to facilitate debugging of unexpected failures. It may therefore be necessary for the backend to provide
@@ -322,19 +321,6 @@ class ExecutorAPI:
         irreversible cleanup which loses information about must be deferred to ExecutorAPI.cleanup() which will only be
         called once the results have been persisted.
 
-        """
-
-    def get_results(self, job_definition: JobDefinition) -> JobResults:
-        """
-        Return the finalized results for a job.
-
-        The results must include a list of output files that the job produced which matched its output spec. It
-        should also include a list of files that it produced but which did not match the output spec, to aid in
-        debugging during study development.
-
-        This method must be idempotent; it may be called more than once for a job even after it has finished, so any
-        irreversible cleanup which loses information about must be deferred to ExecutorAPI.cleanup() which will only be
-        called once the results have been persisted.
         """
 
     def delete_files(self, workspace: str, privacy: Privacy, files: [str]) -> list[str]:
@@ -363,9 +349,6 @@ class NullExecutorAPI(ExecutorAPI):
         raise NotImplementedError
 
     def get_status(self, job_definition, cancelled=False):  # pragma: nocover
-        raise NotImplementedError
-
-    def get_results(self, job_definition):  # pragma: nocover
         raise NotImplementedError
 
     def cleanup(self, job_definition):  # pragma: nocover

--- a/jobrunner/lib/docker.py
+++ b/jobrunner/lib/docker.py
@@ -280,7 +280,7 @@ def container_inspect(name, key="", none_if_not_exists=False, timeout=None):
             and e.returncode == 1
             and b"no such container" in e.stderr.lower()
         ):
-            return
+            return {}
         else:  # pragma: no cover
             raise
     return json.loads(response.stdout)

--- a/tests/agent/stubs.py
+++ b/tests/agent/stubs.py
@@ -183,8 +183,5 @@ class StubExecutorAPI:
     def get_status(self, job, cancelled=False):
         return self.job_statuses.get(job.id, JobStatus(ExecutorState.UNKNOWN))
 
-    def get_results(self, job):
-        raise NotImplementedError()
-
     def delete_files(self, workspace, privacy, files):
         self.deleted[workspace][privacy].extend(files)

--- a/tests/agent/stubs.py
+++ b/tests/agent/stubs.py
@@ -115,7 +115,9 @@ class StubExecutorAPI:
 
         timestamp_ns = time.time_ns()
         self.set_job_status(job.id, executor_state, message, timestamp_ns)
-        return JobStatus(executor_state, message, timestamp_ns)
+        return JobStatus(
+            executor_state, message, timestamp_ns, results=self.metadata.get(job.id, {})
+        )
 
     def prepare(self, job):
         self.tracker["prepare"].add(job.id)
@@ -180,9 +182,6 @@ class StubExecutorAPI:
 
     def get_status(self, job, cancelled=False):
         return self.job_statuses.get(job.id, JobStatus(ExecutorState.UNKNOWN))
-
-    def get_metadata(self, job):
-        return self.metadata.get(job.id)
 
     def get_results(self, job):
         raise NotImplementedError()

--- a/tests/agent/stubs.py
+++ b/tests/agent/stubs.py
@@ -131,7 +131,7 @@ class StubExecutorAPI:
             job, ExecutorState.PREPARED, ExecutorState.EXECUTING, "execute"
         )
 
-    def finalize(self, job, cancelled=False):
+    def finalize(self, job, cancelled=False, error=None):
         if cancelled:
             # a finalize can be called from any status if we're cancelling a job
             executor_state = self.get_status(job).state
@@ -140,7 +140,10 @@ class StubExecutorAPI:
         self.tracker["finalize"].add(job.id)
 
         return self.do_transition(
-            job, executor_state, ExecutorState.FINALIZED, "finalize"
+            job,
+            executor_state,
+            ExecutorState.ERROR if error else ExecutorState.FINALIZED,
+            "finalize",
         )
 
     def terminate(self, job):

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -76,7 +76,7 @@ def test_handle_job_full_execution(db, freezer, caplog):
     task = controller_task_api.get_task(task.id)
     assert task.agent_stage == ExecutorState.FINALIZED.value
     assert task.agent_complete
-    assert "results" in task.agent_results
+    assert task.agent_results
 
     # Note EXECUTING -> EXECUTED happens outside of the agent loop
     # handler, so in this last call to handle_single_task, the job
@@ -126,7 +126,7 @@ def test_handle_job_stable_states(db, executor_state):
     mock_update_controller.assert_called_with(
         task,
         executor_state.value,
-        None,
+        {},
         False if executor_state == ExecutorState.EXECUTING else True,
     )
 

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -158,7 +158,7 @@ def test_handle_job_requires_db_has_secrets(db, monkeypatch):
     main.handle_run_job_task(task, api)
 
 
-@patch("jobrunner.agent.task_api.update_controller")
+@patch("jobrunner.agent.task_api.update_controller", spec=task_api.update_controller)
 def test_handle_job_with_error(mock_update_controller, db):
     api = StubExecutorAPI()
 
@@ -171,10 +171,10 @@ def test_handle_job_with_error(mock_update_controller, db):
     with pytest.raises(Exception):
         main.handle_single_task(task, api)
 
-    assert mock_update_controller.called_with(
+    mock_update_controller.assert_called_with(
         task=task,
-        stage=ExecutorState.ERROR,
-        results={"error": "Exception('foo')"},
+        stage=ExecutorState.ERROR.value,
+        results={},
         complete=True,
     )
 

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -172,13 +172,13 @@ def test_handle_runjob_with_error(mock_update_controller, db):
         main.handle_single_task(task, api)
 
     assert mock_update_controller.call_count == 1
-    task, stage, results, complete = mock_update_controller.call_args[0]
-    assert task == task
+    task2, stage, results, complete = mock_update_controller.call_args[0]
+    assert task2 == task
     assert stage == ExecutorState.ERROR.value
     assert results["error"]["exception"] == "Exception"
     assert results["error"]["message"] == "foo"
     assert "traceback" in results["error"]
-    assert complete == complete
+    assert complete is True
 
     spans = get_trace("agent_loop")
     assert len(spans) == 1
@@ -205,13 +205,13 @@ def test_handle_canceljob_with_error(mock_update_controller, db):
 
     # canceljob handler always calls update first
     assert mock_update_controller.call_count == 2
-    task, stage, results, complete = mock_update_controller.call_args[0]
-    assert task == task
+    task2, stage, results, complete = mock_update_controller.call_args[0]
+    assert task2 == task
     assert stage == ExecutorState.ERROR.value
     assert results["error"]["exception"] == "Exception"
     assert results["error"]["message"] == "foo"
     assert "traceback" in results["error"]
-    assert complete == complete
+    assert complete is True
 
     spans = get_trace("agent_loop")
     assert len(spans) == 1

--- a/tests/cli/test_kill_job.py
+++ b/tests/cli/test_kill_job.py
@@ -195,7 +195,7 @@ def test_kill_job_no_container_metadata(tmp_work_dir, db, monkeypatch):
         return [job]
 
     # no container metadata
-    mocker.container_inspect.return_value = None
+    mocker.container_inspect.return_value = {}
 
     # set both the docker module names used to the mocker version
     monkeypatch.setattr(kill_job, "docker", mocker)

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -25,10 +25,14 @@ def set_job_task_results(job, job_results, error=None):
     runjob_task = database.find_one(
         Task, type=TaskType.RUNJOB, id__like=f"{job.id}-%", active=True
     )
+    results = job_results.to_dict()
+    if error:
+        results["error"] = error
+
     agent_task_api.update_controller(
         runjob_task,
         stage="",
-        results={"results": job_results.to_dict(), "error": error},
+        results=results,
         complete=True,
     )
 

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -449,7 +449,7 @@ def test_finalize_failed(docker_cleanup, job_definition, tmp_work_dir):
 @pytest.mark.needs_docker
 def test_finalize_no_container_metadata(monkeypatch, job_definition, tmp_work_dir):
     mocker = mock.MagicMock(spec=local.docker)
-    mocker.container_inspect.return_value = None
+    mocker.container_inspect.return_value = {}
 
     job_definition.args = ["false"]
     job_definition.output_spec = {

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -840,6 +840,7 @@ def test_finalize_large_level4_outputs_cleanup(
     assert not message_file.exists()
 
 
+@pytest.mark.needs_docker
 def test_finalize_already_finalized_idempotent(
     job_definition, docker_cleanup, tmp_work_dir
 ):
@@ -859,6 +860,7 @@ def test_finalize_already_finalized_idempotent(
     assert status.state == ExecutorState.FINALIZED
 
 
+@pytest.mark.needs_docker
 def test_finalize_already_finalized_with_error_idempotent(
     job_definition, docker_cleanup, tmp_work_dir
 ):

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -1048,3 +1048,11 @@ def test_delete_volume_error_file_bindmount_skips_and_logs(job_definition, caplo
     assert path in caplog.records[-1].msg
     # *not* an exception log, just an error one
     assert caplog.records[-1].exc_text is None
+
+
+@pytest.mark.needs_docker
+def test_finalize_job_with_error(job_definition):
+    local.finalize_job(job_definition, error={"test": "foo"}, cancelled=False)
+    metadata = local.read_job_metadata(job_definition)
+    assert metadata["error"] == {"test": "foo"}
+    assert metadata["status_message"] == "Job errored"

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -871,12 +871,11 @@ def test_prepared_job_cancelled(docker_cleanup, job_definition, tmp_work_dir):
     # Finalizing the job as cancelled sets cancelled metadata
     status = api.finalize(job_definition, cancelled=True)
     assert status.results["cancelled"]
-    # The job state is still prepared, because it hasn't cleaned up yet
-    assert api.get_status(job_definition).state == ExecutorState.PREPARED
+    assert api.get_status(job_definition).state == ExecutorState.FINALIZED
 
     status = api.cleanup(job_definition)
-    assert status.state == ExecutorState.UNKNOWN
-    assert api.get_status(job_definition).state == ExecutorState.UNKNOWN
+    assert status.state == ExecutorState.FINALIZED
+    assert api.get_status(job_definition).state == ExecutorState.FINALIZED
 
     assert not log_dir_log_file_exists(job_definition)
     assert not workspace_log_file_exists(job_definition)
@@ -911,8 +910,8 @@ def test_running_job_cancelled(docker_cleanup, job_definition, tmp_work_dir):
     assert status.state == ExecutorState.FINALIZED
 
     status = api.cleanup(job_definition)
-    assert status.state == ExecutorState.UNKNOWN
-    assert api.get_status(job_definition).state == ExecutorState.UNKNOWN
+    assert status.state == ExecutorState.FINALIZED
+    assert api.get_status(job_definition).state == ExecutorState.FINALIZED
 
     assert log_dir_log_file_exists(job_definition)
     assert not workspace_log_file_exists(job_definition)

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -840,7 +840,9 @@ def test_finalize_large_level4_outputs_cleanup(
     assert not message_file.exists()
 
 
-def test_finalize_already_finalized_idempotent(job_definition, docker_cleanup):
+def test_finalize_already_finalized_idempotent(
+    job_definition, docker_cleanup, tmp_work_dir
+):
     api = local.LocalDockerAPI()
 
     status = api.prepare(job_definition)
@@ -858,7 +860,7 @@ def test_finalize_already_finalized_idempotent(job_definition, docker_cleanup):
 
 
 def test_finalize_already_finalized_with_error_idempotent(
-    job_definition, docker_cleanup
+    job_definition, docker_cleanup, tmp_work_dir
 ):
     api = local.LocalDockerAPI()
 
@@ -882,7 +884,7 @@ def test_finalize_already_finalized_with_error_idempotent(
 
 
 @pytest.mark.needs_docker
-def test_finalize_with_error_when_unknown(job_definition, docker_cleanup):
+def test_finalize_with_error_when_unknown(job_definition, docker_cleanup, tmp_work_dir):
     api = local.LocalDockerAPI()
     status = api.finalize(job_definition, error={"test": "foo"})
     assert status.state == ExecutorState.ERROR

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -886,9 +886,8 @@ def test_prepared_job_cancelled(docker_cleanup, job_definition, tmp_work_dir):
     assert api.get_status(job_definition).state == ExecutorState.PREPARED
 
     # Finalizing the job as cancelled sets cancelled metadata
-    api.finalize(job_definition, cancelled=True)
-    assert api.get_metadata(job_definition)["cancelled"]
-
+    status = api.finalize(job_definition, cancelled=True)
+    assert status.results["cancelled"]
     # The job state is still prepared, because it hasn't cleaned up yet
     assert api.get_status(job_definition).state == ExecutorState.PREPARED
 
@@ -922,7 +921,7 @@ def test_running_job_cancelled(docker_cleanup, job_definition, tmp_work_dir):
     assert api.get_status(job_definition).state == ExecutorState.EXECUTED
 
     status = api.finalize(job_definition, cancelled=True)
-    assert api.get_metadata(job_definition)["cancelled"]
+    assert status.results["cancelled"]
     assert status.state == ExecutorState.FINALIZED
     assert api.get_status(job_definition).state == ExecutorState.FINALIZED
 

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -106,7 +106,7 @@ def workspace_log_file_exists(job_definition):
 
 
 def test_read_metadata_path(job_definition):
-    assert local.read_job_metadata(job_definition) is None
+    assert local.read_job_metadata(job_definition) == {}
 
     globbed_path = (
         config.JOB_LOG_DIR


### PR DESCRIPTION
Fixes: #861

The original plan has been to persist the error information in a separate error.json file. However, this proved to be awkward, as it required plumbing a bunch of extra error related methods that mirrored the metadata methods, e.g. read/write_job_error, get_error, etc.

Instead, we chose to embed the error information in the already persisted metadata.json that is written by ``finalize_job`

This involved making finalize_job work on a job in any state, as an error can happen at any times, and storing as much info as it has available.

Along the way, we refactored away the get_results/get_metadata executor API calls, and instead just return the metadata as part of every get_status() call. This simplified a bunch of things, as we already were loading and checking for metadata.json in get_status anyway.

There's a lot of commits, but they are all fairly small and consistent - we fixed a few smaller issues along the way.


