### PR TITLE
Move dummy data backend config to agent only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ env:
   STATA_LICENSE: ${{ secrets.STATA_LICENSE }}
 
 jobs:
+
   check:
     runs-on: ubuntu-22.04
 
@@ -51,11 +52,14 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           echo "$PYTHON_VERSION"
+          just devenv
           just test -vvv
 
       - name: Run actual tests on macos
         if: ${{ matrix.os == 'macos-14' }}
-        run: just test-no-docker -vvv
+        run: |
+          just devenv
+          just test-no-docker -vvv
 
   test-docker:
     runs-on: ubuntu-22.04

--- a/docker/justfile
+++ b/docker/justfile
@@ -39,6 +39,7 @@ docker-compose-env:
     PYTEST_HOST_TMP=$PYTEST_HOST_TMP
     MEDIUM_PRIVACY_STORAGE_BASE=$(realpath $PWD/medium)
     HIGH_PRIVACY_STORAGE_BASE=$(realpath $PWD/high)
+    USING_DUMMY_DATA_BACKEND=True
     EOF
 
 # run tests in docker container
@@ -53,7 +54,7 @@ functional-test:
     docker compose up -d prod
     docker compose exec prod python3 -m jobrunner.cli.add_job https://github.com/opensafely/research-template generate_dataset
     attempts=""
-    # use docker logs reather than docker compose logs, as those will include previous run's logs 
+    # use docker logs reather than docker compose logs, as those will include previous run's logs
     while ! docker logs -n 10 $container |& grep -q "Completed successfully";
     do
         if test "$attempts" = ".........."; then

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,5 +1,6 @@
 # The name of this backend
-BACKEND=expectations
+BACKEND=local
+USING_DUMMY_DATA_BACKEND=True
 
 # The endpoint to poll for jobs
 JOB_SERVER_ENDPOINT=https://jobs.opensafely.org/jobs/

--- a/jobrunner/actions.py
+++ b/jobrunner/actions.py
@@ -6,8 +6,6 @@ from pipeline.exceptions import ProjectValidationError
 from pipeline.models import Action
 from pipeline.outputs import get_output_dirs
 
-from jobrunner.lib.path_utils import ensure_unix_path
-
 
 class UnknownActionError(ProjectValidationError):
     pass
@@ -22,7 +20,7 @@ class ActionSpecification:
     action: Action
 
 
-def get_action_specification(config, action_id, using_dummy_data_backend=False):
+def get_action_specification(config, action_id):
     """Get a specification for the action from the project.
 
     Args:
@@ -56,18 +54,6 @@ def get_action_specification(config, action_id, using_dummy_data_backend=False):
 
     # Special case handling for the `cohortextractor generate_cohort` command
     if is_cohortextractor_generate_cohort(run_parts):
-        # Set the size of the dummy data population, if that's what we're
-        # generating.  Possibly this should be moved to the study definition
-        # anyway, which would make this unnecessary.
-        if using_dummy_data_backend:
-            if action_spec.dummy_data_file is not None:
-                run_parts.append(
-                    f"--dummy-data-file={ensure_unix_path(action_spec.dummy_data_file)}"
-                )
-            else:
-                size = config.expectations.population_size
-                run_parts.append(f"--expectations-population={size}")
-
         output_dirs = get_output_dirs(action_spec.outputs)
 
         if len(output_dirs) == 1:  # pragma: no branch

--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -283,6 +283,13 @@ def inject_db_secrets(job):
     if config.USING_DUMMY_DATA_BACKEND:
         return
 
+    if job.database_name not in config.DATABASE_URLS:
+        backend = job.env["OPENSAFELY_BACKEND"]
+        raise ValueError(
+            f"Database name '{job.database_name}' is not currently defined "
+            f"for backend '{backend}'"
+        )
+
     job.env["DATABASE_URL"] = config.DATABASE_URLS[job.database_name]
     if config.TEMP_DATABASE_NAME:
         job.env["TEMP_DATABASE_NAME"] = config.TEMP_DATABASE_NAME

--- a/jobrunner/cli/add_job.py
+++ b/jobrunner/cli/add_job.py
@@ -88,7 +88,7 @@ def run(argv=None):
         "--workspace", help="Workspace ID (default 'test')", default="test"
     )
     parser.add_argument(
-        "--database", help="Database name (default 'dummy')", default="dummy"
+        "--database", help="Database name (default 'default')", default="default"
     )
     parser.add_argument("-f", "--force-run-dependencies", action="store_true")
 

--- a/jobrunner/config/agent.py
+++ b/jobrunner/config/agent.py
@@ -19,19 +19,17 @@ METRICS_FILE = WORKDIR / "metrics.sqlite"
 # valid archive formats
 ARCHIVE_FORMATS = (".tar.gz", ".tar.zstd", ".tar.xz")
 
-BACKEND = os.environ.get("BACKEND", "expectations")
+BACKEND = os.environ.get("BACKEND", "dummy")
 if not _is_valid_backend_name(BACKEND):
     raise RuntimeError(f"BACKEND not in valid format: '{BACKEND}'")  # pragma: no cover
 
 truthy = ("true", "1", "yes")
 
-# TODO: Both need this; the controller can pass to the agent in the task
-# however, the agent will also need it if adding jobs via CLI
-# When creating a task, controller will need to check this AND backend==expectations
 if os.environ.get("USING_DUMMY_DATA_BACKEND", "false").lower().strip() in truthy:
-    USING_DUMMY_DATA_BACKEND = True  # pragma: no cover
+    USING_DUMMY_DATA_BACKEND = True
 else:
-    USING_DUMMY_DATA_BACKEND = BACKEND == "expectations"
+    # this branch is tested in tests/test_config.py but via subprocess so it isn't registered by coverage
+    USING_DUMMY_DATA_BACKEND = False  # pragma: no cover
 
 
 # TODO Agent only; controller should pass database name only in env, agent should construct the DB url

--- a/jobrunner/config/agent.py
+++ b/jobrunner/config/agent.py
@@ -3,7 +3,7 @@ import re
 import sys
 from pathlib import Path
 
-from jobrunner.config.common import WORKDIR
+from jobrunner.config.common import VALID_DATABASE_NAMES, WORKDIR
 
 
 class ConfigException(Exception):
@@ -32,14 +32,14 @@ else:
     USING_DUMMY_DATA_BACKEND = False  # pragma: no cover
 
 
-# TODO Agent only; controller should pass database name only in env, agent should construct the DB url
+# Agent only; the controller passes database name only in env, agent constructs the DB url
+# from [NAME]_DATABASE_URL env variables available only inside the backend
 def database_urls_from_env(env):
-    db_names = ["default", "include_t1oo"]
     return {
         db_name: db_url
         for db_name, db_url in [
             (db_name, env.get(f"{db_name.upper()}_DATABASE_URL"))
-            for db_name in db_names
+            for db_name in VALID_DATABASE_NAMES
         ]
         if db_url
     }

--- a/jobrunner/config/common.py
+++ b/jobrunner/config/common.py
@@ -25,3 +25,7 @@ GIT_REPO_DIR = WORKDIR / "repos"
 # TODO Controller will not need to proxy once outside backend
 GIT_PROXY_DOMAIN = "github-proxy.opensafely.org"
 PRIVATE_REPO_ACCESS_TOKEN = os.environ.get("PRIVATE_REPO_ACCESS_TOKEN", "")
+
+# Used by the controller to validate database name passed in a job request
+# Used by the agent to build database URLS
+VALID_DATABASE_NAMES = ["default", "include_t1oo"]

--- a/jobrunner/config/controller.py
+++ b/jobrunner/config/controller.py
@@ -27,17 +27,6 @@ POLL_INTERVAL = float(os.environ.get("POLL_INTERVAL", "5"))
 # We'll also use the BACKENDS config for looping through BACKENDS in sync
 BACKENDS = []
 
-truthy = ("true", "1", "yes")
-
-# TODO: Both need this; the controller can pass to the agent in the task
-# however, the agent will also need it if adding jobs via CLI
-# When creating a task, controller will need to check this AND backend==expectations
-if os.environ.get("USING_DUMMY_DATA_BACKEND", "false").lower().strip() in truthy:
-    USING_DUMMY_DATA_BACKEND = True  # pragma: no cover
-else:
-    USING_DUMMY_DATA_BACKEND = False
-
-
 ALLOWED_IMAGES = {
     "cohortextractor",
     "databuilder",

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -273,11 +273,8 @@ def save_results(job, results):
 
 
 def job_to_job_definition(job):
-    allow_database_access = False
     env = {"OPENSAFELY_BACKEND": job.backend}
-    if job.requires_db:
-        if not config.USING_DUMMY_DATA_BACKEND:
-            allow_database_access = True
+
     # Prepend registry name
     action_args = job.action_args
     image = action_args.pop(0)
@@ -313,8 +310,8 @@ def job_to_job_definition(job):
         env=env,
         inputs=input_files,
         output_spec=outputs,
-        allow_database_access=allow_database_access,
-        database_name=job.database_name if allow_database_access else None,
+        allow_database_access=job.requires_db,
+        database_name=job.database_name if job.requires_db else None,
         # in future, these may come from the JobRequest, but for now, we have
         # config defaults.
         cpu_count=config.DEFAULT_JOB_CPU_COUNT,

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -15,7 +15,6 @@ from pipeline import RUN_ALL_COMMAND, ProjectValidationError, load_pipeline
 
 from jobrunner import tracing
 from jobrunner.actions import get_action_specification
-from jobrunner.config import agent as agent_config
 from jobrunner.config import controller as config
 from jobrunner.lib.database import exists_where, insert, transaction, update_where
 from jobrunner.lib.git import GitError, GitFileNotFoundError, read_file_from_repo
@@ -128,21 +127,7 @@ def validate_job_request(job_request):
         raise JobRequestError(
             "Invalid workspace name (allowed are alphanumeric, dash and underscore)"
         )
-    if not config.USING_DUMMY_DATA_BACKEND:
-        database_name = job_request.database_name
-        valid_names = agent_config.DATABASE_URLS.keys()
 
-        if database_name not in valid_names:
-            raise JobRequestError(
-                f"Invalid database name '{database_name}', allowed are: "
-                + ", ".join(valid_names)
-            )
-
-        if not agent_config.DATABASE_URLS[database_name]:
-            raise JobRequestError(
-                f"Database name '{database_name}' is not currently defined "
-                f"for backend '{job_request.backend}'"
-            )
     # If we're not restricting to specific Github organisations then there's no
     # point in checking the provenance of the supplied commit
     if config.ALLOWED_GITHUB_ORGS:  # pragma: no cover

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -16,6 +16,7 @@ from pipeline import RUN_ALL_COMMAND, ProjectValidationError, load_pipeline
 from jobrunner import tracing
 from jobrunner.actions import get_action_specification
 from jobrunner.config import controller as config
+from jobrunner.config.common import VALID_DATABASE_NAMES
 from jobrunner.lib.database import exists_where, insert, transaction, update_where
 from jobrunner.lib.git import GitError, GitFileNotFoundError, read_file_from_repo
 from jobrunner.lib.github_validators import (
@@ -126,6 +127,12 @@ def validate_job_request(job_request):
     if re.search(r"[^a-zA-Z0-9_\-]", job_request.workspace):
         raise JobRequestError(
             "Invalid workspace name (allowed are alphanumeric, dash and underscore)"
+        )
+
+    if job_request.database_name not in VALID_DATABASE_NAMES:
+        raise JobRequestError(
+            f"Invalid database name '{job_request.database_name}', allowed are: "
+            + ", ".join(VALID_DATABASE_NAMES)
         )
 
     # If we're not restricting to specific Github organisations then there's no

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -200,7 +200,6 @@ def recursively_build_jobs(jobs_by_action, job_request, pipeline_config, action)
     action_spec = get_action_specification(
         pipeline_config,
         action,
-        using_dummy_data_backend=config.USING_DUMMY_DATA_BACKEND,
     )
 
     # Walk over the dependencies of this action, creating any necessary jobs,

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -177,7 +177,9 @@ class LocalDockerAPI(ExecutorAPI):
         # We use a custom Docker network configured so that database jobs can access the
         # database and nothing else
         if (
-            job_definition.allow_database_access and config.DATABASE_ACCESS_NETWORK
+            not config.USING_DUMMY_DATA_BACKEND
+            and job_definition.allow_database_access
+            and config.DATABASE_ACCESS_NETWORK
         ):  # pragma: no cover
             extra_args.extend(["--network", config.DATABASE_ACCESS_NETWORK])
             extra_args.extend(

--- a/justfile
+++ b/justfile
@@ -54,6 +54,7 @@ _dotenv:
       echo "No '.env' file found; creating a default '.env' from 'dotenv-sample'"
       cp dotenv-sample .env
       ./local-setup.sh
+      echo "Rerun command to load new .env"
     fi
 
 # Ensure dev and prod requirements installed and up to date

--- a/tests/cli/test_add_job.py
+++ b/tests/cli/test_add_job.py
@@ -4,7 +4,6 @@ from jobrunner.models import Job
 
 
 def test_add_job(monkeypatch, tmp_work_dir, db, test_repo):
-    monkeypatch.setattr("jobrunner.config.controller.USING_DUMMY_DATA_BACKEND", True)
     job_request, jobs = add_job.run([str(test_repo.path), "generate_dataset"])
 
     assert len(jobs) == 1
@@ -16,7 +15,6 @@ def test_add_job(monkeypatch, tmp_work_dir, db, test_repo):
 
 
 def test_add_job_with_bad_commit(monkeypatch, tmp_work_dir, db, test_repo):
-    monkeypatch.setattr("jobrunner.config.controller.USING_DUMMY_DATA_BACKEND", True)
     _, jobs = add_job.run([str(test_repo.path), "generate_dataset", "--commit", "abc"])
 
     assert len(jobs) == 1

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -374,7 +374,6 @@ def test_handle_job_finalized_failed_with_error(db):
 
 @pytest.fixture
 def backend_db_config(monkeypatch):
-    monkeypatch.setattr(config, "USING_DUMMY_DATA_BACKEND", False)
     # for test jobs, job.database_name is None, so add a dummy connection
     # string for that db
     monkeypatch.setitem(agent_config.DATABASE_URLS, None, "conn str")

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -57,13 +57,11 @@ def test_get_action_specification_for_cohortextractor_generate_cohort_action():
         }
     )
 
-    action_spec = get_action_specification(
-        config, "generate_cohort", using_dummy_data_backend=True
-    )
+    action_spec = get_action_specification(config, "generate_cohort")
 
     assert (
         action_spec.run
-        == """cohortextractor:latest generate_cohort --expectations-population=1000 --output-dir=output"""
+        == """cohortextractor:latest generate_cohort --output-dir=output"""
     )
 
 
@@ -104,73 +102,6 @@ def test_get_action_specification_with_config():
     # by default. sys.argv[0] is the script name (either with or without a path,
     # depending on the OS) so we slice obs_run_command to mimic this.
     parser.parse_args(shlex.split(action_spec.run)[2:])
-
-
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="ActionSpecification is only used to build commands for Docker",
-)
-def test_get_action_specification_with_dummy_data_file_flag(tmp_path):
-    dummy_data_file = tmp_path / "test.csv"
-    with dummy_data_file.open("w") as f:
-        f.write("test")
-
-    config = Pipeline.build(
-        **{
-            "version": 1,
-            "actions": {
-                "generate_cohort": {
-                    "run": "cohortextractor:latest generate_cohort",
-                    "outputs": {"moderately_sensitive": {"cohort": "output/input.csv"}},
-                    "dummy_data_file": str(dummy_data_file),
-                }
-            },
-        }
-    )
-
-    action_spec = get_action_specification(
-        config,
-        "generate_cohort",
-        using_dummy_data_backend=True,
-    )
-
-    expected = " ".join(
-        [
-            "cohortextractor:latest",
-            "generate_cohort",
-            f"--dummy-data-file={dummy_data_file}",
-            "--output-dir=output",
-        ]
-    )
-    assert action_spec.run == expected
-
-
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="ActionSpecification is only used to build commands for Docker",
-)
-def test_get_action_specification_without_dummy_data_file_flag(tmp_path):
-    dummy_data_file = tmp_path / "test.csv"
-    with dummy_data_file.open("w") as f:
-        f.write("test")
-
-    config = Pipeline.build(
-        **{
-            "version": 1,
-            "actions": {
-                "generate_cohort": {
-                    "run": "cohortextractor:latest generate_cohort",
-                    "outputs": {"moderately_sensitive": {"cohort": "output/input.csv"}},
-                    "dummy_data_file": str(dummy_data_file),
-                }
-            },
-        }
-    )
-
-    action_spec = get_action_specification(config, "generate_cohort")
-
-    expected = "cohortextractor:latest generate_cohort --output-dir=output"
-    assert action_spec.run == expected
 
 
 @pytest.mark.skipif(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -95,6 +95,21 @@ def test_config_presto_paths_not_exist(tmp_path):
 
 
 @pytest.mark.parametrize(
+    "env_value,expected",
+    [
+        ("Yes", True),
+        ("true", True),
+        ("1", True),
+        ("false", False),
+        ("foo", False),
+    ],
+)
+def test_config_truthy(env_value, expected):
+    cfg = import_cfg({"USING_DUMMY_DATA_BACKEND": env_value})
+    assert cfg["USING_DUMMY_DATA_BACKEND"] == str(expected)
+
+
+@pytest.mark.parametrize(
     "name,is_valid",
     [
         ("foo_BAR-1", True),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,7 +34,7 @@ def test_integration(
 ):
     api = get_executor_api()
 
-    monkeypatch.setattr("jobrunner.config.controller.USING_DUMMY_DATA_BACKEND", True)
+    monkeypatch.setattr("jobrunner.config.agent.USING_DUMMY_DATA_BACKEND", True)
     monkeypatch.setattr(
         "jobrunner.config.controller.JOB_SERVER_ENDPOINT", "http://testserver/api/v2/"
     )
@@ -43,6 +43,8 @@ def test_integration(
     # Ensure that we have enough workers to start the jobs we expect in the test
     # (CI may have fewer actual available workers than this)
     monkeypatch.setattr("jobrunner.config.controller.MAX_WORKERS", 4)
+
+    monkeypatch.setattr("jobrunner.config.agent.BACKEND", "dummy")
 
     ensure_docker_images_present("ehrql:v1", "python")
 
@@ -62,7 +64,7 @@ def test_integration(
             "branch": "HEAD",
         },
         "codelists_ok": True,
-        "database_name": "dummy",
+        "database_name": "default",
         "sha": test_repo.commit,
         "created_by": "user",
         "project": "project",
@@ -70,7 +72,7 @@ def test_integration(
         "backend": "test",
     }
     requests_mock.get(
-        "http://testserver/api/v2/job-requests/?backend=expectations",
+        "http://testserver/api/v2/job-requests/?backend=dummy",
         json={
             "results": [job_request_1],
         },
@@ -158,7 +160,7 @@ def test_integration(
             "branch": "HEAD",
         },
         "codelists_ok": True,
-        "database_name": "dummy",
+        "database_name": "default",
         "sha": test_repo.commit,
         "created_by": "user",
         "project": "project",
@@ -166,7 +168,7 @@ def test_integration(
         "backend": "test",
     }
     requests_mock.get(
-        "http://testserver/api/v2/job-requests/?backend=expectations",
+        "http://testserver/api/v2/job-requests/?backend=dummy",
         json={
             "results": [job_request_1, job_request_2],
         },

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -164,8 +164,9 @@ def test_sync_empty_response(db, monkeypatch, requests_mock):
     monkeypatch.setattr(
         "jobrunner.config.controller.JOB_SERVER_ENDPOINT", "http://testserver/api/v2/"
     )
+    monkeypatch.setattr("jobrunner.config.agent.BACKEND", "test")
     requests_mock.get(
-        "http://testserver/api/v2/job-requests/?backend=expectations",
+        "http://testserver/api/v2/job-requests/?backend=test",
         json={
             "results": [],
         },


### PR DESCRIPTION
- Make `USING_DUMMY_DATA_BACKEND` agent-only config
  The controller will soon become responsible for all backends so logic about whether the current backend is a dummy data one belongs with the agent only. Also removed references to the no-longer-active "expectation" backend
- Moves database URL validation to the agent and just validates database name is one of the allowed ones ("default" or "allow_t1oo") in the controller
- Removes code that just handled modifiying dummy data args for cohort-extractor actions
