### PR TITLE
Use GLOB rather than LIKE for partial ID matches

### DIFF
--- a/jobrunner/cli/kill_job.py
+++ b/jobrunner/cli/kill_job.py
@@ -57,7 +57,7 @@ def get_jobs(partial_job_ids):
     need_confirmation = False
     for partial_job_id in partial_job_ids:
         # look for partial matches
-        partial_matches = database.find_where(Job, id__like=f"%{partial_job_id}%")
+        partial_matches = database.find_where(Job, id__glob=f"*{partial_job_id}*")
         if len(partial_matches) == 0:
             raise RuntimeError(f"No jobs found matching '{partial_job_id}'")
         elif len(partial_matches) > 1:

--- a/jobrunner/cli/retry_job.py
+++ b/jobrunner/cli/retry_job.py
@@ -41,7 +41,7 @@ def main(partial_job_id):
 
 
 def get_job(partial_job_id):
-    matches = find_where(Job, id__like=f"%{partial_job_id}%")
+    matches = find_where(Job, id__glob=f"*{partial_job_id}*")
     if len(matches) == 0:
         raise RuntimeError("No matching jobs found")
     elif len(matches) > 1:

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -518,7 +518,7 @@ def update_job(job):
 
 def create_task_for_job(job):
     previous_tasks = find_where(
-        Task, id__like=f"{job.id}-%", type=TaskType.RUNJOB, backend=job.backend
+        Task, id__glob=f"{job.id}-*", type=TaskType.RUNJOB, backend=job.backend
     )
     assert all(t.active is False for t in previous_tasks)
     task_number = len(previous_tasks) + 1
@@ -536,7 +536,7 @@ def get_task_for_job(job):
     # with. But for now, it works to always get the most recently created task for a
     # given job.
     tasks = find_where(
-        Task, id__like=f"{job.id}-%", type=TaskType.RUNJOB, backend=job.backend
+        Task, id__glob=f"{job.id}-*", type=TaskType.RUNJOB, backend=job.backend
     )
     # Task IDs are constructed such that, for a given job, lexical order matches
     # creation order

--- a/jobrunner/lib/database.py
+++ b/jobrunner/lib/database.py
@@ -320,7 +320,7 @@ def query_params_to_sql(params):
     """
     Turn a dict of query parameters into a pair of (SQL string, SQL values). All
     parameters are implicitly ANDed together, and there's a bit of magic to handle
-    `field__in=list_of_values` queries, LIKE and GLOB queries and Enum classes.
+    `field__in=list_of_values` queries, GLOB queries and Enum classes.
     """
     if not params:
         return "1 = 1", []
@@ -334,10 +334,6 @@ def query_params_to_sql(params):
             placeholders = ", ".join(["?"] * len(value))
             parts.append(f"{escape(field)} IN ({placeholders})")
             values.extend(value)
-        elif key.endswith("__like"):
-            field = key[:-6]
-            parts.append(f"{escape(field)} LIKE ?")
-            values.append(value)
         elif key.endswith("__glob"):
             field = key[:-6]
             parts.append(f"{escape(field)} GLOB ?")

--- a/jobrunner/lib/database.py
+++ b/jobrunner/lib/database.py
@@ -318,9 +318,9 @@ def migrate_db(conn, migrations=None, verbose=False):
 
 def query_params_to_sql(params):
     """
-    Turn a dict of query parameters into a pair of (SQL string, SQL values).
-    All parameters are implicitly ANDed together, and there's a bit of magic to
-    handle `field__in=list_of_values` queries, LIKE queries and Enum classes.
+    Turn a dict of query parameters into a pair of (SQL string, SQL values). All
+    parameters are implicitly ANDed together, and there's a bit of magic to handle
+    `field__in=list_of_values` queries, LIKE and GLOB queries and Enum classes.
     """
     if not params:
         return "1 = 1", []
@@ -337,6 +337,10 @@ def query_params_to_sql(params):
         elif key.endswith("__like"):
             field = key[:-6]
             parts.append(f"{escape(field)} LIKE ?")
+            values.append(value)
+        elif key.endswith("__glob"):
+            field = key[:-6]
+            parts.append(f"{escape(field)} GLOB ?")
             values.append(value)
         elif value is None:
             parts.append(f"{escape(key)} is NULL")

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -26,7 +26,7 @@ def run_controller_loop_once():
 
 def set_job_task_results(job, job_results, error=None):
     runjob_task = database.find_one(
-        Task, type=TaskType.RUNJOB, id__like=f"{job.id}-%", active=True
+        Task, type=TaskType.RUNJOB, id__glob=f"{job.id}-*", active=True
     )
     results = job_results.to_dict()
     if error:

--- a/tests/lib/test_database.py
+++ b/tests/lib/test_database.py
@@ -313,7 +313,6 @@ def test_ensure_valid_db(tmp_path):
     [
         ({}, "1 = 1", []),
         ({"doubutsu": "neko"}, '"doubutsu" = ?', ["neko"]),
-        ({"doubutsu__like": "ne%"}, '"doubutsu" LIKE ?', ["ne%"]),
         ({"doubutsu__glob": "ne*"}, '"doubutsu" GLOB ?', ["ne*"]),
         (
             {"doubutsu__in": ["neko", "kitsune", "nezumi"]},

--- a/tests/lib/test_database.py
+++ b/tests/lib/test_database.py
@@ -314,6 +314,7 @@ def test_ensure_valid_db(tmp_path):
         ({}, "1 = 1", []),
         ({"doubutsu": "neko"}, '"doubutsu" = ?', ["neko"]),
         ({"doubutsu__like": "ne%"}, '"doubutsu" LIKE ?', ["ne%"]),
+        ({"doubutsu__glob": "ne*"}, '"doubutsu" GLOB ?', ["ne*"]),
         (
             {"doubutsu__in": ["neko", "kitsune", "nezumi"]},
             '"doubutsu" IN (?, ?, ?)',


### PR DESCRIPTION
SQLite's LIKE queries are case-insensitive [by default](https://www.sqlite.org/lang_expr.html#the_like_glob_regexp_match_and_extract_operators). This means that left-anchored prefix queries such as:
```
my_col LIKE 'some_prefix_%'
```
which you might expect to make use of an index on `my_col` will in fact always use a sequential scan.

SQLite also provides the GLOB operator which is very similar to LIKE but uses `*` and `?` instead of `%` and `_` and, more importantly, is case sensitive by default.

It is possible to change LIKE to be case sensitive using a pragma, but the docs very strongly [discourage this](https://www.sqlite.org/pragma.html#pragma_case_sensitive_like):
> This pragma is deprecated and exists for backwards compatibility only. New applications should avoid using this pragma. Older applications should discontinue use of this pragma at the earliest opportunity.

So switching to use GLOB seems like a better solution here.

Below is a SQLite session demonstrating the difference in query plans:
```
$ sqlite3

SQLite version 3.37.2 2022-01-06 13:25:41

sqlite> CREATE TABLE job (id TEXT PRIMARY KEY);

sqlite> EXPLAIN QUERY PLAN SELECT * FROM job WHERE id LIKE 'abc%';
QUERY PLAN
`--SCAN job

sqlite> EXPLAIN QUERY PLAN SELECT * FROM job WHERE id GLOB 'abc*';
QUERY PLAN
`--SEARCH job USING COVERING INDEX sqlite_autoindex_job_1 (id>? AND id<?)

sqlite> PRAGMA case_sensitive_like = true;
sqlite> EXPLAIN QUERY PLAN SELECT * FROM job WHERE id LIKE 'abc%';
QUERY PLAN
`--SEARCH job USING COVERING INDEX sqlite_autoindex_job_1 (id>? AND id<?)
```