### PR TITLE
Test agent/controller deployment as two separate containers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Run tests in docker-image
         run: just docker/test
 
+      - name: Run basic multi-container integration test
+        run: just docker/functional-test
+
   required-checks:
     if: always()
 

--- a/controller_app/settings.py
+++ b/controller_app/settings.py
@@ -104,12 +104,14 @@ WSGI_APPLICATION = "controller_app.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
-# TODO: Currently the django app is using a separate database (for
-# the default included apps that need it - auth/sessions etc).
+# TODO: The Django app doesn't actually use the database at all at the moment but if we
+# don't define one it gets upset and if we point it to a real path we get permissions
+# issues when running inside a container. Using a in-memory database is a quick solution
+# for now.
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "django_db.sqlite3",
+        "NAME": ":memory:",
     }
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,12 +85,14 @@ ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH"
 RUN mkdir /app
 WORKDIR /app
 
-# We set command rather than entrypoint, to make it easier to run different
-# things from the cli
-CMD ["/opt/venv/bin/python", "-m", "jobrunner.service"]
-
 # This may not be necessary, but it probably doesn't hurt
 ENV PYTHONPATH=/app
+
+# We use --init to run the docker container, which mounts tini binary, and uses
+# it as PID 1, but only in single-process mode. Setting TINI_KILL_PROCESS_GROUP
+# means it will forward signals to any background processes as well as the main
+# process.
+ENV TINI_KILL_PROCESS_GROUP=1
 
 ##################################################
 #

--- a/docker/dependencies.txt
+++ b/docker/dependencies.txt
@@ -2,3 +2,4 @@
 docker.io
 sqlite3
 git
+run-one

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -92,3 +92,22 @@ services:
     # override command
     command: >
       bash -c pytest
+
+  # functional test services - note these intentionally extend prod rather than dev
+  test-agent:
+    extends:
+        service: prod
+    command: /app/docker/scripts/agent.sh
+    environment:
+      WORKDIR: "/tmp/workdir"
+      CONTROLLER_TASK_API_ENDPOINT: "http://test-controller:8000/"
+
+  test-controller:
+    extends:
+        service: prod
+    command: /app/docker/scripts/controller.sh
+    environment:
+      WORKDIR: "/tmp/workdir"
+      DJANGO_CONTROLLER_SECRET_KEY: 12345789abcdefghi
+      DJANGO_CONTROLLER_ALLOWED_HOSTS: "*"
+      DJANGO_DEBUG: "False"

--- a/docker/justfile
+++ b/docker/justfile
@@ -53,16 +53,19 @@ test *args: build
 
 functional-test:
     #!/bin/bash
-    container=job-runner-prod-1
-    trap 'docker compose kill prod' EXIT
-    docker compose up -d prod
-    docker compose exec prod python3 -m jobrunner.cli.add_job https://github.com/opensafely/research-template generate_dataset
+    container=job-runner-test-controller-1
+    trap 'docker compose kill test-controller test-agent' EXIT
+    docker compose up -d test-controller
+    docker compose exec test-controller python3 -m jobrunner.cli.controller.migrate
+    docker compose exec test-controller python3 -m jobrunner.cli.controller.add_job https://github.com/opensafely/research-template generate_dataset --backend test
+    docker compose up -d test-agent
     attempts=""
-    # use docker logs reather than docker compose logs, as those will include previous run's logs
+    # use docker logs rather than docker compose logs, as those will include previous run's logs
     while ! docker logs -n 10 $container |& grep -q "Completed successfully";
     do
         if test "$attempts" = ".........."; then
-            docker compose logs prod
+            docker compose logs test-agent
+            docker compose logs test-controller
             exit 1;
         fi
         attempts="${attempts}."

--- a/docker/scripts/agent.sh
+++ b/docker/scripts/agent.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /opt/venv/bin/python -m jobrunner.agent.main

--- a/docker/scripts/controller.sh
+++ b/docker/scripts/controller.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Make sure the log output lines don't clobber each other
+export PYTHONUNBUFFERED=True
+
+# Run the control loop in the background (restarting if necessary)
+# TODO: Replace with a Django management command for consistency
+run-one-constantly /opt/venv/bin/python -m jobrunner.controller.main &
+
+exec /opt/venv/bin/python manage.py runserver 0.0.0.0:8000

--- a/jobrunner/agent/task_api.py
+++ b/jobrunner/agent/task_api.py
@@ -37,7 +37,7 @@ def request_json(method, path, data=None):
 
 def get_active_tasks() -> list[AgentTask]:
     """Get a list of active tasks for this backend from the controller"""
-    agent_tasks = get_json("tasks")["tasks"]
+    agent_tasks = get_json("tasks/")["tasks"]
     return [AgentTask.from_dict(t) for t in agent_tasks]
 
 

--- a/tests/agent/test_task_api.py
+++ b/tests/agent/test_task_api.py
@@ -35,14 +35,14 @@ def test_get_active_tasks(db, monkeypatch, responses):
 
     responses.add(
         method="GET",
-        url=f"{config.TASK_API_ENDPOINT}dummy/tasks",
+        url=f"{config.TASK_API_ENDPOINT}dummy/tasks/",
         status=200,
         json={"tasks": [AgentTask.from_task(task1).asdict()]},
         match=[matchers.header_matcher({"Authorization": config.JOB_SERVER_TOKEN})],
     )
     responses.add(
         method="GET",
-        url=f"{config.TASK_API_ENDPOINT}another/tasks",
+        url=f"{config.TASK_API_ENDPOINT}another/tasks/",
         status=200,
         json={"tasks": [AgentTask.from_task(task3).asdict()]},
         match=[matchers.header_matcher({"Authorization": config.JOB_SERVER_TOKEN})],
@@ -66,7 +66,7 @@ def test_get_active_tasks_api_error(db, monkeypatch, responses):
 
     responses.add(
         method="GET",
-        url=f"{config.TASK_API_ENDPOINT}dummy/tasks",
+        url=f"{config.TASK_API_ENDPOINT}dummy/tasks/",
         status=500,
         match=[matchers.header_matcher({"Authorization": config.JOB_SERVER_TOKEN})],
     )


### PR DESCRIPTION
This updates the Dockerfile to build a single image which we expect to be invoked in two separate ways: as agent and as controller. For each role we add an appropriate entrypoint script.

The controller script actually runs two processes: a Django web process in the foreground and the controller loop in the background. The background process is managed by the `run-one-constantly` tool following the same approach as used in Airlock.

The functional test is updated to use two separate containers communicating over HTTP so as to mimic production. And this test is now included in the CI checks.

Partially addresses #967