### PR TITLE
Sync multiple backends

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -3,6 +3,9 @@
 # These environment variables are used by both agent and CONTROLLER
 # They may be different on agent/controller
 
+# Comma separated list of known backends; default if unset: test,tpp,emis
+# BACKENDS=test
+
 # A Github developer token that has read access to private repos
 PRIVATE_REPO_ACCESS_TOKEN=
 
@@ -41,7 +44,9 @@ TEMP_DATABASE_NAME=OPENCoronaTempTables
 JOB_SERVER_ENDPOINT=https://jobs.opensafely.org/jobs/
 
 # Credentials for logging into the job server
-JOB_SERVER_TOKEN=pass
+# Note this variable is per-backend i.e. <BACKEND>_JOB_SERVER_TOKEN for each backend
+TEST_JOB_SERVER_TOKEN=pass
 
 # Change this to reduce parallelism (per backend)
+# Note this variable is per-backend i.e. <BACKEND>_MAX_WORKERS for each backend
 TEST_MAX_WORKERS=

--- a/jobrunner/cli/add_backend_to_flags.py
+++ b/jobrunner/cli/add_backend_to_flags.py
@@ -1,0 +1,30 @@
+from jobrunner.config import agent as config
+from jobrunner.lib.database import find_where, update
+from jobrunner.models import Flag
+
+
+def main():
+    """
+    Command to add missing backend attribute to flags. We expect this to only
+    run once per backend, prior to moving the controller out of the backend
+    """
+    flags_missing_backend = find_where(Flag, backend=None)
+    if flags_missing_backend:
+        print(
+            "This command will add a backend attribute to all flags and should only be run from inside a backend. Please confirm you want to continue:"
+        )
+        confirm = input("\nY to continue, N to quit\n")
+        if confirm.lower() != "y":
+            return
+    else:
+        print("All flags have a backend assigned; nothing to do")
+
+    for flag in flags_missing_backend:
+        flag.backend = config.BACKEND
+        update(flag)
+
+    print(f"{len(flags_missing_backend)} flags updated")
+
+
+if __name__ == "__main__":
+    main()

--- a/jobrunner/config/agent.py
+++ b/jobrunner/config/agent.py
@@ -14,7 +14,6 @@ METRICS_FILE = common.WORKDIR / "metrics.sqlite"
 # valid archive formats
 ARCHIVE_FORMATS = (".tar.gz", ".tar.zstd", ".tar.xz")
 
-# This will be None for the controller
 BACKEND = os.environ.get("BACKEND")
 # this is tested in tests/test_config.py but via subprocess so it isn't registered by coverage
 if BACKEND and BACKEND not in common.BACKENDS:  # pragma: no cover

--- a/jobrunner/config/controller.py
+++ b/jobrunner/config/controller.py
@@ -17,7 +17,11 @@ DATABASE_FILE = common.WORKDIR / "db.sqlite"
 JOB_SERVER_ENDPOINT = os.environ.get(
     "JOB_SERVER_ENDPOINT", "https://jobs.opensafely.org/api/v2/"
 )
-JOB_SERVER_TOKEN = os.environ.get("JOB_SERVER_TOKEN", "token")
+
+JOB_SERVER_TOKEN = {
+    backend: os.environ.get(f"{backend.upper()}_JOB_SERVER_TOKEN", "token")
+    for backend in common.BACKENDS
+}
 
 POLL_INTERVAL = float(os.environ.get("POLL_INTERVAL", "5"))
 

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -110,8 +110,10 @@ def handle_single_job(job):
     # TODO: These flags are going to need to be set per-backend so we'll need to figure
     # out how to do that and then retrive the values for the backend associated with
     # each job
-    mode = get_flag_value("mode")
-    paused = str(get_flag_value("paused", "False")).lower() == "true"
+    mode = get_flag_value("mode", job.backend)
+    paused = (
+        str(get_flag_value("paused", job.backend, default="False")).lower() == "true"
+    )
     try:
         trace_handle_job(job, mode, paused)
     except Exception as exc:

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -372,13 +372,22 @@ class Flag:
         CREATE TABLE flags (
             id TEXT,
             value TEXT,
+            backend TEXT,
             timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (id)
         )
     """
 
+    migration(
+        6,
+        """
+        ALTER TABLE flags ADD COLUMN backend TEXT;
+        """,
+    )
+
     id: str  # noqa: A003
     value: str
+    backend: str = None
     timestamp: int = None
 
     @property
@@ -387,7 +396,7 @@ class Flag:
 
     def __str__(self):
         ts = self.timestamp_isoformat if self.timestamp else "never set"
-        return f"{self.id}={self.value} ({ts})"
+        return f"[{self.backend}] {self.id}={self.value} ({ts})"
 
 
 @databaseclass

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -98,17 +98,21 @@ DB_MAINTENANCE_MODE = "db-maintenance"
 
 def maintenance_mode():
     """Check if the db is currently in maintenance mode, and set flags as appropriate."""
+    # TODO currently we get and set flags using the agent's backend ,
+    # this will change when the db is only accessible to the controller
+    backend = agent_config.BACKEND
+
     # This did not seem big enough to warrant splitting into a separate module.
     log.info("checking if db undergoing maintenance...")
 
     # manually setting this flag bypasses the automaticaly check
-    manual_db_mode = get_flag_value("manual-db-maintenance")
+    manual_db_mode = get_flag_value("manual-db-maintenance", backend)
     if manual_db_mode:
         log.info(f"manually set db mode: {DB_MAINTENANCE_MODE}")
         mode = DB_MAINTENANCE_MODE
     else:
         # detect db mode from TPP.
-        current = get_flag_value("mode")
+        current = get_flag_value("mode", backend)
         ps = docker(
             [
                 "run",
@@ -139,8 +143,8 @@ def maintenance_mode():
                 log.info("DB maintenance mode had ended")
             mode = None
 
-    set_flag("mode", mode)
-    mode = get_flag_value("mode")
+    set_flag("mode", mode, backend)
+    mode = get_flag_value("mode", backend)
     log.info(f"db mode: {mode}")
     return mode
 

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -92,13 +92,13 @@ def api_request(method, path, *args, backend, headers=None, **kwargs):
 
     url = "{}/{}/".format(config.JOB_SERVER_ENDPOINT.rstrip("/"), path.strip("/"))
 
-    flags = {
-        f.id: {"v": f.value, "ts": f.timestamp_isoformat}
-        for f in queries.get_current_flags()
-    }
-
     if backend not in config.JOB_SERVER_TOKEN:
         raise SyncAPIError(f"No api token found for backend '{backend}'")
+
+    flags = {
+        f.id: {"v": f.value, "ts": f.timestamp_isoformat}
+        for f in queries.get_current_flags(backend=backend)
+    }
 
     headers["Authorization"] = config.JOB_SERVER_TOKEN[backend]
     headers["Flags"] = json.dumps(flags, separators=(",", ":"))

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -78,15 +78,15 @@ def sync_backend(backend):
     api_post("jobs", backend=backend, json=jobs_data)
 
 
-def api_get(*args, backend=None, **kwargs):
+def api_get(*args, backend, **kwargs):
     return api_request("get", *args, backend=backend, **kwargs)
 
 
-def api_post(*args, backend=None, **kwargs):
+def api_post(*args, backend, **kwargs):
     return api_request("post", *args, backend=backend, **kwargs)
 
 
-def api_request(method, path, *args, backend=None, headers=None, **kwargs):
+def api_request(method, path, *args, backend, headers=None, **kwargs):
     if headers is None:  # pragma: no cover
         headers = {}
 

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -72,15 +72,15 @@ def sync():
     api_post("jobs", json=jobs_data)
 
 
-def api_get(*args, **kwargs):
-    return api_request("get", *args, **kwargs)
+def api_get(*args, backend=None, **kwargs):
+    return api_request("get", *args, backend=backend, **kwargs)
 
 
-def api_post(*args, **kwargs):
-    return api_request("post", *args, **kwargs)
+def api_post(*args, backend=None, **kwargs):
+    return api_request("post", *args, backend=backend, **kwargs)
 
 
-def api_request(method, path, *args, headers=None, **kwargs):
+def api_request(method, path, *args, backend=None, headers=None, **kwargs):
     if headers is None:  # pragma: no cover
         headers = {}
 
@@ -91,7 +91,10 @@ def api_request(method, path, *args, headers=None, **kwargs):
         for f in queries.get_current_flags()
     }
 
-    headers["Authorization"] = config.JOB_SERVER_TOKEN
+    if backend not in config.JOB_SERVER_TOKEN:
+        raise SyncAPIError(f"No api token found for backend '{backend}'")
+
+    headers["Authorization"] = config.JOB_SERVER_TOKEN[backend]
     headers["Flags"] = json.dumps(flags, separators=(",", ":"))
 
     response = session.request(method, url, *args, headers=headers, **kwargs)

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -11,7 +11,6 @@ import time
 import requests
 
 from jobrunner import queries, record_stats
-from jobrunner.config import agent as agent_config
 from jobrunner.config import controller as config
 from jobrunner.create_or_update_jobs import create_or_update_jobs
 from jobrunner.lib.database import find_where, select_values
@@ -44,7 +43,6 @@ def sync():
         # of active jobs is always going to be small enough that we can fetch
         # them in a single request and we don't need the extra complexity
         # TODO loop over config.BACKENDS
-        params={"backend": agent_config.BACKEND},
     )
     job_requests = [job_request_from_remote_format(i) for i in response["results"]]
 

--- a/tests/cli/test_add_backend_to_flags.py
+++ b/tests/cli/test_add_backend_to_flags.py
@@ -1,0 +1,53 @@
+import pytest
+
+from jobrunner.cli import add_backend_to_flags
+from jobrunner.lib import database
+from jobrunner.models import Flag
+
+
+def test_add_backend_to_flag(db, monkeypatch):
+    monkeypatch.setattr("jobrunner.config.agent.BACKEND", "dummy_backend")
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    flag1 = Flag(id="foo", value="bar")
+    database.insert(flag1)
+    flag2 = Flag(id="foo1", value="bar1", backend="the_test_backend")
+    database.insert(flag2)
+
+    add_backend_to_flags.main()
+    assert database.find_one(Flag, id=flag1.id).backend == "dummy_backend"
+    assert database.find_one(Flag, id=flag2.id).backend == "the_test_backend"
+
+
+@pytest.mark.parametrize(
+    "response,expected_backend",
+    [
+        ("Y", "dummy_backend"),
+        ("y", "dummy_backend"),
+        ("N", None),
+        ("foo", None),
+    ],
+)
+def test_add_backend_to_flag_confirmation(db, monkeypatch, response, expected_backend):
+    monkeypatch.setattr("jobrunner.config.agent.BACKEND", "dummy_backend")
+    flag1 = Flag(id="foo", value="bar", backend="the_test_backend")
+    database.insert(flag1)
+    flag2 = Flag(id="foo1", value="bar1")
+    database.insert(flag2)
+
+    monkeypatch.setattr("builtins.input", lambda _: response)
+    add_backend_to_flags.main()
+    assert database.find_one(Flag, id=flag1.id).backend == "the_test_backend"
+    assert database.find_one(Flag, id=flag2.id).backend == expected_backend
+
+
+def test_add_backend_to_flag_nothing_to_do(db, monkeypatch, capsys):
+    monkeypatch.setattr("jobrunner.config.agent.BACKEND", "dummy_backend")
+    # flag with a backend already set
+    flag1 = Flag(id="foo", value="bar", backend="the_test_backend")
+    database.insert(flag1)
+
+    add_backend_to_flags.main()
+    assert database.find_one(Flag, id=flag1.id).backend == "the_test_backend"
+    captured = capsys.readouterr()
+    assert "nothing to do" in captured.out

--- a/tests/cli/test_flags.py
+++ b/tests/cli/test_flags.py
@@ -13,55 +13,60 @@ TEST_TIME = time.time()
 TEST_DATESTR = timestamp_to_isoformat(TEST_TIME)
 
 
+@pytest.fixture(autouse=True)
+def configure_backends(monkeypatch):
+    monkeypatch.setattr("jobrunner.config.common.BACKENDS", ["test_backend"])
+
+
 def test_get_no_args(capsys, tmp_work_dir):
-    flags.run(["get"])
+    flags.run(["--backend", "test_backend", "get"])
     stdout, stderr = capsys.readouterr()
     assert stdout == ""
     assert stderr == ""
 
-    queries.set_flag("foo", "bar", TEST_TIME)
-    flags.run(["get"])
+    queries.set_flag("foo", "bar", "test_backend", TEST_TIME)
+    flags.run(["--backend", "test_backend", "get"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
+    assert stdout == f"[test_backend] foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
 
 
 def test_args_get(capsys, tmp_work_dir):
-    flags.run(["get", "foo"])
+    flags.run(["--backend", "test_backend", "get", "foo"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == "foo=None (never set)\n"
+    assert stdout == "[test_backend] foo=None (never set)\n"
     assert stderr == ""
 
-    queries.set_flag("foo", "bar", TEST_TIME)
-    flags.run(["get", "foo"])
+    queries.set_flag("foo", "bar", "test_backend", TEST_TIME)
+    flags.run(["--backend", "test_backend", "get", "foo"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
+    assert stdout == f"[test_backend] foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
 
 
 def test_args_set(capsys, tmp_work_dir, freezer):
     freezer.move_to(TEST_DATESTR)
-    flags.run(["set", "foo=bar"])
+    flags.run(["--backend", "test_backend", "set", "foo=bar"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
+    assert stdout == f"[test_backend] foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
-    assert queries.get_flag("foo").value == "bar"
+    assert queries.get_flag("foo", "test_backend").value == "bar"
 
 
 def test_args_set_clear(capsys, tmp_work_dir, freezer):
     freezer.move_to(TEST_DATESTR)
-    queries.set_flag("foo", "bar")
-    flags.run(["set", "foo="])
+    queries.set_flag("foo", "bar", "test_backend")
+    flags.run(["--backend", "test_backend", "set", "foo="])
     stdout, stderr = capsys.readouterr()
-    assert stdout == f"foo=None ({TEST_DATESTR})\n"
+    assert stdout == f"[test_backend] foo=None ({TEST_DATESTR})\n"
     assert stderr == ""
-    assert queries.get_flag("foo").value is None
+    assert queries.get_flag("foo", "test_backend").value is None
 
 
 def test_args_set_error(capsys, tmp_work_dir, freezer):
     freezer.move_to(TEST_DATESTR)
     with pytest.raises(SystemExit):
-        flags.run(["set", "foo"])
+        flags.run(["--backend", "test_backend", "set", "foo"])
     stdout, stderr = capsys.readouterr()
     assert "invalid parse_cli_flag value" in stderr
     assert stdout == ""
@@ -70,11 +75,11 @@ def test_args_set_error(capsys, tmp_work_dir, freezer):
 def test_args_get_create(capsys, tmp_work_dir):
     database.get_connection().execute("DROP TABLE flags")
     with pytest.raises(SystemExit) as e:
-        flags.run(["get"])
+        flags.run(["--backend", "test_backend", "get"])
 
     assert "--create" in str(e.value)
 
-    flags.run(["get", "--create"])
+    flags.run(["--backend", "test_backend", "get", "--create"])
     stdout, stderr = capsys.readouterr()
     assert stdout == ""
     assert stderr == ""
@@ -84,12 +89,12 @@ def test_args_set_create(capsys, tmp_work_dir, freezer):
     freezer.move_to(TEST_DATESTR)
     database.get_connection().execute("DROP TABLE flags")
     with pytest.raises(SystemExit) as e:
-        flags.run(["set", "foo=bar"])
+        flags.run(["--backend", "test_backend", "set", "foo=bar"])
 
     assert "--create" in str(e.value)
 
-    flags.run(["set", "foo=bar", "--create"])
+    flags.run(["--backend", "test_backend", "set", "foo=bar", "--create"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
+    assert stdout == f"[test_backend] foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
-    assert queries.get_flag("foo").value == "bar"
+    assert queries.get_flag("foo", "test_backend").value == "bar"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,7 @@ def get_trace(tracer=None):
         return [s for s in spans if s.instrumentation_scope.name == tracer]
 
 
-@pytest.fixture
-def tmp_work_dir(request, monkeypatch, tmp_path):
+def set_tmp_workdir_config(monkeypatch, tmp_path):
     monkeypatch.setattr("jobrunner.config.common.WORKDIR", tmp_path)
     monkeypatch.setattr(
         "jobrunner.config.controller.DATABASE_FILE", tmp_path / "db.sqlite"
@@ -72,6 +71,11 @@ def tmp_work_dir(request, monkeypatch, tmp_path):
             monkeypatch.setattr(
                 f"jobrunner.config.{config_type}.{var}", tmp_path / var.lower()
             )
+
+
+@pytest.fixture
+def tmp_work_dir(request, monkeypatch, tmp_path):
+    set_tmp_workdir_config(monkeypatch, tmp_path)
 
     # ensure db initialise
     database.ensure_db()

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -420,11 +420,11 @@ def backend_db_config(monkeypatch):
 
 
 def test_handle_pending_db_maintenance_mode(db, backend_db_config):
-    set_flag("mode", "db-maintenance")
     job = job_factory(
         run_command="ehrql:v1 generate-dataset dataset.py --output data.csv",
         requires_db=True,
     )
+    set_flag("mode", "db-maintenance", job.backend)
 
     run_controller_loop_once()
     job = database.find_one(Job, id=job.id)
@@ -439,12 +439,12 @@ def test_handle_pending_db_maintenance_mode(db, backend_db_config):
 
 
 def test_handle_pending_cancelled_db_maintenance_mode(db, backend_db_config):
-    set_flag("mode", "db-maintenance")
     job = job_factory(
         run_command="ehrql:v1 generate-dataset dataset.py --output data.csv",
         requires_db=True,
         cancelled=True,
     )
+    set_flag("mode", "db-maintenance", job.backend)
 
     run_controller_loop_once()
     job = database.find_one(Job, id=job.id)
@@ -465,7 +465,7 @@ def test_handle_running_db_maintenance_mode(db, backend_db_config):
     job = database.find_one(Job, id=job.id)
     assert job.state == State.RUNNING
 
-    set_flag("mode", "db-maintenance")
+    set_flag("mode", "db-maintenance", job.backend)
     run_controller_loop_once()
     job = database.find_one(Job, id=job.id)
 
@@ -485,11 +485,11 @@ def test_handle_running_db_maintenance_mode(db, backend_db_config):
 
 
 def test_handle_pending_pause_mode(db, backend_db_config):
-    set_flag("paused", "True")
     job = job_factory(
         run_command="ehrql:v1 generate-dataset dataset.py --output data.csv",
         requires_db=True,
     )
+    set_flag("paused", "True", job.backend)
 
     run_controller_loop_once()
     job = database.find_one(Job, id=job.id)
@@ -510,7 +510,7 @@ def test_handle_running_pause_mode(db, backend_db_config):
 
     # Start it running, then pause, then update its status
     run_controller_loop_once()
-    set_flag("paused", "True")
+    set_flag("paused", "True", job.backend)
     run_controller_loop_once()
 
     job = database.find_one(Job, id=job.id)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -76,7 +76,7 @@ def test_integration(
         "backend": "test",
     }
     requests_mock.get(
-        "http://testserver/api/v2/job-requests/?backend=test",
+        "http://testserver/api/v2/job-requests/",
         json={
             "results": [job_request_1],
         },
@@ -172,7 +172,7 @@ def test_integration(
         "backend": "test",
     }
     requests_mock.get(
-        "http://testserver/api/v2/job-requests/?backend=test",
+        "http://testserver/api/v2/job-requests/",
         json={
             "results": [job_request_1, job_request_2],
         },

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,11 +16,68 @@ from jobrunner.executors import get_executor_api
 from jobrunner.lib.database import find_where
 from jobrunner.models import Task
 from jobrunner.schema import TaskType
-from tests.conftest import get_trace
+from tests.conftest import get_trace, set_tmp_workdir_config
 from tests.factories import ensure_docker_images_present
 
 
 log = logging.getLogger(__name__)
+
+
+def set_agent_config(monkeypatch, tmp_work_dir):
+    # set agent config
+    monkeypatch.setattr("jobrunner.config.agent.USING_DUMMY_DATA_BACKEND", True)
+    # Note that as we are running ehrql actions in this test, we need to set
+    # the backend to a value that ehrql will accept
+    monkeypatch.setattr("jobrunner.config.agent.BACKEND", "test")
+    # set all the tmp workdir config as we remove it for the controller phase
+    set_tmp_workdir_config(monkeypatch, tmp_work_dir)
+
+    # disable controller config
+    # (note some of these will be set in prod because they are based on shared config
+    # e.g. JOB_SERVER_TOKEN is based on BACKENDS so will always be populated for each
+    # backend, with the default value. We set it explicitly here to confirm that it
+    # doesn't trigger any errors if it is invalid for the agent i.e. it's not used)
+    monkeypatch.setattr("jobrunner.config.controller.JOB_SERVER_ENDPOINT", None)
+    monkeypatch.setattr("jobrunner.config.controller.JOB_SERVER_TOKEN", None)
+    monkeypatch.setattr("jobrunner.config.controller.ALLOWED_GITHUB_ORGS", None)
+    monkeypatch.setattr("jobrunner.config.controller.MAX_WORKERS", None)
+
+
+def set_controller_config(monkeypatch):
+    # set controller config
+    monkeypatch.setattr(
+        "jobrunner.config.controller.JOB_SERVER_ENDPOINT", "http://testserver/api/v2/"
+    )
+    monkeypatch.setattr(
+        "jobrunner.config.controller.JOB_SERVER_TOKEN", {"test": "token"}
+    )
+    # Disable repo URL checking so we can run using a local test repo
+    monkeypatch.setattr("jobrunner.config.controller.ALLOWED_GITHUB_ORGS", None)
+    # Ensure that we have enough workers to start the jobs we expect in the test
+    # (CI may have fewer actual available workers than this)
+    monkeypatch.setattr("jobrunner.config.controller.MAX_WORKERS", {"test": 4})
+
+    # disable agent config
+    # (note some of these will be set in prod because they are based on shared config
+    # e.g. HIGH_PRIVACY_STORAGE_BASE is based on WORKDIR which is a common config. We
+    # set it explicitly here to confirm that it doesn't trigger any errors if it is
+    # invalid for the controller i.e. it's not used.)
+    monkeypatch.setattr("jobrunner.config.agent.BACKEND", None)
+    monkeypatch.setattr("jobrunner.config.agent.USING_DUMMY_DATA_BACKEND", False)
+
+    config_vars = [
+        "TMP_DIR",
+        "HIGH_PRIVACY_STORAGE_BASE",
+        "MEDIUM_PRIVACY_STORAGE_BASE",
+        "HIGH_PRIVACY_WORKSPACES_DIR",
+        "MEDIUM_PRIVACY_WORKSPACES_DIR",
+        "HIGH_PRIVACY_ARCHIVE_DIR",
+        "HIGH_PRIVACY_VOLUME_DIR",
+        "JOB_LOG_DIR",
+    ]
+
+    for config_var in config_vars:
+        monkeypatch.setattr(f"jobrunner.config.agent.{config_var}", None)
 
 
 @pytest.mark.slow_test
@@ -33,21 +90,7 @@ def test_integration(
     test_repo,
 ):
     api = get_executor_api()
-
-    monkeypatch.setattr("jobrunner.config.agent.USING_DUMMY_DATA_BACKEND", True)
-    monkeypatch.setattr(
-        "jobrunner.config.controller.JOB_SERVER_ENDPOINT", "http://testserver/api/v2/"
-    )
-    # Disable repo URL checking so we can run using a local test repo
-    monkeypatch.setattr("jobrunner.config.controller.ALLOWED_GITHUB_ORGS", None)
-    # Ensure that we have enough workers to start the jobs we expect in the test
-    # (CI may have fewer actual available workers than this)
-    monkeypatch.setattr("jobrunner.config.controller.MAX_WORKERS", {"test": 4})
-
-    # Note that as we are running ehrql actions in this test, we need to set
-    # the backend to a value that ehrql will accept
-    monkeypatch.setattr("jobrunner.config.agent.BACKEND", "test")
-
+    monkeypatch.setattr("jobrunner.config.common.BACKENDS", ["test"])
     monkeypatch.setattr("jobrunner.config.common.JOB_LOOP_INTERVAL", 0)
 
     ensure_docker_images_present("ehrql:v1", "python")
@@ -83,6 +126,8 @@ def test_integration(
     )
     requests_mock.post("http://testserver/api/v2/jobs/", json={})
 
+    # START ON CONTROLLER; set up the expected controller config (and remove agent config)
+    set_controller_config(monkeypatch)
     # Run sync to grab the JobRequest from the mocked job-server
     jobrunner.sync.sync()
     # Check that expected number of pending jobs are created
@@ -123,6 +168,8 @@ def test_integration(
     jobs = get_posted_jobs(requests_mock)
     assert_generate_dataset_dependency_running(jobs)
 
+    # MOVE TO AGENT; set up the expected agent config (and remove controller config)
+    set_agent_config(monkeypatch, tmp_work_dir)
     # Execute one tick of the agent run loop to pick up the runjob task
     # After one tick, the task should have moved to the PREPARED stage
     jobrunner.agent.main.handle_tasks(api)
@@ -130,18 +177,24 @@ def test_integration(
     assert len(active_tasks) == 1
     assert active_tasks[0].agent_stage == "prepared"
 
+    # CONTROLLER
+    set_controller_config(monkeypatch)
     # sync again; no change to status of jobs
     jobrunner.sync.sync()
     # still one running job and all others waiting on dependencies
     jobs = get_posted_jobs(requests_mock)
     assert_generate_dataset_dependency_running(jobs)
 
+    # AGENT
+    set_agent_config(monkeypatch, tmp_work_dir)
     # After one tick of the agent loop, the task should have moved to EXECUTING status
     jobrunner.agent.main.handle_tasks(api)
     active_tasks = get_active_db_tasks()
     assert len(active_tasks) == 1
     assert active_tasks[0].agent_stage == "executing"
 
+    # CONTROLLER
+    set_controller_config(monkeypatch)
     # sync again; no change to status of jobs
     jobrunner.sync.sync()
     # still one running job and all others waiting on dependencies
@@ -211,9 +264,14 @@ def test_integration(
         "test_reusable_action_ehrql",
     ]:
         assert jobs[action]["status_message"].startswith("Waiting on dependencies")
+
+    # AGENT
+    set_agent_config(monkeypatch, tmp_work_dir)
     # Run the agent loop until there are no active tasks left; the generate_dataset jobs should be done
     jobrunner.agent.main.main(exit_callback=lambda active_tasks: len(active_tasks) == 0)
 
+    # CONTROLLER
+    set_controller_config(monkeypatch)
     # Run the controller again, this should:
     # - pick up the completed task and mark generate_dataset as succeeded
     # - add RUNJOB tasks for the 4 jobs that depend on generate_dataset and set the Job state to running
@@ -249,9 +307,14 @@ def test_integration(
     assert jobs["test_cancellation_ehrql"]["status"] == "failed"
     assert jobs["analyse_data_ehrql"]["status"] == "pending"
 
+    # AGENT
+    set_agent_config(monkeypatch, tmp_work_dir)
     # Run the agent loop until there are no active tasks left; the 4 running jobs
     # are now done
     jobrunner.agent.main.main(exit_callback=lambda active_tasks: len(active_tasks) == 0)
+
+    # CONTROLLER
+    set_controller_config(monkeypatch)
     # Run the controller again, this should find the 4 jobs it thinks are still running,
     # identify that their tasks are completed, and mark them as succeeded
     # And it will start a new task for the analyse_data action now that its
@@ -274,7 +337,11 @@ def test_integration(
 
     # Run the agent and controller again to complete the last job and mark it as
     # succeeded
+    # AGENT
+    set_agent_config(monkeypatch, tmp_work_dir)
     jobrunner.agent.main.main(exit_callback=lambda active_tasks: len(active_tasks) == 0)
+    # CONTROLLER
+    set_controller_config(monkeypatch)
     jobrunner.controller.main.handle_jobs()
 
     # no tasks left to do

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -7,24 +7,24 @@ from jobrunner.queries import get_flag_value, set_flag
 def test_get_flag_no_table_does_not_error(tmp_work_dir):
     conn = get_connection()
     conn.execute("DROP TABLE IF EXISTS flags")
-    assert get_flag_value("foo") is None
+    assert get_flag_value("foo", backend="foo") is None
 
 
 def test_get_flag_no_row(tmp_work_dir):
-    assert get_flag_value("foo") is None
+    assert get_flag_value("foo", backend="foo") is None
 
 
 def test_get_flag_no_row_with_default(tmp_work_dir):
-    assert get_flag_value("foo", "default") == "default"
+    assert get_flag_value("foo", backend="foo", default="default") == "default"
 
 
 def test_set_flag(tmp_work_dir):
-    assert get_flag_value("foo") is None
-    ts1 = set_flag("foo", "bar").timestamp
-    assert get_flag_value("foo") == "bar"
+    assert get_flag_value("foo", backend="foo") is None
+    ts1 = set_flag("foo", "bar", backend="foo").timestamp
+    assert get_flag_value("foo", backend="foo") == "bar"
     time.sleep(0.01)
-    ts2 = set_flag("foo", "bar").timestamp
+    ts2 = set_flag("foo", "bar", backend="foo").timestamp
     # check timestamp has not changed
     assert ts1 == ts2
-    set_flag("foo", None)
-    assert get_flag_value("foo") is None
+    set_flag("foo", None, backend="foo")
+    assert get_flag_value("foo", backend="foo") is None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -114,7 +114,7 @@ def test_job_to_remote_format_metrics(db):
 def test_session_request_no_flags(db, responses):
     responses.add(
         method="GET",
-        url=f"{config.JOB_SERVER_ENDPOINT}path/?backend=test",
+        url=f"{config.JOB_SERVER_ENDPOINT}path/",
         status=200,
         json="{}",
         match=[
@@ -128,7 +128,7 @@ def test_session_request_no_flags(db, responses):
     )
 
     # if this works, our expected request was generated
-    sync.api_get("path", params={"backend": "test"})
+    sync.api_get("path")
 
 
 def test_session_request_flags(db, responses):
@@ -143,7 +143,7 @@ def test_session_request_flags(db, responses):
 
     responses.add(
         method="GET",
-        url=f"{config.JOB_SERVER_ENDPOINT}path/?backend=test",
+        url=f"{config.JOB_SERVER_ENDPOINT}path/",
         status=200,
         json="{}",
         match=[
@@ -157,7 +157,7 @@ def test_session_request_flags(db, responses):
     )
 
     # if this works, our expected request was generated
-    sync.api_get("path", params={"backend": "test"})
+    sync.api_get("path")
 
 
 def test_sync_empty_response(db, monkeypatch, requests_mock):
@@ -166,7 +166,7 @@ def test_sync_empty_response(db, monkeypatch, requests_mock):
     )
     monkeypatch.setattr("jobrunner.config.agent.BACKEND", "test")
     requests_mock.get(
-        "http://testserver/api/v2/job-requests/?backend=test",
+        "http://testserver/api/v2/job-requests/",
         json={
             "results": [],
         },

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -133,8 +133,8 @@ def test_session_request_no_flags(db, responses):
 
 
 def test_session_request_flags(db, responses):
-    f1 = queries.set_flag("mode", "db-maintenance")
-    f2 = queries.set_flag("pause", "true")
+    f1 = queries.set_flag("mode", "db-maintenance", backend="test")
+    f2 = queries.set_flag("pause", "true", backend="test")
 
     flags_dict = {
         "mode": {"v": "db-maintenance", "ts": f1.timestamp_isoformat},


### PR DESCRIPTION
Fixes #905 - remove the unused backend parameter from jobserver api calls

Fixes #915 
Loop through the known BACKENDS in `sync()` and sync each one in turn.
This means that the controller will need to know about the JOB_SERVER_TOKEN for each backend, so there are new expected environment variables that populate this config (<BACKEND>_JOB_SERVER_TOKEN for each backend). While the controller is still running inside the backends, the `BACKENDS` variable can be set to a single backend (e.g. `test`) and will only require the token for that backend (i.e. `TEST_JOB_SERVER_TOKEN`)