### PR TITLE
Update prepare for reboot CLI command

### DIFF
--- a/jobrunner/cli/controller/prepare_for_reboot.py
+++ b/jobrunner/cli/controller/prepare_for_reboot.py
@@ -8,11 +8,26 @@ import argparse
 from jobrunner.cli.controller.utils import add_backend_argument
 from jobrunner.controller.main import cancel_job, set_code
 from jobrunner.lib.database import find_where, transaction
-from jobrunner.models import Job, State, StatusCode
+from jobrunner.models import Job, State, StatusCode, Task, TaskType
+from jobrunner.queries import get_flag_value
 
 
-def main(backend, require_confirmation=True):
-    if require_confirmation:
+def main(backend, status=False, require_confirmation=True):
+    # We MUST be paused in order to run prepare-for-reboot, otherwise the
+    # controller will just pick tasks right back up again
+    paused = str(get_flag_value("paused", backend, default="False")).lower() == "true"
+    if not paused and not status:
+        print(
+            f"\nBackend '{backend}' must be paused in order to prepare for a reboot\n"
+            "\n"
+            "Pause with:\n"
+            f"\tjust jobrunner/pause {backend}\n"
+            "\n"
+            "Then try again.\n"
+        )
+        return
+
+    if require_confirmation and not status:
         print(
             "== DANGER ZONE ==\n"
             "\n"
@@ -25,7 +40,33 @@ def main(backend, require_confirmation=True):
         confirm = input("Are you sure you want to continue? (y/N)")
         assert confirm.strip().lower() == "y"
 
-    for job in find_where(Job, state=State.RUNNING, backend=backend):
+    running_jobs = find_where(Job, state=State.RUNNING, backend=backend)
+
+    if status:
+        # Just report on status, don't actually do anything
+        report = (
+            "\n== PREPARING FOR REBOOT ==\n"
+            f"1) backend '{backend}' is {'not ' if not paused else ''}paused\n"
+            f"2) {len(running_jobs)} job(s) are running\n"
+        )
+        cancel_tasks = find_where(
+            Task, type=TaskType.CANCELJOB, backend=backend, active=True
+        )
+        if cancel_tasks:
+            report += f"3) {len(cancel_tasks)} job(s) are being cancelled\n"
+
+        if not running_jobs and not cancel_tasks:
+            # No jobs are running, and there are no active canceljob tasks, we are ready to reboot
+            report += "\n== READY TO REBOOT ==\n"
+            if paused:
+                report += "Safe to reboot now\n"
+            else:
+                report += f"Pause backend '{backend}' before rebooting\n"
+
+        print(report)
+        return
+
+    for job in running_jobs:
         print(f"resetting job {job.slug} to PENDING")
         with transaction():
             set_code(
@@ -41,6 +82,13 @@ def main(backend, require_confirmation=True):
 def run():  # pragma: no cover
     parser = argparse.ArgumentParser(description=__doc__.partition("\n\n")[0])
     add_backend_argument(parser)
+    parser.add_argument(
+        "-s",
+        "--status",
+        action="store_true",
+        default=False,
+        help="Report on status of system in prepration for reboot",
+    )
     args = parser.parse_args()
     main(**vars(args))
 

--- a/jobrunner/cli/controller/prepare_for_reboot.py
+++ b/jobrunner/cli/controller/prepare_for_reboot.py
@@ -14,8 +14,8 @@ from jobrunner.lib.database import find_where
 from jobrunner.models import Job, State, StatusCode
 
 
-def main(backend, pause=True):
-    if pause:
+def main(backend, require_confirmation=True):
+    if require_confirmation:
         print(
             "== DANGER ZONE ==\n"
             "\n"

--- a/jobrunner/cli/controller/prepare_for_reboot.py
+++ b/jobrunner/cli/controller/prepare_for_reboot.py
@@ -12,6 +12,7 @@ from jobrunner.executors import volumes
 from jobrunner.executors.local import container_name, docker
 from jobrunner.lib.database import find_where
 from jobrunner.models import Job, State, StatusCode
+from jobrunner.queries import get_flag_value
 
 
 def main(backend, require_confirmation=True):

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -195,12 +195,17 @@ def handle_job(job, mode=None, paused=None):
     # Handle special modes
     if paused:
         if job.state == State.PENDING:
-            # Do not start the job, keep it pending
-            set_code(
-                job,
-                StatusCode.WAITING_PAUSED,
-                "Backend is currently paused for maintenance, job will start once this is completed",
-            )
+            if job.status_code == StatusCode.WAITING_ON_REBOOT:
+                # This job was already reset in prepration for reboot, just
+                # update that we've seen it
+                refresh_job_timestamps(job)
+            else:
+                # Do not start the job, keep it pending
+                set_code(
+                    job,
+                    StatusCode.WAITING_PAUSED,
+                    "Backend is currently paused for maintenance, job will start once this is completed",
+                )
             return
 
     if mode == "db-maintenance" and job.requires_db:

--- a/tests/cli/controller/test_prepare_for_reboot.py
+++ b/tests/cli/controller/test_prepare_for_reboot.py
@@ -1,11 +1,8 @@
-from unittest import mock
-
 import pytest
 
 from jobrunner.cli.controller import prepare_for_reboot
-from jobrunner.executors import local, volumes
-from jobrunner.lib import database, docker
-from jobrunner.models import Job, State, StatusCode, Task
+from jobrunner.lib import database
+from jobrunner.models import Job, State, StatusCode, Task, TaskType
 from jobrunner.queries import set_flag
 from tests.conftest import get_trace
 from tests.factories import job_factory, runjob_db_task_factory
@@ -15,8 +12,7 @@ def pause_backend(paused=True):
     set_flag("paused", str(paused), backend="test")
 
 
-@pytest.mark.needs_docker
-def test_prepare_for_reboot(db, monkeypatch):
+def test_prepare_for_reboot(db):
     pause_backend()
     t1 = runjob_db_task_factory(
         state=State.RUNNING, status_code=StatusCode.EXECUTING, backend="test"
@@ -38,12 +34,6 @@ def test_prepare_for_reboot(db, monkeypatch):
 
     assert t1.active
     assert not t2.active
-
-    mocker = mock.MagicMock(spec=docker)
-    mockumes = mock.MagicMock(spec=volumes)
-
-    monkeypatch.setattr(prepare_for_reboot, "docker", mocker)
-    monkeypatch.setattr(prepare_for_reboot, "volumes", mockumes)
 
     prepare_for_reboot.main("test", require_confirmation=False)
 
@@ -70,33 +60,22 @@ def test_prepare_for_reboot(db, monkeypatch):
     assert job1.status_code == StatusCode.WAITING_ON_REBOOT
     assert "restarted" in job3.status_message
 
-    mocker.kill.call_args_list == [
-        local.container_name(job1),
-        local.container_name(job3),
-    ]
-    mocker.delete_container.call_args_list == [
-        local.container_name(job1),
-        local.container_name(job3),
-    ]
-    mocker.delete_volume.call_args_list == [job1, job3]
+    # Only job1 was running with an active runjob task
+    cancel_tasks = database.find_where(Task, type=TaskType.CANCELJOB)
+    assert len(cancel_tasks) == 1
+    assert cancel_tasks[0].id.startswith(job1.id)
 
     spans = get_trace("jobs")
     assert spans[-1].name == "EXECUTING"
 
 
-@pytest.mark.needs_docker
 @pytest.mark.parametrize("input_response", ["y", "n"])
 def test_prepare_for_reboot_require_confirmation(input_response, db, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: input_response)
     pause_backend()
+
     t1 = runjob_db_task_factory(state=State.RUNNING, status_code=StatusCode.EXECUTING)
     j1 = database.find_one(Job, id=t1.id.split("-")[0])
-
-    mocker = mock.MagicMock(spec=docker)
-    mockumes = mock.MagicMock(spec=volumes)
-
-    monkeypatch.setattr(prepare_for_reboot, "docker", mocker)
-    monkeypatch.setattr(prepare_for_reboot, "volumes", mockumes)
-    monkeypatch.setattr("builtins.input", lambda _: input_response)
 
     if input_response != "y":
         with pytest.raises(AssertionError):
@@ -106,29 +85,28 @@ def test_prepare_for_reboot_require_confirmation(input_response, db, monkeypatch
 
     job = database.find_one(Job, id=j1.id)
     task = database.find_one(Task, id=t1.id)
+    cancel_tasks = database.find_where(Task, type=TaskType.CANCELJOB)
+
     if input_response == "y":
         assert job.state == State.PENDING
         assert job.status_code == StatusCode.WAITING_ON_REBOOT
         assert not task.active
         assert task.finished_at is not None
+        assert len(cancel_tasks) == 1
+        assert cancel_tasks[0].id.startswith(j1.id)
     else:
         assert job.state == State.RUNNING
         assert job.status_code == StatusCode.EXECUTING
         assert task.active
         assert task.finished_at is None
+        assert len(cancel_tasks) == 0
 
 
-@pytest.mark.needs_docker
-def test_prepare_for_reboot_backend_not_paused(db, monkeypatch):
+def test_prepare_for_reboot_backend_not_paused(db):
     t1 = runjob_db_task_factory(
         state=State.RUNNING, status_code=StatusCode.EXECUTING, backend="test"
     )
     j1 = database.find_one(Job, id=t1.id.split("-")[0])
-
-    mocker = mock.MagicMock(spec=docker)
-    mockumes = mock.MagicMock(spec=volumes)
-    monkeypatch.setattr(prepare_for_reboot, "docker", mocker)
-    monkeypatch.setattr(prepare_for_reboot, "volumes", mockumes)
 
     # Run prepare_for_reboot without pausing the backend; nothing is changed
     prepare_for_reboot.main("test", require_confirmation=False)
@@ -136,6 +114,7 @@ def test_prepare_for_reboot_backend_not_paused(db, monkeypatch):
     task = database.find_one(Task, id=t1.id)
     assert job.state == State.RUNNING
     assert task.active
+    assert not database.exists_where(Task, type=TaskType.CANCELJOB)
 
     # Pause backend and try again
     pause_backend()
@@ -146,3 +125,4 @@ def test_prepare_for_reboot_backend_not_paused(db, monkeypatch):
     assert job.status_code == StatusCode.WAITING_ON_REBOOT
     assert not task.active
     assert task.finished_at is not None
+    assert database.exists_where(Task, type=TaskType.CANCELJOB)

--- a/tests/cli/controller/test_prepare_for_reboot.py
+++ b/tests/cli/controller/test_prepare_for_reboot.py
@@ -39,7 +39,7 @@ def test_prepare_for_reboot(db, monkeypatch):
     monkeypatch.setattr(prepare_for_reboot, "docker", mocker)
     monkeypatch.setattr(prepare_for_reboot, "volumes", mockumes)
 
-    prepare_for_reboot.main("test", pause=False)
+    prepare_for_reboot.main("test", require_confirmation=False)
 
     job1 = database.find_one(Job, id=j1.id)
     assert job1.state == State.PENDING
@@ -80,7 +80,7 @@ def test_prepare_for_reboot(db, monkeypatch):
 
 @pytest.mark.needs_docker
 @pytest.mark.parametrize("input_response", ["y", "n"])
-def test_prepare_for_reboot_pause(input_response, db, monkeypatch):
+def test_prepare_for_reboot_require_confirmation(input_response, db, monkeypatch):
     t1 = runjob_db_task_factory(state=State.RUNNING, status_code=StatusCode.EXECUTING)
     j1 = database.find_one(Job, id=t1.id.split("-")[0])
 
@@ -93,9 +93,9 @@ def test_prepare_for_reboot_pause(input_response, db, monkeypatch):
 
     if input_response != "y":
         with pytest.raises(AssertionError):
-            prepare_for_reboot.main("test", pause=True)
+            prepare_for_reboot.main("test", require_confirmation=True)
     else:
-        prepare_for_reboot.main("test", pause=True)
+        prepare_for_reboot.main("test", require_confirmation=True)
 
     job = database.find_one(Job, id=j1.id)
     task = database.find_one(Task, id=t1.id)


### PR DESCRIPTION
Fixes #957 

I decided not to add a new KILLJOB task, as CANCELJOB does everything that's needed, and the job status has the information that the job is waiting on reboot (and cancel_job is used for killing jobs in db maintence already)

Prepare for reboot now creates CANCELJOB tasks. It checks that the backend is paused before doing anything, as we need the agent to be running in order to pick up the cancel tasks, but we don't want pending ones to be started.

Also adds a --status option so we can check if we're safe to do the actual reboot (i.e. no running jobs or active cancel tasks)