### PR TITLE
Don't fail jobs on transient errors

### DIFF
--- a/jobrunner/lib/database.py
+++ b/jobrunner/lib/database.py
@@ -382,3 +382,7 @@ def decode_field_values(fields, row):
             value = field.type(value)
         values.append(value)
     return values
+
+
+def is_database_locked_error(exc):
+    return isinstance(exc, sqlite3.OperationalError) and "locked" in str(exc)

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -209,6 +209,10 @@ def test_handle_runjob_with_transient_error(mock_update_controller, db):
     # Controller is not notified of transient error
     assert mock_update_controller.call_count == 0
 
+    spans = get_trace("agent_loop")
+    assert spans[-1].attributes["transient_error"]
+    assert spans[-1].attributes["transient_error_type"] == "db_locked"
+
 
 @patch("jobrunner.agent.task_api.update_controller", spec=task_api.update_controller)
 def test_handle_canceljob_with_error(mock_update_controller, db):

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -1,4 +1,5 @@
 import logging
+import sqlite3
 from unittest.mock import Mock, patch
 
 import pytest
@@ -168,7 +169,7 @@ def test_handle_runjob_with_error(mock_update_controller, db):
         job_id, ExecutorState.EXECUTING, hook=Mock(side_effect=Exception("foo"))
     )
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="foo"):
         main.handle_single_task(task, api)
 
     assert mock_update_controller.call_count == 1
@@ -188,6 +189,25 @@ def test_handle_runjob_with_error(mock_update_controller, db):
     # exception info has been added to the span
     assert span.status.status_code.name == "ERROR"
     assert span.status.description == "Exception: foo"
+
+
+@patch("jobrunner.agent.task_api.update_controller", spec=task_api.update_controller)
+def test_handle_runjob_with_transient_error(mock_update_controller, db):
+    api = StubExecutorAPI()
+
+    task, job_id = api.add_test_runjob_task(ExecutorState.PREPARED)
+
+    api.set_job_transition(
+        job_id,
+        ExecutorState.EXECUTING,
+        hook=Mock(side_effect=sqlite3.OperationalError("database locked")),
+    )
+
+    with pytest.raises(Exception, match="database locked"):
+        main.handle_single_task(task, api)
+
+    # Controller is not notified of transient error
+    assert mock_update_controller.call_count == 0
 
 
 @patch("jobrunner.agent.task_api.update_controller", spec=task_api.update_controller)

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -691,3 +691,7 @@ def test_handle_transient_error(patched_handle_job, db, monkeypatch):
     job = database.find_one(Job, id=job.id)
     # Job should still be pending
     assert job.state == State.PENDING
+
+    spans = get_trace("loop")
+    assert spans[-1].attributes["transient_error"]
+    assert spans[-1].attributes["transient_error_type"] == "db_locked"


### PR DESCRIPTION
For now the only errors we treat as transient are "database locked" errors but we may expand this in future.

Closes #908