### PR TITLE
Robust metadata

### DIFF
--- a/jobrunner/agent/tracing.py
+++ b/jobrunner/agent/tracing.py
@@ -96,7 +96,7 @@ def set_job_results_metadata(span, results, attributes=None):
                 action_created=results["action_created"],
                 base_revision=results["base_revision"],
                 base_created=results["base_created"],
-                cancelled=results.get("cancelled"),
+                cancelled=results["cancelled"],
             )
         )
         if "error" in results:

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -251,7 +251,7 @@ def handle_job(job, mode=None, paused=None):
         task = get_task_for_job(job)
         assert task is not None
         if task.agent_complete:
-            if job_error := task.agent_results.get("error"):
+            if job_error := task.agent_results["error"]:
                 # Handled elsewhere
                 raise PlatformError(job_error)
             else:

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -479,10 +479,13 @@ def finalize_job(job_definition, cancelled, error=None):
         base_created=labels.get("org.opencontainers.base.build-date", "unknown"),
     )
     job_metadata = get_job_metadata(
-        job_definition, outputs, container_metadata, results, cancelled=cancelled
+        job_definition,
+        outputs,
+        container_metadata,
+        results,
+        cancelled=cancelled,
+        error=error,
     )
-    if error:
-        job_metadata["error"] = error
 
     if cancelled or error:
         if container_metadata:
@@ -503,7 +506,7 @@ def finalize_job(job_definition, cancelled, error=None):
 
 
 def get_job_metadata(
-    job_definition, outputs, container_metadata, results, cancelled=False
+    job_definition, outputs, container_metadata, results, cancelled=False, error=False
 ):
     # job_metadata is a big dict capturing everything we know about the state
     # of the job
@@ -534,6 +537,7 @@ def get_job_metadata(
     job_metadata["base_created"] = results.base_created
     job_metadata["level4_excluded_files"] = {}
     job_metadata["cancelled"] = cancelled
+    job_metadata["error"] = error
     return job_metadata
 
 
@@ -551,6 +555,7 @@ METADATA_DEFAULTS = {
     "base_created": None,
     "level4_excluded_files": tuple(),
     "cancelled": False,
+    "error": False,
 }
 
 

--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -77,7 +77,10 @@ def get_log_dir(job_definition):
 def read_job_metadata(job_definition):
     path = job_metadata_path(job_definition)
     if path:
-        return json.loads(path.read_text())
+        metadata = json.loads(path.read_text())
+        # ensure all metadata has default values, as older json files might be
+        # missing some
+        return METADATA_DEFAULTS | metadata
 
     return {}
 
@@ -518,6 +521,7 @@ def get_job_metadata(
     job_metadata["outputs"] = outputs
     job_metadata["commit"] = job_definition.study.commit
     job_metadata["database_name"] = job_definition.database_name
+    # new metadata added later, ensure default value is in METADATA_DEFAULTS
     job_metadata["hint"] = results.unmatched_hint
     # all calculated results
     job_metadata["unmatched_patterns"] = results.unmatched_patterns
@@ -531,6 +535,23 @@ def get_job_metadata(
     job_metadata["level4_excluded_files"] = {}
     job_metadata["cancelled"] = cancelled
     return job_metadata
+
+
+# keys that may be missing in older metadata files, and their default empty values
+# Note: we use tuples to provide immutable empty iterables
+METADATA_DEFAULTS = {
+    "hint": None,
+    "unmatched_patterns": tuple(),
+    "unmatched_outputs": tuple(),
+    "timestamp_ns": None,
+    "action_version": None,
+    "action_revision": None,
+    "action_created": None,
+    "base_revision": None,
+    "base_created": None,
+    "level4_excluded_files": tuple(),
+    "cancelled": False,
+}
 
 
 def write_job_logs(

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -29,8 +29,7 @@ def set_job_task_results(job, job_results, error=None):
         Task, type=TaskType.RUNJOB, id__glob=f"{job.id}-*", active=True
     )
     results = job_results.to_dict()
-    if error:
-        results["error"] = error
+    results["error"] = error or False
 
     agent_task_api.update_controller(
         runjob_task,

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -118,12 +118,16 @@ def test_read_metadata_path(job_definition):
     )
     globbed_path.parent.mkdir(parents=True)
     globbed_path.write_text(json.dumps({"test": "globbed"}))
-    assert local.read_job_metadata(job_definition) == {"test": "globbed"}
+    assert local.read_job_metadata(job_definition) == local.METADATA_DEFAULTS | {
+        "test": "globbed"
+    }
 
     actual_path = local.get_log_dir(job_definition) / local.METADATA_FILE
     actual_path.parent.mkdir(parents=True)
     actual_path.write_text(json.dumps({"test": "actual"}))
-    assert local.read_job_metadata(job_definition) == {"test": "actual"}
+    assert local.read_job_metadata(job_definition) == local.METADATA_DEFAULTS | {
+        "test": "actual"
+    }
 
 
 @pytest.mark.needs_docker

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -10,7 +10,11 @@ from jobrunner.config import agent as config
 from jobrunner.executors import local, volumes
 from jobrunner.job_executor import ExecutorState, JobDefinition, Privacy, Study
 from jobrunner.lib import datestr_to_ns_timestamp, docker
-from tests.factories import ensure_docker_images_present, job_factory
+from tests.factories import (
+    ensure_docker_images_present,
+    job_factory,
+    job_results_factory,
+)
 
 
 @pytest.fixture
@@ -1206,3 +1210,17 @@ def test_finalize_job_with_error(job_definition):
     metadata = local.read_job_metadata(job_definition)
     assert metadata["error"] == {"test": "foo"}
     assert metadata["status_message"] == "Job errored"
+
+
+def test_get_job_metadata_has_expected_keys(job_definition):
+    job_results = job_results_factory()
+
+    metadata = local.get_job_metadata(
+        job_definition=job_definition,
+        outputs=["outputs"],
+        container_metadata={"State": {"ExitCode": 0, "OOMKilled": False}},
+        results=job_results,
+    )
+
+    for key in local.METADATA_DEFAULTS:
+        assert key in metadata


### PR DESCRIPTION
Ensure that job metadata always has all expected keys present.

They maybe Falsey or have default values in some cases, like when reading
metadata.json generated by older version of job-runner, but they will always be
present.

The goal is to always be able to assume presence and use `metadata["key"]`
rather than `metadata.get(key)`, thus simplifying usage.

I chose to just deal with the expected issues we have with the migration to the split, in that only some things will be missing from old version of written metadata.json, which were only written on a successful finalize. I anticipate we'll make further changes to this later, I think we can do a better job of typing and defining job metadata with some refactoring

Fixes #931
