### PR TITLE
Add backend to job model

### DIFF
--- a/jobrunner/cli/add_backend_to_job.py
+++ b/jobrunner/cli/add_backend_to_job.py
@@ -1,5 +1,5 @@
 from jobrunner import config
-from jobrunner.lib.database import find_all, find_where, update
+from jobrunner.lib.database import find_where, update
 from jobrunner.models import Job, SavedJobRequest
 
 
@@ -8,13 +8,16 @@ def main():
     Command to add missing backend attribute to jobs. We expect this to only
     run once per backend, prior to moving the controller out of the backend
     """
-    jobs = find_all(Job)
     jobs_missing_backend = find_where(Job, backend=None)
-    if len(jobs) > len(jobs_missing_backend):
-        print("This command has already been run, please confirm you want to re-run:")
+    if jobs_missing_backend:
+        print(
+            "This command will add a backend attribute to all jobs and should only be run from inside a backend. Please confirm you want to continue:"
+        )
         confirm = input("\nY to continue, N to quit\n")
         if confirm.lower() != "y":
             return
+    else:
+        print("All jobs have a backend assigned; nothing to do")
 
     for job in jobs_missing_backend:
         job_requests = find_where(SavedJobRequest, id=job.job_request_id)

--- a/jobrunner/cli/add_backend_to_job.py
+++ b/jobrunner/cli/add_backend_to_job.py
@@ -1,0 +1,36 @@
+from jobrunner import config
+from jobrunner.lib.database import find_all, find_where, update
+from jobrunner.models import Job, SavedJobRequest
+
+
+def main():
+    """
+    Command to add missing backend attribute to jobs. We expect this to only
+    run once per backend, prior to moving the controller out of the backend
+    """
+    jobs = find_all(Job)
+    jobs_missing_backend = find_where(Job, backend=None)
+    if len(jobs) > len(jobs_missing_backend):
+        print("This command has already been run, please confirm you want to re-run:")
+        confirm = input("\nY to continue, N to quit\n")
+        if confirm.lower() != "y":
+            return
+
+    for job in jobs_missing_backend:
+        job_requests = find_where(SavedJobRequest, id=job.job_request_id)
+        if job.job_request_id is None or not job_requests:
+            # Some very old jobs have no job_request_id; as we expect this command to
+            # be run from within a backend, we can just assign it from the config variable
+            backend = config.BACKEND
+        else:
+            assert len(job_requests) == 1
+            backend = job_requests[0].original.get("backend", config.BACKEND)
+
+        job.backend = backend
+        update(job, exclude_fields=["cancelled"])
+
+    print(f"{len(jobs_missing_backend)} jobs updated")
+
+
+if __name__ == "__main__":
+    main()

--- a/jobrunner/cli/add_job.py
+++ b/jobrunner/cli/add_job.py
@@ -11,6 +11,7 @@ import textwrap
 from pathlib import Path
 from urllib.parse import urlparse
 
+from jobrunner import config
 from jobrunner.create_or_update_jobs import create_or_update_jobs
 from jobrunner.lib.database import find_where
 from jobrunner.lib.git import get_sha_from_remote_ref
@@ -38,6 +39,8 @@ def main(
             force_run_dependencies=force_run_dependencies,
             cancelled_actions=[],
             codelists_ok=True,
+            # TODO: pass this in as a cli arg when run from the controller
+            backend=config.BACKEND,
         )
     )
     print("Submitting JobRequest:\n")

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -272,8 +272,7 @@ def save_results(job, results):
 
 def job_to_job_definition(job):
     allow_database_access = False
-    # TODO: This will need to become a field on `Job` and fetched from there
-    env = {"OPENSAFELY_BACKEND": config.BACKEND}
+    env = {"OPENSAFELY_BACKEND": job.backend}
     if job.requires_db:
         if not config.USING_DUMMY_DATA_BACKEND:
             allow_database_access = True
@@ -511,8 +510,7 @@ def create_task_for_job(job):
         id=f"{job.id}-{task_number:03}",
         type=TaskType.RUNJOB,
         definition=job_to_job_definition(job).to_dict(),
-        # TODO: Uncomment this when Job grows a `backend` field
-        backend="",  # job.backend,
+        backend=job.backend,
     )
 
 

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -248,6 +248,7 @@ def recursively_build_jobs(jobs_by_action, job_request, pipeline_config, action)
         output_spec=action_spec.outputs,
         created_at=int(timestamp),
         updated_at=int(timestamp),
+        backend=job_request.backend,
     )
     tracing.initialise_trace(job)
 
@@ -367,6 +368,7 @@ def create_job_from_exception(job_request, exception):
         started_at=int(now),
         updated_at=int(now),
         completed_at=int(now),
+        backend=job_request.backend,
     )
     tracing.initialise_trace(job)
     insert_into_database(job_request, [job])

--- a/jobrunner/lib/database.py
+++ b/jobrunner/lib/database.py
@@ -317,6 +317,8 @@ def query_params_to_sql(params):
             field = key[:-6]
             parts.append(f"{escape(field)} LIKE ?")
             values.append(value)
+        elif value is None:
+            parts.append(f"{escape(key)} is NULL")
         else:
             parts.append(f"{escape(key)} = ?")
             values.append(value)

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -113,6 +113,7 @@ class JobRequest:
     database_name: str
     force_run_dependencies: bool = False
     branch: str = None
+    backend: str = None
     original: dict = None
 
 

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -168,6 +168,7 @@ class Job:
             status_code_updated_at INT,
             level4_excluded_files TEXT,
             requires_db BOOLEAN,
+            backend TEXT,
 
             PRIMARY KEY (id)
         );
@@ -201,6 +202,13 @@ class Job:
         3,
         """
         ALTER TABLE job ADD COLUMN requires_db BOOLEAN;
+        """,
+    )
+
+    migration(
+        5,
+        """
+        ALTER TABLE job ADD COLUMN backend TEXT;
         """,
     )
 
@@ -267,6 +275,9 @@ class Job:
 
     # does the job require db access
     requires_db: bool = False
+
+    # the backend that this job runs on
+    backend: str = None
 
     # used to cache the job_request json by the tracing code
     _job_request = None

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -134,6 +134,7 @@ def job_request_from_remote_format(job_request):
             else job_request["workspace"]["db"]
         ),
         force_run_dependencies=job_request["force_run_dependencies"],
+        backend=job_request["backend"],
         original=job_request,
     )
 

--- a/justfile
+++ b/justfile
@@ -108,9 +108,13 @@ test-verbose *ARGS: devenv
 test-no-docker *ARGS: devenv
     $BIN/python -m pytest -m "not needs_docker" "$@"
 
+# Run a cli command locally
+cli command *ARGS: devenv
+    $BIN/python -m jobrunner.cli.{{ command }} {{ ARGS }}
+
 # Run db migrations locally
 migrate:
-    $BIN/python -m jobrunner.cli.migrate
+    just cli migrate
 
 # Lint and check formatting but don't modify anything
 check: devenv
@@ -151,8 +155,8 @@ fix: devenv
     just --fmt --unstable --justfile docker/justfile
 
 # Run the dev project
-add-job *args: devenv
-    $BIN/python -m jobrunner.cli.add_job {{ args }}
+add-job *args:
+    just cli add_job {{ args }}
 
 run-agent: devenv
     $BIN/python -m jobrunner.agent.main

--- a/tests/cli/test_add_backend_to_job.py
+++ b/tests/cli/test_add_backend_to_job.py
@@ -1,0 +1,54 @@
+import pytest
+
+from jobrunner.cli import add_backend_to_job
+from jobrunner.lib import database
+from jobrunner.models import Job, SavedJobRequest
+from tests.factories import job_factory, job_request_factory, job_request_factory_raw
+
+
+def test_add_backend_to_job(db, monkeypatch):
+    monkeypatch.setattr("jobrunner.config.BACKEND", "dummy_backend")
+    # job with no SavedJobRequest instance
+    job1 = job_factory(job_request=job_request_factory_raw(), backend=None)
+    assert not database.find_where(SavedJobRequest, id=job1.job_request_id)
+
+    # job with job_request and SavedJobRequest instance
+    job_request = job_request_factory(original={"backend": "the_test_backend"})
+    job2 = job_factory(job_request, backend=None)
+    assert database.find_where(SavedJobRequest, id=job2.job_request_id)
+
+    # job with no job_request id
+    job3 = job_factory(backend=None)
+    job3.job_request_id = None
+    database.update(job3)
+    assert not database.find_where(SavedJobRequest, id=job3.job_request_id)
+    assert database.find_one(Job, id=job3.id).job_request_id is None
+
+    for job in [job1, job2, job3]:
+        assert database.find_one(Job, id=job.id).backend is None, job
+
+    add_backend_to_job.main()
+    assert database.find_one(Job, id=job1.id).backend == "dummy_backend"
+    assert database.find_one(Job, id=job2.id).backend == "the_test_backend"
+    assert database.find_one(Job, id=job3.id).backend == "dummy_backend"
+
+
+@pytest.mark.parametrize(
+    "response,expected_backend",
+    [
+        ("Y", "dummy_backend"),
+        ("y", "dummy_backend"),
+        ("N", None),
+        ("foo", None),
+    ],
+)
+def test_add_backend_to_job_already_done(db, monkeypatch, response, expected_backend):
+    monkeypatch.setattr("jobrunner.config.BACKEND", "dummy_backend")
+    # job with a backend already set
+    job1 = job_factory(backend="test")
+    job2 = job_factory(backend=None)
+
+    monkeypatch.setattr("builtins.input", lambda _: response)
+    add_backend_to_job.main()
+    assert database.find_one(Job, id=job1.id).backend == "test"
+    assert database.find_one(Job, id=job2.id).backend == expected_backend

--- a/tests/lib/test_database.py
+++ b/tests/lib/test_database.py
@@ -81,7 +81,7 @@ def test_generate_insert_sql(tmp_work_dir):
 
     assert (
         sql
-        == 'INSERT INTO "job" ("id", "job_request_id", "state", "repo_url", "commit", "workspace", "database_name", "action", "action_repo_url", "action_commit", "requires_outputs_from", "wait_for_job_ids", "run_command", "image_id", "output_spec", "outputs", "unmatched_outputs", "status_message", "status_code", "cancelled", "created_at", "updated_at", "started_at", "completed_at", "status_code_updated_at", "trace_context", "level4_excluded_files", "requires_db") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        == 'INSERT INTO "job" ("id", "job_request_id", "state", "repo_url", "commit", "workspace", "database_name", "action", "action_repo_url", "action_commit", "requires_outputs_from", "wait_for_job_ids", "run_command", "image_id", "output_spec", "outputs", "unmatched_outputs", "status_message", "status_code", "cancelled", "created_at", "updated_at", "started_at", "completed_at", "status_code_updated_at", "trace_context", "level4_excluded_files", "requires_db", "backend") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
     )
 
 

--- a/tests/lib/test_database.py
+++ b/tests/lib/test_database.py
@@ -128,6 +128,16 @@ def test_exists_where(tmp_work_dir):
     assert job_id_exists is True
 
 
+def exists_where_null(tmp_work_dir):
+    insert(Job(id="foo123", backend=None))
+    insert(Job(id="foo124", backend="test"))
+    insert(Job(id="foo125", backend="foo"))
+    job_no_backend = exists_where(Job, backend=None)
+    assert job_no_backend is True
+    job_no_backend = exists_where(Job, id="foo124", backend=None)
+    assert job_no_backend is False
+
+
 def test_count_where(tmp_work_dir):
     insert(Job(id="foo123", state=State.PENDING))
     insert(Job(id="foo124", state=State.RUNNING))

--- a/tests/test_create_or_update_jobs.py
+++ b/tests/test_create_or_update_jobs.py
@@ -46,6 +46,7 @@ def test_create_or_update_jobs(tmp_work_dir, db):
             project="project",
             orgs=["org1", "org2"],
         ),
+        backend="test",
     )
     create_or_update_jobs(job_request)
     old_job = find_one(Job)
@@ -62,6 +63,7 @@ def test_create_or_update_jobs(tmp_work_dir, db):
         " --output-dir=."
     )
     assert old_job.output_spec == {"highly_sensitive": {"cohort": "input.csv"}}
+    assert old_job.backend == "test"
     assert old_job.status_message == "Created"
     # Check no new jobs created from same JobRequest
     create_or_update_jobs(job_request)
@@ -88,6 +90,7 @@ def test_create_or_update_jobs_with_git_error(tmp_work_dir):
             project="project",
             orgs=["org1", "org2"],
         ),
+        backend="test",
     )
     create_or_update_jobs(job_request)
     j = find_one(Job)
@@ -100,6 +103,7 @@ def test_create_or_update_jobs_with_git_error(tmp_work_dir):
     assert j.requires_outputs_from is None
     assert j.run_command is None
     assert j.output_spec is None
+    assert j.backend == "test"
     assert (
         j.status_message
         == f"GitError: Error fetching commit {bad_commit} from {repo_url}"
@@ -125,6 +129,7 @@ def test_create_or_update_jobs_with_unhandled_error(tmp_work_dir, db):
             project="project",
             orgs=["org1", "org2"],
         ),
+        backend="test",
     )
     create_or_update_jobs(job_request)
     j = find_one(Job, job_request_id="123")
@@ -137,6 +142,7 @@ def test_create_or_update_jobs_with_unhandled_error(tmp_work_dir, db):
     assert j.requires_outputs_from is None
     assert j.run_command is None
     assert j.output_spec is None
+    assert j.backend == "test"
     assert j.status_message == "JobRequestError: Internal error"
 
 
@@ -331,7 +337,8 @@ def test_validate_job_request(patch_config, params, exc_msg, exc_cls, monkeypatc
         cancelled_actions=[],
         workspace="1",
         codelists_ok=True,
-        database_name="default",  # note db from from job-server is 'default'
+        database_name="default",  # note db from from job-server is 'default',
+        backend="test",
         original=dict(
             created_by="user",
             project="project",
@@ -361,6 +368,7 @@ def make_job_request(action=None, actions=None, **kwargs):
         database_name="default",
         requested_actions=actions,
         cancelled_actions=[],
+        backend="test",
         original=dict(
             created_by="user",
             project="project",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -66,6 +66,7 @@ def test_integration(
         "created_by": "user",
         "project": "project",
         "orgs": ["org"],
+        "backend": "test",
     }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",
@@ -161,6 +162,7 @@ def test_integration(
         "created_by": "user",
         "project": "project",
         "orgs": ["org"],
+        "backend": "test",
     }
     requests_mock.get(
         "http://testserver/api/v2/job-requests/?backend=expectations",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -25,6 +25,7 @@ def test_job_request_from_remote_format():
         "created_by": "user",
         "project": "project",
         "orgs": ["org"],
+        "backend": "test",
     }
     expected = JobRequest(
         id="123",
@@ -37,6 +38,7 @@ def test_job_request_from_remote_format():
         requested_actions=["generate_cohort"],
         cancelled_actions=["analyse"],
         force_run_dependencies=True,
+        backend="test",
         original=remote_job_request,
     )
     job_request = sync.job_request_from_remote_format(remote_job_request)
@@ -60,6 +62,7 @@ def test_job_request_from_remote_format_database_name_fallback():
         "created_by": "user",
         "project": "project",
         "orgs": ["org"],
+        "backend": "test",
     }
     expected = JobRequest(
         id="123",
@@ -73,6 +76,7 @@ def test_job_request_from_remote_format_database_name_fallback():
         cancelled_actions=["analyse"],
         force_run_dependencies=True,
         original=remote_job_request,
+        backend="test",
     )
     job_request = sync.job_request_from_remote_format(remote_job_request)
     assert job_request == expected


### PR DESCRIPTION
Fixes #879 

- adds a backend attribute to Job
- and to JobRequest (not a db object, but it's convenient to include it as a representation of the job-server job request)
- job-server already includes the backend in the job request response, so we can use it now when creating jobs in `sync`
- Use the new job.backend to set the task's backend in the controller loop
- Add a cli command to add the backend to existing jobs based on their SavedJobRequest, or if not available, the config.BACKEND; this is intended to run once only per backend before we move the controller and the jobs DB out of the backends and merge them

Note this deliberately doesn't do any filtering of jobs by backend yet (for determining dependencies etc). It doesn't need it while the db is still backend-specific and it will need the backend for existing jobs populated first.