### PR TITLE
Always return DBSTATUS tasks first from controller

### DIFF
--- a/jobrunner/agent/task_api.py
+++ b/jobrunner/agent/task_api.py
@@ -1,6 +1,4 @@
-from jobrunner.controller.task_api import handle_task_update
-from jobrunner.lib import database  # cheating!
-from jobrunner.models import Task as ControllerTask  # cheating!
+from jobrunner.controller import task_api as controller_task_api  # cheating!
 from jobrunner.schema import AgentTask
 
 
@@ -8,8 +6,7 @@ def get_active_tasks(backend: str) -> list[AgentTask]:
     """Get a list of active tasks for this backend from the controller"""
     # cheating for now - should be HTTP API call
     return [
-        AgentTask.from_task(t)
-        for t in database.find_where(ControllerTask, active=True, backend=backend)
+        AgentTask.from_task(t) for t in controller_task_api.get_active_tasks(backend)
     ]
 
 
@@ -27,4 +24,6 @@ def update_controller(
     """
     # Cheating! This will eventaully be an HTTP API call to the controller but we just
     # do a direct function call for now
-    handle_task_update(task_id=task.id, stage=stage, results=results, complete=complete)
+    controller_task_api.handle_task_update(
+        task_id=task.id, stage=stage, results=results, complete=complete
+    )

--- a/jobrunner/controller/task_api.py
+++ b/jobrunner/controller/task_api.py
@@ -31,6 +31,11 @@ def get_task(task_id):
     return database.find_one(Task, id=task_id)
 
 
+def get_active_tasks(backend: str) -> list[Task]:
+    """Return list of active tasks to be sent to the agent for the supplied backend"""
+    return database.find_where(Task, active=True, backend=backend)
+
+
 def handle_task_update(*, task_id, stage, results, complete):
     # This is the function we expect to eventually be invoked via an HTTP API call.
     # This currently just updates the task table, and lets the main controller loop

--- a/jobrunner/controller/task_api.py
+++ b/jobrunner/controller/task_api.py
@@ -33,7 +33,15 @@ def get_task(task_id):
 
 def get_active_tasks(backend: str) -> list[Task]:
     """Return list of active tasks to be sent to the agent for the supplied backend"""
-    return database.find_where(Task, active=True, backend=backend)
+    active_tasks = database.find_where(Task, active=True, backend=backend)
+    # This is a small hack to ensure that the controller always receives the results of
+    # DBSTATUS tasks before the results of RUNJOB tasks so that if the jobs have failed
+    # because we've just entered database maintenance then the controller will handle
+    # the failures correctly. This not the proper fix, but it's cheap to do, has little
+    # downside and may help. See:
+    # https://github.com/opensafely-core/job-runner/issues/893
+    active_tasks.sort(key=lambda task: 0 if task.type == TaskType.DBSTATUS else 1)
+    return active_tasks
 
 
 def handle_task_update(*, task_id, stage, results, complete):


### PR DESCRIPTION
 This is a small hack to ensure that the controller always receives the results of DBSTATUS tasks before the results of RUNJOB tasks so that if the jobs have failed because we've just entered database maintenance then the controller will handle the failures correctly.

This not the proper fix, but it's cheap to do, has little downside and may help.

Closes #893