### PR TITLE
Tracing and tests

### DIFF
--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -280,7 +280,7 @@ def inject_db_secrets(job):
         job.env["EMIS_ORGANISATION_HASH"] = config.EMIS_ORGANISATION_HASH
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     configure_logging()
 
     try:

--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -242,15 +242,7 @@ def update_controller(
         "final_job_status": status.state.name,
         "complete": complete,
     }
-    if results is not None:
-        results_attrs = results.get("results")
-        if results_attrs:
-            attributes.update(**results_attrs)
-        error = results.get("error")
-        if error:
-            attributes.update(error=error)
-
-    span.set_attributes(attributes)
+    tracing.set_job_results_metadata(span, results, attributes)
     task_api.update_controller(task, status.state.value, results, complete)
 
 

--- a/jobrunner/agent/tracing.py
+++ b/jobrunner/agent/tracing.py
@@ -56,12 +56,8 @@ def trace_job_attributes(job: JobDefinition):
     """These attributes are added to every span in order to slice and dice by
     each as needed.
     """
-    if job.study:
-        repo_url = job.study.git_repo_url or ""
-        commit = job.study.commit or ""
-    else:
-        repo_url = ""
-        commit = ""
+    repo_url = job.study.git_repo_url or ""
+    commit = job.study.commit or ""
 
     attrs = dict(
         job=job.id,

--- a/jobrunner/agent/tracing.py
+++ b/jobrunner/agent/tracing.py
@@ -77,3 +77,33 @@ def trace_job_attributes(job: JobDefinition):
     )
 
     return attrs
+
+
+def set_job_results_metadata(span, job_results, attributes=None):
+    attributes = attributes or {}
+
+    if job_results is not None:
+        results = job_results.get("results")
+        error = job_results.get("error")
+
+        if results:
+            attributes.update(
+                dict(
+                    exit_code=results["exit_code"],
+                    image_id=results["docker_image_id"],
+                    outputs=len(results["outputs"]),
+                    unmatched_patterns=len(results["unmatched_patterns"]),
+                    unmatched_outputs=len(results["unmatched_outputs"]),
+                    executor_message=results["status_message"],
+                    action_version=results["action_version"],
+                    action_revision=results["action_revision"],
+                    action_created=results["action_created"],
+                    base_revision=results["base_revision"],
+                    base_created=results["base_created"],
+                    cancelled=results["cancelled"],
+                )
+            )
+        if error:
+            attributes.update(error=error)
+
+    set_span_attributes(span, attributes)

--- a/jobrunner/cli/kill_job.py
+++ b/jobrunner/cli/kill_job.py
@@ -98,5 +98,5 @@ def run():  # pragma: no cover
     main(**vars(args))
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     run()

--- a/jobrunner/cli/retry_job.py
+++ b/jobrunner/cli/retry_job.py
@@ -67,5 +67,5 @@ def run():  # pragma: no cover
     main(**vars(args))
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     run()

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -546,7 +546,7 @@ def cancel_job(job):
     insert_task(canceljob_task)
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     configure_logging()
 
     try:

--- a/jobrunner/lib/log_utils.py
+++ b/jobrunner/lib/log_utils.py
@@ -106,7 +106,6 @@ def formatting_filter(record):
     status_code = getattr(record, "status_code", None)
     if job and not status_code:
         status_code = job.status_code
-
     tags = {}
 
     if status_code:
@@ -121,7 +120,7 @@ def formatting_filter(record):
         tags["req"] = req.id
     if task:
         tags["task"] = task.id
-        tags["task_type"] = task.type
+        tags["task_type"] = task.type.name
 
     record.tags = " ".join(f"{k}={v}" for k, v in tags.items())
 

--- a/jobrunner/record_stats.py
+++ b/jobrunner/record_stats.py
@@ -240,7 +240,7 @@ def update_job_metrics(job, raw_metrics, duration_s, runtime_s):
     return job_metrics
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     configure_logging()
 
     try:

--- a/jobrunner/run.py
+++ b/jobrunner/run.py
@@ -743,7 +743,7 @@ def update_job(job):
     update(job, exclude_fields=["cancelled"])
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     configure_logging()
 
     try:

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -162,7 +162,7 @@ def job_to_remote_format(job):
     }
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     configure_logging()
 
     try:

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -335,7 +335,7 @@ def trace_attributes(job, results=None):
     return attrs
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     # local testing utility for tracing
     import time
 

--- a/tests/agent/stubs.py
+++ b/tests/agent/stubs.py
@@ -35,7 +35,7 @@ class StubExecutorAPI:
             "cleanup": set(),
         }
         self.transitions = {}
-        self.results = {}
+        self.metadata = {}
         self.job_statuses = {}
         self.deleted = defaultdict(lambda: defaultdict(list))
         self.last_time = int(time.time())
@@ -82,7 +82,7 @@ class StubExecutorAPI:
         """Set the next transition for this job when called"""
         self.transitions[job_id] = (next_executor_state, message, hook)
 
-    def set_job_result(self, job_id, timestamp_ns=None, **kwargs):
+    def set_job_metadata(self, job_id, timestamp_ns=None, **kwargs):
         if timestamp_ns is None:
             timestamp_ns = time.time_ns()
         defaults = {
@@ -97,9 +97,10 @@ class StubExecutorAPI:
             "action_created": "unknown",
             "base_revision": "unknown",
             "base_created": "unknown",
+            "cancelled": False,
         }
         kwargs = {**defaults, **kwargs}
-        self.results[job_id] = kwargs
+        self.metadata[job_id] = kwargs
 
     def do_transition(
         self,
@@ -189,7 +190,7 @@ class StubExecutorAPI:
         return self.job_statuses.get(job.id, JobStatus(ExecutorState.UNKNOWN))
 
     def get_metadata(self, job):
-        return self.results.get(job.id)
+        return self.metadata.get(job.id)
 
     def get_results(self, job):
         raise NotImplementedError()

--- a/tests/agent/stubs.py
+++ b/tests/agent/stubs.py
@@ -90,8 +90,13 @@ class StubExecutorAPI:
             "unmatched_patterns": [],
             "unmatched_outputs": [],
             "exit_code": 0,
-            "image_id": "image_id",
-            "message": "message",
+            "docker_image_id": "image_id",
+            "status_message": "message",
+            "action_version": "unknown",
+            "action_revision": "unknown",
+            "action_created": "unknown",
+            "base_revision": "unknown",
+            "base_created": "unknown",
         }
         kwargs = {**defaults, **kwargs}
         self.results[job_id] = kwargs

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -42,7 +42,7 @@ def test_handle_job_full_execution(db, freezer):
 
     def finalize(job):
         freezer.tick(1)
-        api.set_job_result(job.id)
+        api.set_job_metadata(job.id)
 
     api.set_job_transition(job_id, ExecutorState.FINALIZED, hook=finalize)
     assert job_id not in api.tracker["finalize"]

--- a/tests/agent/test_tracing.py
+++ b/tests/agent/test_tracing.py
@@ -61,7 +61,7 @@ def test_tracing_final_state_attributes(db):
 
     task, job_id = api.add_test_runjob_task(ExecutorState.EXECUTED)
     api.set_job_transition(
-        job_id, ExecutorState.FINALIZED, hook=lambda job: api.set_job_result(job.id)
+        job_id, ExecutorState.FINALIZED, hook=lambda job: api.set_job_metadata(job.id)
     )
     main.handle_single_task(task, api)
 

--- a/tests/agent/test_tracing.py
+++ b/tests/agent/test_tracing.py
@@ -96,8 +96,15 @@ def test_tracing_final_state_attributes(db):
         "unmatched_patterns",
         "image_id",
         "unmatched_outputs",
-        "message",
+        "executor_message",
         "exit_code",
+        "outputs",
+        "action_version",
+        "action_revision",
+        "action_created",
+        "base_revision",
+        "base_created",
+        "cancelled",
     }
     # attributes added from the task
     assert span.attributes["backend"] == "test"
@@ -116,7 +123,7 @@ def test_set_task_span_metadata_no_attrs(db):
     tracer = trace.get_tracer("test")
 
     span = tracer.start_span("test")
-    set_job_span_metadata(span, task)
+    set_task_span_metadata(span, task)
     assert span.attributes["backend"] == "test"
     assert span.attributes["task_type"] == "RUNJOB"
     assert span.attributes["task"] == task.id

--- a/tests/agent/test_tracing.py
+++ b/tests/agent/test_tracing.py
@@ -1,7 +1,11 @@
+from opentelemetry import trace
+
 from jobrunner.agent import main
+from jobrunner.agent.tracing import set_job_span_metadata, set_task_span_metadata
 from jobrunner.job_executor import ExecutorState
 from tests.agent.stubs import StubExecutorAPI
 from tests.conftest import get_trace
+from tests.factories import job_definition_factory, runjob_db_task_factory
 
 
 def test_tracing_state_change_attributes(db):
@@ -105,3 +109,76 @@ def test_tracing_final_state_attributes(db):
     assert spans[0].attributes["initial_job_status"] == "EXECUTED"
     assert spans[0].attributes["final_job_status"] == "FINALIZED"
     assert spans[0].attributes["complete"]
+
+
+def test_set_task_span_metadata_no_attrs(db):
+    task = runjob_db_task_factory()
+    tracer = trace.get_tracer("test")
+
+    span = tracer.start_span("test")
+    set_job_span_metadata(span, task)
+    assert span.attributes["backend"] == "test"
+    assert span.attributes["task_type"] == "RUNJOB"
+    assert span.attributes["task"] == task.id
+    assert span.attributes["task_created_at"] == task.created_at * 1e9
+
+
+def test_set_task_span_metadata_attrs(db):
+    task = runjob_db_task_factory()
+    tracer = trace.get_tracer("the-tracer")
+
+    class CustomClass:
+        def __str__(self):
+            return "I am the custom class"
+
+    span = tracer.start_span("the-span")
+    set_task_span_metadata(
+        span,
+        task,
+        custom_attr=CustomClass(),  # test that attr is added and the type coerced to string
+        task_type="should be ignored",  # test that we can't override core task attributes
+    )
+
+    assert span.attributes["backend"] == "test"
+    assert span.attributes["task_type"] == "RUNJOB"  # not "should be ignored"
+    assert span.attributes["task"] == task.id
+    assert span.attributes["task_created_at"] == task.created_at * 1e9
+    assert span.attributes["custom_attr"] == "I am the custom class"
+
+
+def test_set_job_span_metadata_no_attrs(db):
+    job = job_definition_factory()
+    tracer = trace.get_tracer("test")
+
+    span = tracer.start_span("test")
+    set_job_span_metadata(
+        span,
+        job,
+    )
+    assert span.attributes["job"] == job.id
+    assert span.attributes["job_request"] == job.job_request_id
+    assert span.attributes["workspace"] == job.workspace
+
+
+def test_set_job_span_metadata_attrs(db):
+    job = job_definition_factory()
+    tracer = trace.get_tracer("the-tracer")
+
+    class CustomClass:
+        def __str__(self):
+            return "I am the custom class"
+
+    span = tracer.start_span("the-span")
+
+    set_job_span_metadata(
+        span,
+        job,
+        custom_attr=CustomClass(),  # test that attr is added and the type coerced to string
+        action="should be ignored",  # test that we can't override core job attributes
+    )
+
+    assert span.attributes["job"] == job.id
+    assert span.attributes["job_request"] == job.job_request_id
+    assert span.attributes["workspace"] == job.workspace
+    assert span.attributes["action"] == job.action  # not "should be ignored"
+    assert span.attributes["custom_attr"] == "I am the custom class"


### PR DESCRIPTION
Fixes #856 

- Gets dev coverage to 100% 
- Updates the results attributes that we trace when a job completes to replicate what we currently send in prod 