### PR TITLE
Update config for multiple backends

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,29 +1,10 @@
-# The name of this backend
-BACKEND=test
-USING_DUMMY_DATA_BACKEND=True
-
-# The endpoint to poll for jobs
-JOB_SERVER_ENDPOINT=https://jobs.opensafely.org/jobs/
-
-# Credentials for logging into the job server
-JOB_SERVER_TOKEN=pass
-
-# A location where cohort CSVs (one row per patient) should be
-# stored. This folder must exist.
-HIGH_PRIVACY_STORAGE_BASE=
-
-# A location where script outputs (some for publication) should be
-# stored
-MEDIUM_PRIVACY_STORAGE_BASE=
+# USED BY BOTH AGENT AND CONTROLLER
+###################################
+# These environment variables are used by both agent and CONTROLLER
+# They may be different on agent/controller
 
 # A Github developer token that has read access to private repos
 PRIVATE_REPO_ACCESS_TOKEN=
-
-# The DSN for accessing the database
-FULL_DATABASE_URL=mssql+pyodbc://xxxx
-
-# Database in which we can create temporary tables
-TEMP_DATABASE_NAME=OPENCoronaTempTables
 
 # How frequently to poll the job-server to pick up new JobRequests and post
 # updates to Jobs
@@ -33,5 +14,34 @@ POLL_INTERVAL=5
 # active jobs
 JOB_LOOP_INTERVAL=1.0
 
-# Default is number of CPUs minus one. Change this to reduce parallelism
-MAX_WORKERS=
+# USED BY AGENT ONLY
+####################
+
+# The name of this backend
+BACKEND=test
+USING_DUMMY_DATA_BACKEND=True
+
+# A location where dataset outputs (one row per patient) should be
+# stored. This folder must exist.
+HIGH_PRIVACY_STORAGE_BASE=
+
+# A location where script outputs (some for publication) should be
+# stored
+MEDIUM_PRIVACY_STORAGE_BASE=
+
+# The DSN for accessing the database
+DEFAULT_DATABASE_URL=mssql+pyodbc://xxxx
+
+# Database in which we can create temporary tables
+TEMP_DATABASE_NAME=OPENCoronaTempTables
+
+# USED BY CONTROLLER ONLY
+#########################
+# The endpoint to poll for jobs
+JOB_SERVER_ENDPOINT=https://jobs.opensafely.org/jobs/
+
+# Credentials for logging into the job server
+JOB_SERVER_TOKEN=pass
+
+# Change this to reduce parallelism (per backend)
+TEST_MAX_WORKERS=

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,5 +1,5 @@
 # The name of this backend
-BACKEND=local
+BACKEND=test
 USING_DUMMY_DATA_BACKEND=True
 
 # The endpoint to poll for jobs

--- a/jobrunner/config/agent.py
+++ b/jobrunner/config/agent.py
@@ -1,5 +1,4 @@
 import os
-import re
 import sys
 from pathlib import Path
 
@@ -10,18 +9,19 @@ class ConfigException(Exception):
     pass
 
 
-def _is_valid_backend_name(name):
-    return bool(re.match(r"^[A-Za-z0-9][A-Za-z0-9_\-]*[A-Za-z0-9]$", name))
-
-
 METRICS_FILE = common.WORKDIR / "metrics.sqlite"
 
 # valid archive formats
 ARCHIVE_FORMATS = (".tar.gz", ".tar.zstd", ".tar.xz")
 
-BACKEND = os.environ.get("BACKEND", "dummy")
-if not _is_valid_backend_name(BACKEND):
-    raise RuntimeError(f"BACKEND not in valid format: '{BACKEND}'")  # pragma: no cover
+# This will be None for the controller
+BACKEND = os.environ.get("BACKEND")
+# this is tested in tests/test_config.py but via subprocess so it isn't registered by coverage
+if BACKEND and BACKEND not in common.BACKENDS:  # pragma: no cover
+    valid_backends = ", ".join(common.BACKENDS)
+    raise RuntimeError(
+        f"BACKEND {BACKEND} is not valid, allowed backends are: {valid_backends}"
+    )
 
 truthy = ("true", "1", "yes")
 

--- a/jobrunner/config/common.py
+++ b/jobrunner/config/common.py
@@ -7,8 +7,7 @@ from pathlib import Path
 # - validate each job is from a known backend
 # - looping through BACKENDS in sync
 # The agent uses it to validate its BACKEND config
-BACKENDS = ["test", "tpp", "emis"]
-
+BACKENDS = os.environ.get("BACKENDS", "test,tpp,emis").strip().split(",")
 
 # Used for tracing in both agent and controller
 VERSION = os.environ.get("VERSION", "")

--- a/jobrunner/config/common.py
+++ b/jobrunner/config/common.py
@@ -2,6 +2,14 @@ import os
 from pathlib import Path
 
 
+# A list of known available backends
+# The controller uses this to:
+# - validate each job is from a known backend
+# - looping through BACKENDS in sync
+# The agent uses it to validate its BACKEND config
+BACKENDS = ["test", "tpp", "emis"]
+
+
 # Used for tracing in both agent and controller
 VERSION = os.environ.get("VERSION", "")
 

--- a/jobrunner/config/controller.py
+++ b/jobrunner/config/controller.py
@@ -22,11 +22,6 @@ JOB_SERVER_TOKEN = os.environ.get("JOB_SERVER_TOKEN", "token")
 
 POLL_INTERVAL = float(os.environ.get("POLL_INTERVAL", "5"))
 
-
-# TODO Add a BACKENDS config and validate each job is from a known backend
-# We'll also use the BACKENDS config for looping through BACKENDS in sync
-BACKENDS = []
-
 ALLOWED_IMAGES = {
     "cohortextractor",
     "databuilder",

--- a/jobrunner/config/controller.py
+++ b/jobrunner/config/controller.py
@@ -83,7 +83,9 @@ def parse_job_resource_weights(config_file_template):
     weights = {}
     for backend in common.BACKENDS:
         weights[backend] = {}
-        config_file = Path(config_file_template.format(backend=backend.lower()))
+        config_file = common.WORKDIR / Path(
+            config_file_template.format(backend=backend.lower())
+        )
         if config_file.exists():
             config = configparser.ConfigParser()
             config.read_string(config_file.read_text(), source=str(config_file))

--- a/jobrunner/config/controller.py
+++ b/jobrunner/config/controller.py
@@ -35,15 +35,19 @@ ALLOWED_IMAGES = {
 #  Set workers per-backend. This will be used by the controller to
 # determine if there are enough resources available to start a new
 # job running.
+default_workers = {"test": 2, "tpp": 10, "emis": 10}
 MAX_WORKERS = {
-    "test": int(os.environ.get("TEST_MAX_WORKERS") or 3),
-    "tpp": int(os.environ.get("TPP_MAX_WORKERS") or 10),
-    "emis": int(os.environ.get("EMIS_MAX_WORKERS") or 10),
+    backend: int(
+        os.environ.get(f"{backend.upper()}_MAX_WORKERS")
+        or default_workers.get(backend, 10)
+    )
+    for backend in common.BACKENDS
 }
 MAX_DB_WORKERS = {
-    "test": int(os.environ.get("TEST_MAX_DB_WORKERS") or MAX_WORKERS["test"]),
-    "tpp": int(os.environ.get("TPP_MAX_DB_WORKERS") or MAX_WORKERS["tpp"]),
-    "emis": int(os.environ.get("EMIS_MAX_DB_WORKERS") or MAX_WORKERS["emis"]),
+    backend: int(
+        os.environ.get(f"{backend.upper()}_MAX_DB_WORKERS") or MAX_WORKERS[backend]
+    )
+    for backend in common.BACKENDS
 }
 
 # Currently we assume all backends will have the same

--- a/jobrunner/config/controller.py
+++ b/jobrunner/config/controller.py
@@ -1,7 +1,6 @@
 import configparser
 import os
 import re
-from multiprocessing import cpu_count
 from pathlib import Path
 
 import pipeline
@@ -33,21 +32,29 @@ ALLOWED_IMAGES = {
     "sqlrunner",
 }
 
-# TODO per-backend
-MAX_WORKERS = int(os.environ.get("MAX_WORKERS") or max(cpu_count() - 1, 1))
-# TODO per-backend
-MAX_DB_WORKERS = int(os.environ.get("MAX_DB_WORKERS") or MAX_WORKERS)
-# TODO per-backend
+#  Set workers per-backend. This will be used by the controller to
+# determine if there are enough resources available to start a new
+# job running.
+MAX_WORKERS = {
+    "test": int(os.environ.get("TEST_MAX_WORKERS") or 3),
+    "tpp": int(os.environ.get("TPP_MAX_WORKERS") or 10),
+    "emis": int(os.environ.get("EMIS_MAX_WORKERS") or 10),
+}
+MAX_DB_WORKERS = {
+    "test": int(os.environ.get("TEST_MAX_DB_WORKERS") or MAX_WORKERS["test"]),
+    "tpp": int(os.environ.get("TPP_MAX_DB_WORKERS") or MAX_WORKERS["tpp"]),
+    "emis": int(os.environ.get("EMIS_MAX_DB_WORKERS") or MAX_WORKERS["emis"]),
+}
+
+# Currently we assume all backends will have the same
+# limits on L4 files
 LEVEL4_MAX_FILESIZE = int(
     os.environ.get("LEVEL4_MAX_FILESIZE", 16 * 1024 * 1024)
 )  # 16mb
-# TODO per-backend
 LEVEL4_MAX_CSV_ROWS = int(os.environ.get("LEVEL4_MAX_CSV_ROWS", 5000))
-# TODO per-backend
 LEVEL4_FILE_TYPES = pipeline.constants.LEVEL4_FILE_TYPES
 
 STATA_LICENSE = os.environ.get("STATA_LICENSE")
-
 
 ACTIONS_GITHUB_ORG = "opensafely-actions"
 ACTIONS_GITHUB_ORG_URL = f"https://github.com/{ACTIONS_GITHUB_ORG}"
@@ -113,7 +120,17 @@ DATABASE_EXIT_CODES = {
     5: "Something went wrong with the database, please contact tech support",
 }
 
-# TODO per-backend
-DEFAULT_JOB_CPU_COUNT = float(os.environ.get("DEFAULT_JOB_CPU_COUNT", 2))
-# TODO per-backend
-DEFAULT_JOB_MEMORY_LIMIT = os.environ.get("DEFAULT_JOB_MEMORY_LIMIT", "4G")
+
+# per-backend job limits
+def job_limits_from_env(env, limit_name, default, transform=str):
+    common_default = transform(env.get(f"DEFAULT_{limit_name.upper()}") or default)
+    return {
+        backend: transform(
+            env.get(f"{backend.upper()}_{limit_name.upper()}") or common_default
+        )
+        for backend in common.BACKENDS
+    }
+
+
+DEFAULT_JOB_CPU_COUNT = job_limits_from_env(os.environ, "job_cpu_count", 2, float)
+DEFAULT_JOB_MEMORY_LIMIT = job_limits_from_env(os.environ, "job_memory_limit", "4G")

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -452,7 +452,7 @@ def get_reason_job_not_started(job):
         get_job_resource_weight(running_job) for running_job in running_jobs
     )
     required_resources = get_job_resource_weight(job)
-    if used_resources + required_resources > config.MAX_WORKERS:
+    if used_resources + required_resources > config.MAX_WORKERS[job.backend]:
         if required_resources > 1:
             return (
                 StatusCode.WAITING_ON_WORKERS,
@@ -463,7 +463,7 @@ def get_reason_job_not_started(job):
 
     if job.requires_db:
         running_db_jobs = len([j for j in running_jobs if j.requires_db])
-        if running_db_jobs >= config.MAX_DB_WORKERS:
+        if running_db_jobs >= config.MAX_DB_WORKERS[job.backend]:
             return (
                 StatusCode.WAITING_ON_DB_WORKERS,
                 "Waiting on available database workers",

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -317,8 +317,8 @@ def job_to_job_definition(job):
         database_name=job.database_name if job.requires_db else None,
         # in future, these may come from the JobRequest, but for now, we have
         # config defaults.
-        cpu_count=config.DEFAULT_JOB_CPU_COUNT,
-        memory_limit=config.DEFAULT_JOB_MEMORY_LIMIT,
+        cpu_count=config.DEFAULT_JOB_CPU_COUNT[job.backend],
+        memory_limit=config.DEFAULT_JOB_MEMORY_LIMIT[job.backend],
         level4_max_filesize=config.LEVEL4_MAX_FILESIZE,
         level4_max_csv_rows=config.LEVEL4_MAX_CSV_ROWS,
         level4_file_types=list(config.LEVEL4_FILE_TYPES),

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -485,7 +485,7 @@ def get_job_resource_weight(job, weights=None):
     the config file, default to 1 otherwise
     """
     weights = weights or config.JOB_RESOURCE_WEIGHTS
-    action_patterns = weights.get(job.workspace)
+    action_patterns = weights.get(job.backend, {}).get(job.workspace)
     if action_patterns:
         for pattern, weight in action_patterns.items():
             if pattern.fullmatch(job.action):

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -129,6 +129,12 @@ def validate_job_request(job_request):
             "Invalid workspace name (allowed are alphanumeric, dash and underscore)"
         )
 
+    if job_request.backend not in common_config.BACKENDS:
+        raise JobRequestError(
+            f"Invalid backend '{job_request.backend}', allowed are: "
+            + ", ".join(common_config.BACKENDS)
+        )
+
     if job_request.database_name not in common_config.VALID_DATABASE_NAMES:
         raise JobRequestError(
             f"Invalid database name '{job_request.database_name}', allowed are: "

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 from jobrunner import record_stats
 from jobrunner.config import agent as config
-from jobrunner.config import controller as controller_config
 from jobrunner.executors import volumes
 from jobrunner.job_executor import (
     ExecutorAPI,
@@ -766,7 +765,7 @@ def check_l4_file(job_definition, filename, size, workspace_dir):
                 limit=mb(job_definition.level4_max_filesize),
             )
         )
-    elif suffix not in controller_config.LEVEL4_FILE_TYPES:
+    elif suffix not in job_definition.level4_file_types:
         job_msgs.append(f"File type of {suffix} is not valid level 4 file")
         file_msgs.append(INVALID_FILE_TYPE_MSG.format(filename=filename, suffix=suffix))
 

--- a/tests/agent/test_task_api.py
+++ b/tests/agent/test_task_api.py
@@ -1,6 +1,23 @@
+import pytest
+
 from jobrunner.agent import task_api
 from jobrunner.controller import task_api as controller_api
 from tests.factories import runjob_db_task_factory
+
+
+@pytest.fixture(autouse=True)
+def setup_config(monkeypatch):
+    monkeypatch.setattr(
+        "jobrunner.config.controller.DEFAULT_JOB_CPU_COUNT",
+        {
+            "dummy": 2,
+            "another": 2,
+        },
+    )
+    monkeypatch.setattr(
+        "jobrunner.config.controller.DEFAULT_JOB_MEMORY_LIMIT",
+        {"dummy": "4G", "another": "4G"},
+    )
 
 
 def test_get_active_jobs(db):
@@ -19,7 +36,7 @@ def test_get_active_jobs(db):
 
 
 def test_update_controller(db):
-    task = runjob_db_task_factory()
+    task = runjob_db_task_factory(backend="dummy")
 
     task_api.update_controller(
         task,
@@ -35,7 +52,7 @@ def test_update_controller(db):
 
 
 def test_full_job_stages(db):
-    task = runjob_db_task_factory()
+    task = runjob_db_task_factory(backend="dummy")
 
     stages = [
         "PREPARING",

--- a/tests/cli/test_add_backend_to_job.py
+++ b/tests/cli/test_add_backend_to_job.py
@@ -10,12 +10,13 @@ def test_add_backend_to_job(db, monkeypatch):
     monkeypatch.setattr("jobrunner.config.agent.BACKEND", "dummy_backend")
     monkeypatch.setattr("builtins.input", lambda _: "y")
     # job with no SavedJobRequest instance
-    job1 = job_factory(job_request=job_request_factory_raw(), backend=None)
+    job1 = job_factory(job_request=job_request_factory_raw(backend=None), backend=None)
     assert not database.find_where(SavedJobRequest, id=job1.job_request_id)
 
     # job with job_request and SavedJobRequest instance
-    job_request = job_request_factory(original={"backend": "the_test_backend"})
-    job2 = job_factory(job_request, backend=None)
+    job2 = job_factory(
+        job_request=job_request_factory(backend="the_test_backend"), backend=None
+    )
     assert database.find_where(SavedJobRequest, id=job2.job_request_id)
 
     # job with no job_request id
@@ -47,7 +48,7 @@ def test_add_backend_to_job_confirmation(db, monkeypatch, response, expected_bac
     monkeypatch.setattr("jobrunner.config.agent.BACKEND", "dummy_backend")
     # job with a backend already set
     job1 = job_factory(backend="test")
-    job2 = job_factory(backend=None)
+    job2 = job_factory(job_request=job_request_factory_raw(backend=None), backend=None)
 
     monkeypatch.setattr("builtins.input", lambda _: response)
     add_backend_to_job.main()

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -116,7 +116,7 @@ def test_handle_pending_job_waiting_on_dependency(db):
 
 
 def test_handle_job_waiting_on_workers(monkeypatch, db):
-    monkeypatch.setattr(config, "MAX_WORKERS", 0)
+    monkeypatch.setattr(config, "MAX_WORKERS", {"test": 0})
 
     job = job_factory()
     run_controller_loop_once()
@@ -136,7 +136,9 @@ def test_handle_job_waiting_on_workers(monkeypatch, db):
 
 def test_handle_job_waiting_on_workers_by_backend(monkeypatch, db):
     # backends can run at most 1 job
-    monkeypatch.setattr(config, "MAX_WORKERS", 1)
+    monkeypatch.setattr(config, "MAX_WORKERS", {"foo": 1, "bar": 1})
+    monkeypatch.setattr(config, "DEFAULT_JOB_CPU_COUNT", {"foo": 2, "bar": 2})
+    monkeypatch.setattr(config, "DEFAULT_JOB_MEMORY_LIMIT", {"foo": "4G", "bar": "4G"})
 
     # One running job on backend foo
     # No running jobs on backend bar
@@ -170,7 +172,7 @@ def test_handle_job_waiting_on_workers_by_backend(monkeypatch, db):
 
 
 def test_handle_job_waiting_on_workers_resource_intensive_job(monkeypatch, db):
-    monkeypatch.setattr(config, "MAX_WORKERS", 2)
+    monkeypatch.setattr(config, "MAX_WORKERS", {"test": 2})
     monkeypatch.setattr(
         config, "JOB_RESOURCE_WEIGHTS", {"workspace": {re.compile(r"action\d{1}"): 1.5}}
     )
@@ -217,7 +219,7 @@ def test_handle_job_waiting_on_workers_resource_intensive_job(monkeypatch, db):
 
 
 def test_handle_job_waiting_on_db_workers(monkeypatch, db):
-    monkeypatch.setattr(config, "MAX_DB_WORKERS", 0)
+    monkeypatch.setattr(config, "MAX_DB_WORKERS", {"test": 0})
     job = job_factory(
         run_command="ehrql:v1 generate-dataset dataset.py --output data.csv",
         requires_db=True,

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -174,7 +174,9 @@ def test_handle_job_waiting_on_workers_by_backend(monkeypatch, db):
 def test_handle_job_waiting_on_workers_resource_intensive_job(monkeypatch, db):
     monkeypatch.setattr(config, "MAX_WORKERS", {"test": 2})
     monkeypatch.setattr(
-        config, "JOB_RESOURCE_WEIGHTS", {"workspace": {re.compile(r"action\d{1}"): 1.5}}
+        config,
+        "JOB_RESOURCE_WEIGHTS",
+        {"test": {"workspace": {re.compile(r"action\d{1}"): 1.5}}},
     )
 
     # Resource-heavy jobs can be configured with a weighting, which is used as a

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -24,10 +24,12 @@ JOB_REQUEST_DEFAULTS = {
     "workspace": "workspace",
     "codelists_ok": True,
     "database_name": "default",
+    "backend": "test",
     "original": {
         "created_by": "testuser",
         "project": "project",
         "orgs": ["org1", "org2"],
+        "backend": "test",
     },
 }
 
@@ -42,6 +44,7 @@ JOB_DEFAULTS = {
     "output_spec": {},
     "created_at": 0,
     "status_code": StatusCode.CREATED,
+    "backend": "test",
 }
 
 
@@ -61,6 +64,8 @@ def job_request_factory_raw(**kwargs):
 
     values = deepcopy(JOB_REQUEST_DEFAULTS)
     values.update(kwargs)
+    if "backend" in kwargs:
+        values["original"]["backend"] = kwargs["backend"]
     return JobRequest(**values)
 
 
@@ -72,7 +77,11 @@ def job_request_factory(**kwargs):
 
 def job_factory(job_request=None, **kwargs):
     if job_request is None:
-        job_request = job_request_factory()
+        # if there's a job backend, make sure the job request is consistent
+        job_request_kwargs = {}
+        if job_backend := kwargs.get("backend"):
+            job_request_kwargs = {"backend": job_backend}
+        job_request = job_request_factory(**job_request_kwargs)
 
     values = deepcopy(JOB_DEFAULTS)
     # default times

--- a/tests/test_create_or_update_jobs.py
+++ b/tests/test_create_or_update_jobs.py
@@ -206,8 +206,9 @@ def test_existing_active_jobs_are_picked_up_when_checking_dependencies(tmp_work_
 
 
 def test_existing_active_jobs_for_other_backends_are_ignored_when_checking_dependencies(
-    tmp_work_dir,
+    tmp_work_dir, monkeypatch
 ):
+    monkeypatch.setattr("jobrunner.config.common.BACKENDS", ["foo", "bar"])
     # Schedule the same job on 2 backends
     create_jobs_with_project_file(
         make_job_request(action="analyse_data", backend="foo"), TEST_PROJECT
@@ -326,6 +327,7 @@ def test_cancelled_jobs_are_flagged(tmp_work_dir):
         ({}, {"workspace": None}, "Workspace name cannot be blank", JobRequestError),
         ({}, {"workspace": "$%#"}, "Invalid workspace", JobRequestError),
         ({}, {"database_name": "invalid"}, "Invalid database name", JobRequestError),
+        ({}, {"backend": "foo"}, "Invalid backend", JobRequestError),
         (
             {},
             {"requested_actions": []},

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -42,7 +42,7 @@ def test_integration(
     monkeypatch.setattr("jobrunner.config.controller.ALLOWED_GITHUB_ORGS", None)
     # Ensure that we have enough workers to start the jobs we expect in the test
     # (CI may have fewer actual available workers than this)
-    monkeypatch.setattr("jobrunner.config.controller.MAX_WORKERS", 4)
+    monkeypatch.setattr("jobrunner.config.controller.MAX_WORKERS", {"test": 4})
 
     # Note that as we are running ehrql actions in this test, we need to set
     # the backend to a value that ehrql will accept

--- a/tests/test_job_resource_weights.py
+++ b/tests/test_job_resource_weights.py
@@ -6,6 +6,7 @@ from jobrunner.models import Job
 
 
 def test_job_resource_weights(tmp_path):
+    config_file_template = "config_{backend}.ini"
     config = textwrap.dedent(
         """
         [my-workspace]
@@ -13,14 +14,22 @@ def test_job_resource_weights(tmp_path):
         pattern[\\d]+ = 4
         """
     )
-    config_file = tmp_path / "config.ini"
+    config_file = tmp_path / "config_test.ini"
     config_file.write_text(config)
-    weights = parse_job_resource_weights(config_file)
-    job = Job(workspace="foo", action="bar")
+    weights = parse_job_resource_weights(str(tmp_path / config_file_template))
+    job = Job(workspace="foo", action="bar", backend="test")
     assert get_job_resource_weight(job, weights=weights) == 1
-    job = Job(workspace="my-workspace", action="some_action")
+    job = Job(workspace="my-workspace", action="some_action", backend="test")
     assert get_job_resource_weight(job, weights=weights) == 2.5
-    job = Job(workspace="my-workspace", action="pattern315")
+    other_backend_job = Job(
+        workspace="my-workspace", action="some_action", backend="other"
+    )
+    assert get_job_resource_weight(other_backend_job, weights=weights) == 1
+    job = Job(workspace="my-workspace", action="pattern315", backend="test")
     assert get_job_resource_weight(job, weights=weights) == 4
-    job = Job(workspace="my-workspace", action="pattern000no_match")
+    other_backend_job = Job(
+        workspace="my-workspace", action="pattern315", backend="other"
+    )
+    assert get_job_resource_weight(other_backend_job, weights=weights) == 1
+    job = Job(workspace="my-workspace", action="pattern000no_match", backend="test")
     assert get_job_resource_weight(job, weights=weights) == 1

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -40,6 +40,7 @@ def job_definition(request, test_repo):
         allow_database_access=False,
         level4_max_filesize=16 * 1024 * 1024,
         level4_max_csv_rows=5000,
+        level4_file_types=[".txt", ".csv"],
     )
 
 


### PR DESCRIPTION
Fixes #904

- Adds a BACKENDS config variable to define known backends, and validates job requests against it.
- Updates controller config that will need to be backend-specific 
    - MAX_WORKERS
    - MAX_DB_WORKERS
    - DEFAULT_JOB_CPU_COUNT
    - DEFAULT_JOB_MEMORY_LIMIT
    - JOB_RESOURCE_WEIGHTS (now read from backend-specific ini files)
- LEVEL4_FILE_TYPES remains constant across backends, but is now passed explicitly in the task definition

MAX_WORKERS is the only env variable which is currently defined in backends, and will need to change to include the backend name (i.e. MAX_WORKERS becomes TEST_MAX_WORKERS and TPP_MAX_WORKERS).