### PR TITLE
Remove quickfix transactions added from incident

### DIFF
--- a/jobrunner/agent/task_api.py
+++ b/jobrunner/agent/task_api.py
@@ -32,18 +32,17 @@ def update_controller(
     # future, we may want the HTTP handler to do both, so that the main loop
     # does not need to handle agent updates and completed jobs at all.  But all
     # we have currently is the loop, so we'll do that logic there for step 1
-    with database.transaction():
-        db_task = database.find_one(ControllerTask, id=task.id)
-        db_task.agent_stage = stage
-        db_task.agent_results = results
-        db_task.agent_complete = complete
-        # This looks like the agent overstepping itself but I think this is the
-        # behaviour we need to simulate how the HTTP handler will work. The
-        # controller endpoint which receives task updates will always mark
-        # tasks as inactive if the agent says they're complete: there's no
-        # point continuing to ask for updates on completed tasks. Note that
-        # these are still semantically different things though because the
-        # controller can mark tasks inactive even when they're not complete.
-        if complete:
-            db_task.active = False
-        database.update(db_task)
+    db_task = database.find_one(ControllerTask, id=task.id)
+    db_task.agent_stage = stage
+    db_task.agent_results = results
+    db_task.agent_complete = complete
+    # This looks like the agent overstepping itself but I think this is the
+    # behaviour we need to simulate how the HTTP handler will work. The
+    # controller endpoint which receives task updates will always mark
+    # tasks as inactive if the agent says they're complete: there's no
+    # point continuing to ask for updates on completed tasks. Note that
+    # these are still semantically different things though because the
+    # controller can mark tasks inactive even when they're not complete.
+    if complete:
+        db_task.active = False
+    database.update(db_task)

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -383,13 +383,12 @@ def set_cancelled_flag_for_actions(job_request_id, actions):
     # It's important that we modify the Jobs in-place in the database rather than retrieving, updating and re-writing
     # them. If we did the latter then we would risk dirty writes if the run thread modified a Job while we were
     # working.
-    with transaction():
-        update_where(
-            Job,
-            {
-                "cancelled": True,
-                "completed_at": int(time.time()),
-            },
-            job_request_id=job_request_id,
-            action__in=actions,
-        )
+    update_where(
+        Job,
+        {
+            "cancelled": True,
+            "completed_at": int(time.time()),
+        },
+        job_request_id=job_request_id,
+        action__in=actions,
+    )


### PR DESCRIPTION
We only need transactions around multiple statements. sqlite's default
autocommit behaviour DTRT with respecting busy_wait timeout with single
statment write statements.

So the changes reverted here didn't really do anything, and could cause
confusion.
