### PR TITLE
Fix for assertion bug

### DIFF
--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -529,7 +529,7 @@ def create_task_for_job(job):
     previous_tasks = find_where(
         Task, id__glob=f"{job.id}-*", type=TaskType.RUNJOB, backend=job.backend
     )
-    assert all(t.active is False for t in previous_tasks)
+    assert all(not t.active for t in previous_tasks)
     task_number = len(previous_tasks) + 1
     return Task(
         # Zero-pad the task number so tasks sort lexically


### PR DESCRIPTION
Task.active when returned from find_where is an integer, 0 or 1. Using is False returns False when active == 0, so this was unexpectedly raising assertion errors