### PR TITLE
Handle missing cancelled field

### DIFF
--- a/jobrunner/agent/tracing.py
+++ b/jobrunner/agent/tracing.py
@@ -96,7 +96,7 @@ def set_job_results_metadata(span, results, attributes=None):
                 action_created=results["action_created"],
                 base_revision=results["base_revision"],
                 base_created=results["base_created"],
-                cancelled=results["cancelled"],
+                cancelled=results.get("cancelled"),
             )
         )
         if "error" in results:


### PR DESCRIPTION
When switching from old metadata.json to new, it might not be there
