### PR TITLE
Per-backend flags

### DIFF
--- a/jobrunner/cli/add_backend_to_flags.py
+++ b/jobrunner/cli/add_backend_to_flags.py
@@ -1,0 +1,30 @@
+from jobrunner.config import agent as config
+from jobrunner.lib.database import find_where, update
+from jobrunner.models import Flag
+
+
+def main():
+    """
+    Command to add missing backend attribute to flags. We expect this to only
+    run once per backend, prior to moving the controller out of the backend
+    """
+    flags_missing_backend = find_where(Flag, backend=None)
+    if flags_missing_backend:
+        print(
+            "This command will add a backend attribute to all flags and should only be run from inside a backend. Please confirm you want to continue:"
+        )
+        confirm = input("\nY to continue, N to quit\n")
+        if confirm.lower() != "y":
+            return
+    else:
+        print("All flags have a backend assigned; nothing to do")
+
+    for flag in flags_missing_backend:
+        flag.backend = config.BACKEND
+        update(flag)
+
+    print(f"{len(flags_missing_backend)} flags updated")
+
+
+if __name__ == "__main__":
+    main()

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -110,8 +110,10 @@ def handle_single_job(job):
     # TODO: These flags are going to need to be set per-backend so we'll need to figure
     # out how to do that and then retrive the values for the backend associated with
     # each job
-    mode = get_flag_value("mode")
-    paused = str(get_flag_value("paused", "False")).lower() == "true"
+    mode = get_flag_value("mode", job.backend)
+    paused = (
+        str(get_flag_value("paused", job.backend, default="False")).lower() == "true"
+    )
     try:
         trace_handle_job(job, mode, paused)
     except Exception as exc:

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -372,13 +372,22 @@ class Flag:
         CREATE TABLE flags (
             id TEXT,
             value TEXT,
+            backend TEXT,
             timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (id)
         )
     """
 
+    migration(
+        6,
+        """
+        ALTER TABLE flags ADD COLUMN backend TEXT;
+        """,
+    )
+
     id: str  # noqa: A003
     value: str
+    backend: str = None
     timestamp: int = None
 
     @property
@@ -387,7 +396,7 @@ class Flag:
 
     def __str__(self):
         ts = self.timestamp_isoformat if self.timestamp else "never set"
-        return f"{self.id}={self.value} ({ts})"
+        return f"[{self.backend}] {self.id}={self.value} ({ts})"
 
 
 @databaseclass

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -98,17 +98,21 @@ DB_MAINTENANCE_MODE = "db-maintenance"
 
 def maintenance_mode():
     """Check if the db is currently in maintenance mode, and set flags as appropriate."""
+    # TODO currently we get and set flags using the agent's backend ,
+    # this will change when the db is only accessible to the controller
+    backend = agent_config.BACKEND
+
     # This did not seem big enough to warrant splitting into a separate module.
     log.info("checking if db undergoing maintenance...")
 
     # manually setting this flag bypasses the automaticaly check
-    manual_db_mode = get_flag_value("manual-db-maintenance")
+    manual_db_mode = get_flag_value("manual-db-maintenance", backend)
     if manual_db_mode:
         log.info(f"manually set db mode: {DB_MAINTENANCE_MODE}")
         mode = DB_MAINTENANCE_MODE
     else:
         # detect db mode from TPP.
-        current = get_flag_value("mode")
+        current = get_flag_value("mode", backend)
         ps = docker(
             [
                 "run",
@@ -139,8 +143,8 @@ def maintenance_mode():
                 log.info("DB maintenance mode had ended")
             mode = None
 
-    set_flag("mode", mode)
-    mode = get_flag_value("mode")
+    set_flag("mode", mode, backend)
+    mode = get_flag_value("mode", backend)
     log.info(f"db mode: {mode}")
     return mode
 

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -92,13 +92,13 @@ def api_request(method, path, *args, backend, headers=None, **kwargs):
 
     url = "{}/{}/".format(config.JOB_SERVER_ENDPOINT.rstrip("/"), path.strip("/"))
 
-    flags = {
-        f.id: {"v": f.value, "ts": f.timestamp_isoformat}
-        for f in queries.get_current_flags()
-    }
-
     if backend not in config.JOB_SERVER_TOKEN:
         raise SyncAPIError(f"No api token found for backend '{backend}'")
+
+    flags = {
+        f.id: {"v": f.value, "ts": f.timestamp_isoformat}
+        for f in queries.get_current_flags(backend=backend)
+    }
 
     headers["Authorization"] = config.JOB_SERVER_TOKEN[backend]
     headers["Flags"] = json.dumps(flags, separators=(",", ":"))

--- a/tests/cli/test_add_backend_to_flags.py
+++ b/tests/cli/test_add_backend_to_flags.py
@@ -1,0 +1,53 @@
+import pytest
+
+from jobrunner.cli import add_backend_to_flags
+from jobrunner.lib import database
+from jobrunner.models import Flag
+
+
+def test_add_backend_to_flag(db, monkeypatch):
+    monkeypatch.setattr("jobrunner.config.agent.BACKEND", "dummy_backend")
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    flag1 = Flag(id="foo", value="bar")
+    database.insert(flag1)
+    flag2 = Flag(id="foo1", value="bar1", backend="the_test_backend")
+    database.insert(flag2)
+
+    add_backend_to_flags.main()
+    assert database.find_one(Flag, id=flag1.id).backend == "dummy_backend"
+    assert database.find_one(Flag, id=flag2.id).backend == "the_test_backend"
+
+
+@pytest.mark.parametrize(
+    "response,expected_backend",
+    [
+        ("Y", "dummy_backend"),
+        ("y", "dummy_backend"),
+        ("N", None),
+        ("foo", None),
+    ],
+)
+def test_add_backend_to_flag_confirmation(db, monkeypatch, response, expected_backend):
+    monkeypatch.setattr("jobrunner.config.agent.BACKEND", "dummy_backend")
+    flag1 = Flag(id="foo", value="bar", backend="the_test_backend")
+    database.insert(flag1)
+    flag2 = Flag(id="foo1", value="bar1")
+    database.insert(flag2)
+
+    monkeypatch.setattr("builtins.input", lambda _: response)
+    add_backend_to_flags.main()
+    assert database.find_one(Flag, id=flag1.id).backend == "the_test_backend"
+    assert database.find_one(Flag, id=flag2.id).backend == expected_backend
+
+
+def test_add_backend_to_flag_nothing_to_do(db, monkeypatch, capsys):
+    monkeypatch.setattr("jobrunner.config.agent.BACKEND", "dummy_backend")
+    # flag with a backend already set
+    flag1 = Flag(id="foo", value="bar", backend="the_test_backend")
+    database.insert(flag1)
+
+    add_backend_to_flags.main()
+    assert database.find_one(Flag, id=flag1.id).backend == "the_test_backend"
+    captured = capsys.readouterr()
+    assert "nothing to do" in captured.out

--- a/tests/cli/test_flags.py
+++ b/tests/cli/test_flags.py
@@ -13,55 +13,60 @@ TEST_TIME = time.time()
 TEST_DATESTR = timestamp_to_isoformat(TEST_TIME)
 
 
+@pytest.fixture(autouse=True)
+def configure_backends(monkeypatch):
+    monkeypatch.setattr("jobrunner.config.common.BACKENDS", ["test_backend"])
+
+
 def test_get_no_args(capsys, tmp_work_dir):
-    flags.run(["get"])
+    flags.run(["--backend", "test_backend", "get"])
     stdout, stderr = capsys.readouterr()
     assert stdout == ""
     assert stderr == ""
 
-    queries.set_flag("foo", "bar", TEST_TIME)
-    flags.run(["get"])
+    queries.set_flag("foo", "bar", "test_backend", TEST_TIME)
+    flags.run(["--backend", "test_backend", "get"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
+    assert stdout == f"[test_backend] foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
 
 
 def test_args_get(capsys, tmp_work_dir):
-    flags.run(["get", "foo"])
+    flags.run(["--backend", "test_backend", "get", "foo"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == "foo=None (never set)\n"
+    assert stdout == "[test_backend] foo=None (never set)\n"
     assert stderr == ""
 
-    queries.set_flag("foo", "bar", TEST_TIME)
-    flags.run(["get", "foo"])
+    queries.set_flag("foo", "bar", "test_backend", TEST_TIME)
+    flags.run(["--backend", "test_backend", "get", "foo"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
+    assert stdout == f"[test_backend] foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
 
 
 def test_args_set(capsys, tmp_work_dir, freezer):
     freezer.move_to(TEST_DATESTR)
-    flags.run(["set", "foo=bar"])
+    flags.run(["--backend", "test_backend", "set", "foo=bar"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
+    assert stdout == f"[test_backend] foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
-    assert queries.get_flag("foo").value == "bar"
+    assert queries.get_flag("foo", "test_backend").value == "bar"
 
 
 def test_args_set_clear(capsys, tmp_work_dir, freezer):
     freezer.move_to(TEST_DATESTR)
-    queries.set_flag("foo", "bar")
-    flags.run(["set", "foo="])
+    queries.set_flag("foo", "bar", "test_backend")
+    flags.run(["--backend", "test_backend", "set", "foo="])
     stdout, stderr = capsys.readouterr()
-    assert stdout == f"foo=None ({TEST_DATESTR})\n"
+    assert stdout == f"[test_backend] foo=None ({TEST_DATESTR})\n"
     assert stderr == ""
-    assert queries.get_flag("foo").value is None
+    assert queries.get_flag("foo", "test_backend").value is None
 
 
 def test_args_set_error(capsys, tmp_work_dir, freezer):
     freezer.move_to(TEST_DATESTR)
     with pytest.raises(SystemExit):
-        flags.run(["set", "foo"])
+        flags.run(["--backend", "test_backend", "set", "foo"])
     stdout, stderr = capsys.readouterr()
     assert "invalid parse_cli_flag value" in stderr
     assert stdout == ""
@@ -70,11 +75,11 @@ def test_args_set_error(capsys, tmp_work_dir, freezer):
 def test_args_get_create(capsys, tmp_work_dir):
     database.get_connection().execute("DROP TABLE flags")
     with pytest.raises(SystemExit) as e:
-        flags.run(["get"])
+        flags.run(["--backend", "test_backend", "get"])
 
     assert "--create" in str(e.value)
 
-    flags.run(["get", "--create"])
+    flags.run(["--backend", "test_backend", "get", "--create"])
     stdout, stderr = capsys.readouterr()
     assert stdout == ""
     assert stderr == ""
@@ -84,12 +89,12 @@ def test_args_set_create(capsys, tmp_work_dir, freezer):
     freezer.move_to(TEST_DATESTR)
     database.get_connection().execute("DROP TABLE flags")
     with pytest.raises(SystemExit) as e:
-        flags.run(["set", "foo=bar"])
+        flags.run(["--backend", "test_backend", "set", "foo=bar"])
 
     assert "--create" in str(e.value)
 
-    flags.run(["set", "foo=bar", "--create"])
+    flags.run(["--backend", "test_backend", "set", "foo=bar", "--create"])
     stdout, stderr = capsys.readouterr()
-    assert stdout == f"foo=bar ({TEST_DATESTR})\n"
+    assert stdout == f"[test_backend] foo=bar ({TEST_DATESTR})\n"
     assert stderr == ""
-    assert queries.get_flag("foo").value == "bar"
+    assert queries.get_flag("foo", "test_backend").value == "bar"

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -420,11 +420,11 @@ def backend_db_config(monkeypatch):
 
 
 def test_handle_pending_db_maintenance_mode(db, backend_db_config):
-    set_flag("mode", "db-maintenance")
     job = job_factory(
         run_command="ehrql:v1 generate-dataset dataset.py --output data.csv",
         requires_db=True,
     )
+    set_flag("mode", "db-maintenance", job.backend)
 
     run_controller_loop_once()
     job = database.find_one(Job, id=job.id)
@@ -439,12 +439,12 @@ def test_handle_pending_db_maintenance_mode(db, backend_db_config):
 
 
 def test_handle_pending_cancelled_db_maintenance_mode(db, backend_db_config):
-    set_flag("mode", "db-maintenance")
     job = job_factory(
         run_command="ehrql:v1 generate-dataset dataset.py --output data.csv",
         requires_db=True,
         cancelled=True,
     )
+    set_flag("mode", "db-maintenance", job.backend)
 
     run_controller_loop_once()
     job = database.find_one(Job, id=job.id)
@@ -465,7 +465,7 @@ def test_handle_running_db_maintenance_mode(db, backend_db_config):
     job = database.find_one(Job, id=job.id)
     assert job.state == State.RUNNING
 
-    set_flag("mode", "db-maintenance")
+    set_flag("mode", "db-maintenance", job.backend)
     run_controller_loop_once()
     job = database.find_one(Job, id=job.id)
 
@@ -485,11 +485,11 @@ def test_handle_running_db_maintenance_mode(db, backend_db_config):
 
 
 def test_handle_pending_pause_mode(db, backend_db_config):
-    set_flag("paused", "True")
     job = job_factory(
         run_command="ehrql:v1 generate-dataset dataset.py --output data.csv",
         requires_db=True,
     )
+    set_flag("paused", "True", job.backend)
 
     run_controller_loop_once()
     job = database.find_one(Job, id=job.id)
@@ -510,7 +510,7 @@ def test_handle_running_pause_mode(db, backend_db_config):
 
     # Start it running, then pause, then update its status
     run_controller_loop_once()
-    set_flag("paused", "True")
+    set_flag("paused", "True", job.backend)
     run_controller_loop_once()
 
     job = database.find_one(Job, id=job.id)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -7,24 +7,24 @@ from jobrunner.queries import get_flag_value, set_flag
 def test_get_flag_no_table_does_not_error(tmp_work_dir):
     conn = get_connection()
     conn.execute("DROP TABLE IF EXISTS flags")
-    assert get_flag_value("foo") is None
+    assert get_flag_value("foo", backend="foo") is None
 
 
 def test_get_flag_no_row(tmp_work_dir):
-    assert get_flag_value("foo") is None
+    assert get_flag_value("foo", backend="foo") is None
 
 
 def test_get_flag_no_row_with_default(tmp_work_dir):
-    assert get_flag_value("foo", "default") == "default"
+    assert get_flag_value("foo", backend="foo", default="default") == "default"
 
 
 def test_set_flag(tmp_work_dir):
-    assert get_flag_value("foo") is None
-    ts1 = set_flag("foo", "bar").timestamp
-    assert get_flag_value("foo") == "bar"
+    assert get_flag_value("foo", backend="foo") is None
+    ts1 = set_flag("foo", "bar", backend="foo").timestamp
+    assert get_flag_value("foo", backend="foo") == "bar"
     time.sleep(0.01)
-    ts2 = set_flag("foo", "bar").timestamp
+    ts2 = set_flag("foo", "bar", backend="foo").timestamp
     # check timestamp has not changed
     assert ts1 == ts2
-    set_flag("foo", None)
-    assert get_flag_value("foo") is None
+    set_flag("foo", None, backend="foo")
+    assert get_flag_value("foo", backend="foo") is None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -133,8 +133,8 @@ def test_session_request_no_flags(db, responses):
 
 
 def test_session_request_flags(db, responses):
-    f1 = queries.set_flag("mode", "db-maintenance")
-    f2 = queries.set_flag("pause", "true")
+    f1 = queries.set_flag("mode", "db-maintenance", backend="test")
+    f2 = queries.set_flag("pause", "true", backend="test")
 
     flags_dict = {
         "mode": {"v": "db-maintenance", "ts": f1.timestamp_isoformat},


### PR DESCRIPTION
Fixes #922

Update the flags table and queries to always filter by a backend.

Punts on how the db-maintenance flag will be set for now and just uses the agent's BACKEND setting.

Also adds a cli command to add the current backend to any existing flags, intended to be run while the controller is still inside the backend and removed later (along with the add_backend_to_job command)