### PR TITLE
Consider all platform errors as transient for the time being

### DIFF
--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -90,9 +90,16 @@ def handle_single_task(task, api):
             raise
 
 
-def get_transient_error_type(exc):
+def get_transient_error_type(exc: Exception) -> str | None:
+    # To faciliate the migration to the split agent/controller world we don't currently
+    # consider _any_ errors as hard failures. But we will do so later and we want to
+    # ensure that these code paths are adequately tested so we provide a simple
+    # mechanism to trigger these in tests.
+    if "test_hard_failure" in str(exc):
+        return None
     if is_database_locked_error(exc):
         return "db_locked"
+    return exc.__class__.__name__
 
 
 def handle_cancel_job_task(task, api):

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -141,9 +141,16 @@ def handle_single_job(job):
         raise
 
 
-def get_transient_error_type(exc):
+def get_transient_error_type(exc: Exception) -> str | None:
+    # To faciliate the migration to the split agent/controller world we don't currently
+    # consider _any_ errors as hard failures. But we will do so later and we want to
+    # ensure that these code paths are adequately tested so we provide a simple
+    # mechanism to trigger these in tests.
+    if "test_hard_failure" in str(exc):
+        return None
     if is_database_locked_error(exc):
         return "db_locked"
+    return exc.__class__.__name__
 
 
 def trace_handle_job(job, mode, paused):


### PR DESCRIPTION
Because we are migrating between systems and the code is under heavy development we anticipate hitting errors much more often than we have historically. But we also anticipate fixing these rapidly and so it's much better from the user's perspective if these errors don't cause their jobs to fail.

We eventually expect to move back to treating at least some errors as permanent failures of the job and so, to avoid either removing or leaving untested these code paths, we add a mechanism for simulating a permanent failure in the test suite. 

Closes #930