### PR TITLE
Filter jobs/tasks by backend

### DIFF
--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -39,7 +39,7 @@ def main(exit_callback=lambda _: False):  # pragma: no cover
 
 
 def handle_tasks(api: ExecutorAPI | None):
-    active_tasks = task_api.get_active_tasks()
+    active_tasks = task_api.get_active_tasks(backend=config.BACKEND)
 
     handled_tasks = []
 

--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -7,7 +7,7 @@ from opentelemetry import trace
 
 from jobrunner.agent import task_api, tracing
 from jobrunner.config import agent as config
-from jobrunner.config.common import JOB_LOOP_INTERVAL
+from jobrunner.config import common as common_config
 from jobrunner.executors import get_executor_api
 from jobrunner.job_executor import ExecutorAPI, ExecutorState, JobDefinition, JobStatus
 from jobrunner.lib.log_utils import configure_logging, set_log_context
@@ -35,7 +35,7 @@ def main(exit_callback=lambda _: False):  # pragma: no cover
         if exit_callback(active_tasks):
             break
 
-        time.sleep(JOB_LOOP_INTERVAL)
+        time.sleep(common_config.JOB_LOOP_INTERVAL)
 
 
 def handle_tasks(api: ExecutorAPI | None):

--- a/jobrunner/agent/task_api.py
+++ b/jobrunner/agent/task_api.py
@@ -3,11 +3,12 @@ from jobrunner.models import Task as ControllerTask  # cheating!
 from jobrunner.schema import AgentTask
 
 
-def get_active_tasks() -> list[AgentTask]:
-    """Get a list of active tasks from the controller"""
+def get_active_tasks(backend: str) -> list[AgentTask]:
+    """Get a list of active tasks for this backend from the controller"""
     # cheating for now - should be HTTP API call
     return [
-        AgentTask.from_task(t) for t in database.find_where(ControllerTask, active=True)
+        AgentTask.from_task(t)
+        for t in database.find_where(ControllerTask, active=True, backend=backend)
     ]
 
 

--- a/jobrunner/config/agent.py
+++ b/jobrunner/config/agent.py
@@ -3,7 +3,7 @@ import re
 import sys
 from pathlib import Path
 
-from jobrunner.config.common import VALID_DATABASE_NAMES, WORKDIR
+from jobrunner.config import common
 
 
 class ConfigException(Exception):
@@ -14,7 +14,7 @@ def _is_valid_backend_name(name):
     return bool(re.match(r"^[A-Za-z0-9][A-Za-z0-9_\-]*[A-Za-z0-9]$", name))
 
 
-METRICS_FILE = WORKDIR / "metrics.sqlite"
+METRICS_FILE = common.WORKDIR / "metrics.sqlite"
 
 # valid archive formats
 ARCHIVE_FORMATS = (".tar.gz", ".tar.zstd", ".tar.xz")
@@ -39,7 +39,7 @@ def database_urls_from_env(env):
         db_name: db_url
         for db_name, db_url in [
             (db_name, env.get(f"{db_name.upper()}_DATABASE_URL"))
-            for db_name in VALID_DATABASE_NAMES
+            for db_name in common.VALID_DATABASE_NAMES
         ]
         if db_url
     }
@@ -86,10 +86,10 @@ EXECUTOR = os.environ.get("EXECUTOR", "jobrunner.executors.local:LocalDockerAPI"
 # Note: the local backend also reuses the main GIT_REPO_DIR config
 
 HIGH_PRIVACY_STORAGE_BASE = Path(
-    os.environ.get("HIGH_PRIVACY_STORAGE_BASE", WORKDIR / "high_privacy")
+    os.environ.get("HIGH_PRIVACY_STORAGE_BASE", common.WORKDIR / "high_privacy")
 )
 MEDIUM_PRIVACY_STORAGE_BASE = Path(
-    os.environ.get("MEDIUM_PRIVACY_STORAGE_BASE", WORKDIR / "medium_privacy")
+    os.environ.get("MEDIUM_PRIVACY_STORAGE_BASE", common.WORKDIR / "medium_privacy")
 )
 
 HIGH_PRIVACY_WORKSPACES_DIR = HIGH_PRIVACY_STORAGE_BASE / "workspaces"
@@ -103,7 +103,7 @@ HIGH_PRIVACY_ARCHIVE_DIR = Path(
 CLEAN_UP_DOCKER_OBJECTS = True
 
 # use to checkout the repo
-TMP_DIR = WORKDIR / "temp"
+TMP_DIR = common.WORKDIR / "temp"
 
 # docker specific exit codes we understand
 DOCKER_EXIT_CODES = {

--- a/jobrunner/config/controller.py
+++ b/jobrunner/config/controller.py
@@ -6,14 +6,14 @@ from pathlib import Path
 
 import pipeline
 
-from jobrunner.config.common import WORKDIR
+from jobrunner.config import common
 
 
 class ConfigException(Exception):
     pass
 
 
-DATABASE_FILE = WORKDIR / "db.sqlite"
+DATABASE_FILE = common.WORKDIR / "db.sqlite"
 
 JOB_SERVER_ENDPOINT = os.environ.get(
     "JOB_SERVER_ENDPOINT", "https://jobs.opensafely.org/api/v2/"

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -502,7 +502,9 @@ def start_job(job):
 
 
 def create_task_for_job(job):
-    previous_tasks = find_where(Task, id__like=f"{job.id}-%", type=TaskType.RUNJOB)
+    previous_tasks = find_where(
+        Task, id__like=f"{job.id}-%", type=TaskType.RUNJOB, backend=job.backend
+    )
     assert all(t.active is False for t in previous_tasks)
     task_number = len(previous_tasks) + 1
     return Task(
@@ -518,7 +520,9 @@ def get_task_for_job(job):
     # TODO: I think jobs need to store the ID of the task they are currently associated
     # with. But for now, it works to always get the most recently created task for a
     # given job.
-    tasks = find_where(Task, id__like=f"{job.id}-%", type=TaskType.RUNJOB)
+    tasks = find_where(
+        Task, id__like=f"{job.id}-%", type=TaskType.RUNJOB, backend=job.backend
+    )
     # Task IDs are constructed such that, for a given job, lexical order matches
     # creation order
     tasks.sort(key=lambda t: t.id)

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -69,9 +69,9 @@ def handle_jobs():
                 # counts in `running_for_workspace` will be up-to-date.
                 0 if job.state == State.RUNNING else 1,
                 # Then process PENDING jobs in order of how many are running in the
-                # workspace. This gives a fairer allocation of capacity among
+                # workspace for that backend. This gives a fairer allocation of capacity among
                 # workspaces.
-                running_for_workspace[job.workspace],
+                running_for_workspace[(job.backend, job.workspace)],
                 # DB jobs are more important than cpu jobs
                 0 if job.requires_db else 1,
                 # Finally use job age as a tie-breaker
@@ -85,9 +85,9 @@ def handle_jobs():
         with set_log_context(job=job):
             handle_single_job(job)
 
-        # Add running jobs to the workspace count
+        # Add running jobs to the backend/workspace count
         if job.state == State.RUNNING:
-            running_for_workspace[job.workspace] += 1
+            running_for_workspace[(job.backend, job.workspace)] += 1
 
         handled_jobs.append(job)
 

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -13,8 +13,8 @@ import time
 from opentelemetry import trace
 
 from jobrunner import tracing
+from jobrunner.config import common as common_config
 from jobrunner.config import controller as config
-from jobrunner.config.common import DOCKER_REGISTRY, JOB_LOOP_INTERVAL
 from jobrunner.controller.task_api import insert_task, mark_task_inactive
 from jobrunner.job_executor import (
     JobDefinition,
@@ -49,7 +49,7 @@ def main(exit_callback=lambda _: False):
         if exit_callback(active_jobs):
             break
 
-        time.sleep(JOB_LOOP_INTERVAL)
+        time.sleep(common_config.JOB_LOOP_INTERVAL)
 
 
 def handle_jobs():
@@ -279,7 +279,7 @@ def job_to_job_definition(job):
     # Prepend registry name
     action_args = job.action_args
     image = action_args.pop(0)
-    full_image = f"{DOCKER_REGISTRY}/{image}"
+    full_image = f"{common_config.DOCKER_REGISTRY}/{image}"
     if image.startswith("stata-mp"):
         env["STATA_LICENSE"] = str(config.STATA_LICENSE)
 

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -444,7 +444,7 @@ def set_code(job, new_status_code, message, error=None, results=None, **attrs):
 
 def get_reason_job_not_started(job):
     log.debug("Querying for running jobs")
-    running_jobs = find_where(Job, state=State.RUNNING)
+    running_jobs = find_where(Job, state=State.RUNNING, backend=job.backend)
     log.debug("Query done")
     used_resources = sum(
         get_job_resource_weight(running_job) for running_job in running_jobs

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -291,7 +291,7 @@ def job_to_job_definition(job):
 
     input_files = []
     for action in job.requires_outputs_from:
-        for filename in list_outputs_from_action(job.workspace, action):
+        for filename in list_outputs_from_action(job.backend, job.workspace, action):
             input_files.append(filename)
 
     outputs = {}
@@ -468,8 +468,8 @@ def get_reason_job_not_started(job):
             )
 
 
-def list_outputs_from_action(workspace, action):
-    for job in calculate_workspace_state(workspace):
+def list_outputs_from_action(backend, workspace, action):
+    for job in calculate_workspace_state(backend, workspace):
         if job.action == action:
             return job.output_files
 

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -88,7 +88,7 @@ def create_jobs(job_request):
     project_file = get_project_file(job_request)
     pipeline_config = load_pipeline(project_file)
     latest_jobs = get_latest_jobs_for_actions_in_project(
-        job_request.workspace, pipeline_config
+        job_request.backend, job_request.workspace, pipeline_config
     )
     new_jobs = get_new_jobs_to_run(job_request, pipeline_config, latest_jobs)
     assert_new_jobs_created(job_request, new_jobs, latest_jobs)
@@ -154,10 +154,10 @@ def get_project_file(job_request):
         raise JobRequestError(f"No project.yaml file found in {job_request.repo_url}")
 
 
-def get_latest_jobs_for_actions_in_project(workspace, pipeline_config):
+def get_latest_jobs_for_actions_in_project(backend, workspace, pipeline_config):
     return [
         job
-        for job in calculate_workspace_state(workspace)
+        for job in calculate_workspace_state(backend, workspace)
         if job.action in pipeline_config.all_actions
     ]
 

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -15,8 +15,8 @@ from pipeline import RUN_ALL_COMMAND, ProjectValidationError, load_pipeline
 
 from jobrunner import tracing
 from jobrunner.actions import get_action_specification
+from jobrunner.config import common as common_config
 from jobrunner.config import controller as config
-from jobrunner.config.common import VALID_DATABASE_NAMES
 from jobrunner.lib.database import exists_where, insert, transaction, update_where
 from jobrunner.lib.git import GitError, GitFileNotFoundError, read_file_from_repo
 from jobrunner.lib.github_validators import (
@@ -129,10 +129,10 @@ def validate_job_request(job_request):
             "Invalid workspace name (allowed are alphanumeric, dash and underscore)"
         )
 
-    if job_request.database_name not in VALID_DATABASE_NAMES:
+    if job_request.database_name not in common_config.VALID_DATABASE_NAMES:
         raise JobRequestError(
             f"Invalid database name '{job_request.database_name}', allowed are: "
-            + ", ".join(VALID_DATABASE_NAMES)
+            + ", ".join(common_config.VALID_DATABASE_NAMES)
         )
 
     # If we're not restricting to specific Github organisations then there's no

--- a/jobrunner/lib/docker.py
+++ b/jobrunner/lib/docker.py
@@ -8,7 +8,7 @@ import os
 import re
 import subprocess
 
-from jobrunner.config.common import DOCKER_REGISTRY
+from jobrunner.config import common as common_config
 from jobrunner.lib import atomic_writer
 
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 # Docker requires a container in order to interact with volumes, but it doesn't
 # much matter what it is for our purposes as long as it has `sh` and `find`
-MANAGEMENT_CONTAINER_IMAGE = f"{DOCKER_REGISTRY}/busybox"
+MANAGEMENT_CONTAINER_IMAGE = f"{common_config.DOCKER_REGISTRY}/busybox"
 
 # This path is pretty arbitrary: it sets where we mount volumes inside their
 # management containers (which are used for copying files in and out), but this

--- a/jobrunner/lib/git.py
+++ b/jobrunner/lib/git.py
@@ -46,6 +46,14 @@ class GitUnknownRefError(GitError):
     pass
 
 
+def get_github_username():
+    # If we have an agent BACKEND set, use that as the github user
+    if agent_config.BACKEND:
+        return f"jobrunner-{agent_config.BACKEND}"
+    # If there is no agent BACKEND set, assume we are the controller
+    return "jobrunner-ctrl"
+
+
 def read_file_from_repo(repo_url, commit_sha, path):
     """
     Return the contents of the file at `path` in `repo_url` as of `commit_sha`
@@ -333,7 +341,7 @@ def add_access_token_and_proxy(repo_url):
         return repo_url
     # Github accepts arbitrary usernames when using a PAT so this is just for
     # easy identification in the proxy logs
-    username = f"jobrunner-{agent_config.BACKEND}"
+    username = get_github_username()
     # Add the token to the URL
     return urlunparse(parsed._replace(netloc=f"{username}:{token}@{parsed.netloc}"))
 

--- a/jobrunner/queries.py
+++ b/jobrunner/queries.py
@@ -7,14 +7,14 @@ from jobrunner.lib.database import find_all, find_one, find_where, upsert
 from jobrunner.models import Flag, Job
 
 
-def calculate_workspace_state(workspace):
+def calculate_workspace_state(backend, workspace):
     """
     Return a list containing the most recent uncancelled job (if any) for each action in the workspace. We always
     ignore cancelled jobs when considering the historical state of the system. We also ignore jobs whose action is
     '__error__'; these are dummy jobs created only to help us communicate failure states back to the job-server (see
     create_or_update_jobs.create_failed_job()).
     """
-    all_jobs = find_where(Job, workspace=workspace, cancelled=False)
+    all_jobs = find_where(Job, workspace=workspace, cancelled=False, backend=backend)
     latest_jobs = []
     for action, jobs in group_by(all_jobs, attrgetter("action")):
         if action == "__error__":

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -10,7 +10,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExport
 from opentelemetry.trace import propagation
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
-from jobrunner.config.common import VERSION
+from jobrunner.config import common as common_config
 from jobrunner.lib import database, warn_assertions
 from jobrunner.models import Job, SavedJobRequest, State, StatusCode
 
@@ -25,7 +25,7 @@ def get_provider():
             "service.name": os.environ.get("OTEL_SERVICE_NAME", "jobrunner"),
             # Note this will be set in the agent only
             "service.namespace": os.environ.get("BACKEND", "unknown"),
-            "service.version": VERSION,
+            "service.version": common_config.VERSION,
         }
     )
     return TracerProvider(resource=resource)

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -23,6 +23,7 @@ def get_provider():
     resource = Resource.create(
         attributes={
             "service.name": os.environ.get("OTEL_SERVICE_NAME", "jobrunner"),
+            # Note this will be set in the agent only
             "service.namespace": os.environ.get("BACKEND", "unknown"),
             "service.version": VERSION,
         }

--- a/tests/agent/test_task_api.py
+++ b/tests/agent/test_task_api.py
@@ -4,13 +4,18 @@ from tests.factories import runjob_db_task_factory
 
 
 def test_get_active_jobs(db):
-    task1 = runjob_db_task_factory()
-    task2 = runjob_db_task_factory()
+    task1 = runjob_db_task_factory(backend="dummy")
+    task2 = runjob_db_task_factory(backend="dummy")
+    task3 = runjob_db_task_factory(backend="another")
     controller_api.mark_task_inactive(task2)
 
-    active = task_api.get_active_tasks()
+    active = task_api.get_active_tasks(backend="dummy")
     assert len(active) == 1
     assert active[0].id == task1.id
+
+    active = task_api.get_active_tasks(backend="another")
+    assert len(active) == 1
+    assert active[0].id == task3.id
 
 
 def test_update_controller(db):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -126,7 +126,7 @@ def runjob_db_task_factory(*args, state=State.RUNNING, **kwargs):
     job = job_factory(*args, state=state, **kwargs)
     task = Task(
         id=job.id,
-        backend="test",
+        backend=kwargs.pop("backend", "test"),
         type=TaskType.RUNJOB,
         definition=job_to_job_definition(job).to_dict(),
     )

--- a/tests/lib/test_git.py
+++ b/tests/lib/test_git.py
@@ -249,28 +249,38 @@ def test_commit_fetch_retry_unexpected_error(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "repo_url,token,expected",
+    "repo_url,token,backend,expected",
     [
+        # uses agent BACKEND in username
         (
             "https://github.com/org/repo",
             "token",
+            "test",
             "https://jobrunner-test:token@proxy.com/org/repo",
         ),
+        # no BACKEND, uses ctrl (for controller) in username
+        (
+            "https://github.com/org/repo",
+            "token",
+            None,
+            "https://jobrunner-ctrl:token@proxy.com/org/repo",
+        ),
         # no token, return without username/pass
-        ("https://github.com/org/repo", "", "https://proxy.com/org/repo"),
+        ("https://github.com/org/repo", "", "test", "https://proxy.com/org/repo"),
         # no https, return without username/pass
-        ("http://github.com/org/repo", "token", "http://proxy.com/org/repo"),
+        ("http://github.com/org/repo", "token", "test", "http://proxy.com/org/repo"),
         # already includes username/pass, don't update
         (
             "https://user:pass@github.com/org/repo",
             "token",
+            "test",
             "https://user:pass@proxy.com/org/repo",
         ),
     ],
 )
-def test_add_access_token_and_proxy(repo_url, token, expected, monkeypatch):
+def test_add_access_token_and_proxy(repo_url, token, backend, expected, monkeypatch):
     monkeypatch.setattr("jobrunner.config.common.GIT_PROXY_DOMAIN", "proxy.com")
-    monkeypatch.setattr("jobrunner.config.agent.BACKEND", "test")
+    monkeypatch.setattr("jobrunner.config.agent.BACKEND", backend)
     monkeypatch.setattr("jobrunner.config.common.PRIVATE_REPO_ACCESS_TOKEN", token)
 
     assert add_access_token_and_proxy(repo_url) == expected

--- a/tests/test_workspace_state.py
+++ b/tests/test_workspace_state.py
@@ -4,59 +4,82 @@ from tests.factories import job_factory
 
 
 def test_gets_one_job(db):
-    job_factory(workspace="the-workspace", action="the-action", state=State.SUCCEEDED)
-    job = only(calculate_workspace_state("the-workspace"))
+    job_factory(
+        backend="the-backend",
+        workspace="the-workspace",
+        action="the-action",
+        state=State.SUCCEEDED,
+    )
+    job_factory(
+        backend="other-backend",
+        workspace="the-workspace",
+        action="the-action",
+        state=State.SUCCEEDED,
+    )
+    job = only(calculate_workspace_state("the-backend", "the-workspace"))
     assert job.action == "the-action"
     assert job.state == State.SUCCEEDED
 
 
 def test_gets_a_job_for_each_action(db):
-    job_factory(workspace="the-workspace", action="action1")
-    job_factory(workspace="the-workspace", action="action2")
-    jobs = calculate_workspace_state("the-workspace")
+    job_factory(backend="the-backend", workspace="the-workspace", action="action1")
+    job_factory(backend="the-backend", workspace="the-workspace", action="action2")
+    jobs = calculate_workspace_state("the-backend", "the-workspace")
     assert len(jobs) == 2
     for action in ["action1", "action2"]:
         assert action in [job.action for job in jobs]
 
 
+def test_ignores_jobs_for_other_backends(db):
+    job_factory(backend="the-backend", workspace="the-workspace", action="action1")
+    job_factory(backend="other-backend", workspace="the-workspace", action="action1")
+    job_factory(backend="other-backend", workspace="the-workspace", action="action2")
+    job = only(calculate_workspace_state("the-backend", "the-workspace"))
+    assert job.action == "action1"
+
+
 def test_gets_the_latest_job_for_an_action(db):
     job_factory(
+        backend="the-backend",
         workspace="the-workspace",
         action="the-action",
         created_at=1000,
         state=State.FAILED,
     )
     job_factory(
+        backend="the-backend",
         workspace="the-workspace",
         action="the-action",
         created_at=2000,
         state=State.SUCCEEDED,
     )
-    job = only(calculate_workspace_state("the-workspace"))
+    job = only(calculate_workspace_state("the-backend", "the-workspace"))
     assert job.state == State.SUCCEEDED
 
 
 def test_ignores_cancelled_jobs(db):
     job_factory(
+        backend="the-backend",
         workspace="the-workspace",
         action="the-action",
         created_at=1000,
         state=State.FAILED,
     )
     job_factory(
+        backend="the-backend",
         workspace="the-workspace",
         action="the-action",
         created_at=2000,
         state=State.SUCCEEDED,
         cancelled=True,
     )
-    job = only(calculate_workspace_state("the-workspace"))
+    job = only(calculate_workspace_state("the-backend", "the-workspace"))
     assert job.state == State.FAILED
 
 
 def test_doesnt_include_dummy_error_jobs(db):
-    job_factory(workspace="the-workspace", action="__error__")
-    jobs = calculate_workspace_state("the-workspace")
+    job_factory(backend="the-backend", workspace="the-workspace", action="__error__")
+    jobs = calculate_workspace_state("the-backend", "the-workspace")
     assert not jobs
 
 


### PR DESCRIPTION
Fixes #882 

This updates all the main agent/controller code to filter jobs/tasks by backend where necessary.

It does not yet address:
- flags
- cli commands
- config that needs to be per-backend
- fetching job requests from job server for all backends