### PR TITLE
Handle None values in span attributes without logging

### DIFF
--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -266,13 +266,16 @@ def set_span_attributes(span, attributes):
     clean_attrs = {}
     for k, v in attributes.items():
         if not isinstance(v, OTEL_ATTR_TYPES):
-            # log to help us notice this
-            # If the span has no name attribute (e.g. NonRecordingSpans), log its type instead
-            span_name = getattr(span, "name", type(span))
-            logger.error(
-                f"Trace span {span_name} attribute {k} was set invalid type: {v}, type {type(v)}"
-            )
-            # coerce to string so we preserve some information
+            if v is not None:
+                # log to help us notice this
+                # values can often be None and this isn't particularly interesting, so don't fill up
+                # the logs with that
+                # If the span has no name attribute (e.g. NonRecordingSpans), log its type instead
+                span_name = getattr(span, "name", type(span))
+                logger.error(
+                    f"Trace span {span_name} attribute {k} was set invalid type: {v}, type {type(v)}"
+                )
+                # coerce to string so we preserve some information
             v = str(v)
         clean_attrs[k] = v
 


### PR DESCRIPTION
We log an error if we try to set span metadata with a type that otel can't handle. None is one of those values, but it's not very interesting, and because it happens quite a lot, we end up with logs full of these errors. Now we just coerce it to a string without logging it.