### PR TITLE
 Avoid handling exceptions in the executor and raise instead

### DIFF
--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -18,10 +18,6 @@ log = logging.getLogger(__name__)
 tracer = trace.get_tracer("agent_loop")
 
 
-class InvalidTransition(Exception):
-    pass
-
-
 def main(exit_callback=lambda _: False):  # pragma: no cover
     log.info("jobrunner.agent.main loop started")
     api = get_executor_api()
@@ -133,8 +129,8 @@ def handle_cancel_job_task(task, api):
                 )
                 # call finalize to write the job logs
                 final_status = api.finalize(job, cancelled=True)
-            case _:  # pragma: no cover
-                raise InvalidTransition(
+            case _:
+                assert False, (
                     f"unexpected state of job {job.id}: {initial_job_status.state}"
                 )
 

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -184,16 +184,14 @@ def test_prepare_volume_exists_unprepared(docker_cleanup, job_definition):
 
 
 @pytest.mark.needs_docker
-def test_prepare_no_image(docker_cleanup, job_definition, caplog):
+def test_prepare_no_image(docker_cleanup, job_definition):
     job_definition.image = "invalid-test-image"
-    caplog.set_level(logging.INFO)
     api = local.LocalDockerAPI()
-    status = api.prepare(job_definition)
 
-    assert status.state == ExecutorState.ERROR
+    with pytest.raises(local.LocalExecutorError) as exc:
+        api.prepare(job_definition)
 
-    # check that the log info contains the expected message when there is no image
-    assert job_definition.image in caplog.records[-1].msg
+    assert job_definition.image in str(exc)
 
 
 @pytest.mark.needs_docker
@@ -205,10 +203,11 @@ def test_prepare_archived(ext, job_definition):
     )
     archive.parent.mkdir(parents=True, exist_ok=True)
     archive.write_text("I exist")
-    status = api.prepare(job_definition)
 
-    assert status.state == ExecutorState.ERROR
-    assert "has been archived"
+    with pytest.raises(local.LocalExecutorError) as exc:
+        api.prepare(job_definition)
+
+    assert "has been archived" in str(exc)
 
 
 @pytest.mark.needs_docker


### PR DESCRIPTION
This re-adds the two commits from #894 that were lost by force-pushing to dev.  (See [activity log](https://github.com/opensafely-core/job-runner/activity?ref=dev).)