### PR TITLE
Filter jobs by backend in cli commands

### DIFF
--- a/jobrunner/cli/prepare_for_reboot.py
+++ b/jobrunner/cli/prepare_for_reboot.py
@@ -5,6 +5,7 @@ automatically re-run after a reboot.
 
 import argparse
 
+from jobrunner.config import agent as agent_config
 from jobrunner.controller.main import get_task_for_job, set_code
 from jobrunner.controller.task_api import mark_task_inactive
 from jobrunner.executors import volumes
@@ -14,11 +15,13 @@ from jobrunner.models import Job, State, StatusCode
 
 
 def main(pause=True):
+    # TODO: pass this in as a cli arg when run from the controller
+    backend = agent_config.BACKEND
     if pause:
         print(
             "== DANGER ZONE ==\n"
             "\n"
-            "This will kill all running jobs and reset them to the PENDING state, ready\n"
+            f"This will kill all running jobs on backend '{backend}' and reset them to the PENDING state, ready\n"
             "to be restarted following a reboot.\n"
             "\n"
             "It should only be run when the job-runner service has been stopped."
@@ -27,7 +30,7 @@ def main(pause=True):
         confirm = input("Are you sure you want to continue? (y/N)")
         assert confirm.strip().lower() == "y"
 
-    for job in find_where(Job, state=State.RUNNING):
+    for job in find_where(Job, state=State.RUNNING, backend=backend):
         print(f"resetting job {job.id} to PENDING")
         set_code(
             job,

--- a/tests/cli/test_retry_job.py
+++ b/tests/cli/test_retry_job.py
@@ -11,7 +11,7 @@ def test_get_jobs_no_jobs(db):
     # set a string to use as a partial id
     partial_job_id = "1234"
     with pytest.raises(RuntimeError):
-        retry_job.get_job(partial_job_id)
+        retry_job.get_job(partial_job_id, backend="test")
 
 
 def test_get_job_no_match(db):
@@ -21,7 +21,7 @@ def test_get_job_no_match(db):
     )
     partial_job_id = "1234"
     with pytest.raises(RuntimeError):
-        retry_job.get_job(partial_job_id)
+        retry_job.get_job(partial_job_id, backend="test")
 
 
 def test_get_job_multiple_matches(db, monkeypatch):
@@ -38,7 +38,7 @@ def test_get_job_multiple_matches(db, monkeypatch):
 
     monkeypatch.setattr("builtins.input", lambda _: "1")
 
-    output_job = retry_job.get_job(partial_job_id)
+    output_job = retry_job.get_job(partial_job_id, backend="test")
 
     assert output_job.id == job.id
 
@@ -62,7 +62,7 @@ def test_main(mock_api_post, mock_container_exists, db, monkeypatch):
     partial_job_id = "l6tk"
     monkeypatch.setattr("builtins.input", lambda _: "")
     retry_job.main(partial_job_id)
-    job = retry_job.get_job(partial_job_id)
+    job = retry_job.get_job(partial_job_id, backend="test")
     assert job.status_code == StatusCode.EXECUTING
     assert job.state == State.RUNNING
     mock_api_post.assert_called_once()


### PR DESCRIPTION
Where appropriate, filter jobs by backend in the CLI commands. This currently uses the agent's BACKEND as a default, in preparations for at least some of these commands being run by the controller outside of the backend itself. It does not yet do the work of splitting the commands between agent and controller and making them runnable by the controller only (via tasks) - see #929 .

Fixes #927