### PR TITLE
Add a kill_task agent cli command

### DIFF
--- a/jobrunner/cli/agent/kill_task.py
+++ b/jobrunner/cli/agent/kill_task.py
@@ -1,0 +1,124 @@
+"""
+Ops utility for killing run-job tasks
+
+Kills and cleans up running containers matching provided
+job ids. Will accept and attempt to match partial job ids.
+
+Killing the task will cause the agent to retry.
+"""
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+
+from jobrunner.executors.volumes import delete_volume
+from jobrunner.lib import docker
+
+
+@dataclass(frozen=True)
+class JobDefinitionId:
+    id: str
+
+
+def main(partial_job_ids):
+    # Get all running job containers that match the partial job ids provided
+    job_containers = get_job_containers(partial_job_ids)
+    for job_container in job_containers:
+        job_id = job_id_from_container_name(job_container)
+        # check it exists, it might have finished since we got the list of running containers
+        if not docker.container_exists(job_container):
+            print(
+                f"Cannot kill task for job {job_id}, associated container does not exist. "
+                "The job may have completed."
+            )
+            continue
+
+        docker.kill(job_container)
+        docker.delete_container(job_container)
+        delete_volume(JobDefinitionId(id=job_id))
+        print(f"Task for job {job_id} killed.")
+
+
+def get_job_containers(partial_job_ids):
+    # We don't have access to the jobs database in this (agent) command, so we need
+    # to use docker to find all jobs with a container that exists
+    # get all job container names
+
+    job_container_names = get_container_names()
+    # Use a dict to track the containers
+    # This keeps the order we match them, but excludes duplicates in case
+    # multiple partial ids match the same containers
+    job_containers = {}
+    need_confirmation = False
+    for partial_job_id in partial_job_ids:
+        # look for partial matches
+        partial_matches = list(matching_containers(partial_job_id, job_container_names))
+
+        if len(partial_matches) == 0:
+            print(f"No running tasks found matching '{partial_job_id}'")
+        elif len(partial_matches) > 1:
+            print(f"Multiple running tasks found matching '{partial_job_id}':")
+            for i, job_container in enumerate(partial_matches, start=1):
+                print(f"  {i}: {job_id_from_container_name(job_container)}")
+            print()
+            index = int(input("Enter number: "))
+            assert 0 < index <= len(partial_matches)
+            job_containers[partial_matches[index - 1]] = None
+        else:
+            # We only need confirmation if the supplied job ID doesn't exactly
+            # match the found job
+            job_container = partial_matches[0]
+            if job_id_from_container_name(job_container) != partial_job_id:
+                need_confirmation = True
+
+            job_containers[job_container] = None
+
+    job_containers = list(job_containers)
+    if need_confirmation:
+        print("About to kill tasks for jobs:")
+        for job_container in job_containers:
+            print(f"  {job_id_from_container_name(job_container)}")
+        confirm = input("\nEnter to continue, Ctrl-C to quit ")
+        assert confirm == ""
+    return job_containers
+
+
+def job_id_from_container_name(job_container_name):
+    return job_container_name.lstrip("os-job-")
+
+
+def get_container_names():
+    response = docker.docker(
+        [
+            "container",
+            "ls",
+            "--filter",
+            "name=os-job-",
+            "--format",
+            "'{{ json .Names }}'",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return re.findall(r"\"(os-job-.+)\"", response.stdout)
+
+
+def matching_containers(partial_job_id, container_names):
+    for job_container_name in container_names:
+        if partial_job_id in job_container_name:
+            yield job_container_name
+
+
+def run(argv):
+    parser = argparse.ArgumentParser(description=__doc__.partition("\n\n")[0])
+    parser.add_argument(
+        "partial_job_ids", nargs="+", help="ID of the jobs (or substring of the ID)"
+    )
+    args = parser.parse_args(argv)
+    main(**vars(args))
+
+
+if __name__ == "__main__":
+    run(sys.argv[1:])

--- a/tests/cli/agent/test_kill_task.py
+++ b/tests/cli/agent/test_kill_task.py
@@ -1,0 +1,110 @@
+from unittest import mock
+
+import pytest
+
+from jobrunner.cli.agent import kill_task
+
+
+@pytest.fixture(autouse=True)
+def mock_delete_volume():
+    with mock.patch("jobrunner.cli.agent.kill_task.delete_volume", autospec=True):
+        yield
+
+
+@pytest.fixture
+def mock_container_ls():
+    with mock.patch(
+        "jobrunner.cli.agent.kill_task.docker", autospec=True
+    ) as mock_docker:
+        mock_docker.docker.return_value = mock.Mock(
+            stdout="'\"os-job-1234\"'\n'\"os-job-1245\"'\n"
+        )
+        yield
+
+
+def test_get_container_names(mock_container_ls):
+    assert kill_task.get_container_names() == ["os-job-1234", "os-job-1245"]
+
+
+@mock.patch("jobrunner.cli.agent.kill_task.docker", autospec=True)
+def test_get_container_names_no_containers(mock_docker):
+    mock_docker.docker.return_value = mock.Mock(stdout="")
+    assert kill_task.get_container_names() == []
+
+
+def test_get_job_containers_no_matches(mock_container_ls):
+    partial_job_ids = ["1256"]
+    kill_task.get_job_containers(partial_job_ids) == []
+
+
+def test_get_job_containers_with_full_match(mock_container_ls):
+    partial_job_ids = ["1234"]
+    kill_task.get_job_containers(partial_job_ids) == ["os-job-1234"]
+
+
+def test_get_job_containers_with_partial_match(mock_container_ls, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    partial_job_ids = ["123"]
+    kill_task.get_job_containers(partial_job_ids) == ["os-job-1234"]
+
+
+def test_get_job_multiple_matches(mock_container_ls, monkeypatch):
+    partial_job_ids = ["12"]
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+    kill_task.get_job_containers(partial_job_ids) == ["os-job-1234"]
+
+
+def test_main_no_running_container(monkeypatch, capsys):
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    with mock.patch(
+        "jobrunner.cli.agent.kill_task.docker", autospec=True
+    ) as mock_docker:
+        mock_docker.docker.return_value = mock.Mock(stdout="'\"os-job-1234\"'\n")
+        mock_docker.container_exists.return_value = False
+        kill_task.main(["1234"])
+
+    assert "Cannot kill task for job 1234" in capsys.readouterr().out
+    mock_docker.kill.assert_not_called
+
+
+def test_main_kill_one_task(monkeypatch, capsys):
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    with mock.patch(
+        "jobrunner.cli.agent.kill_task.docker", autospec=True
+    ) as mock_docker:
+        mock_docker.docker.return_value = mock.Mock(stdout="'\"os-job-1234\"'\n")
+        mock_docker.container_exists.return_value = True
+        kill_task.main(["1234"])
+    assert "Task for job 1234 killed" in capsys.readouterr().out
+    mock_docker.kill.assert_called_with("os-job-1234")
+    mock_docker.delete_container.assert_called_with("os-job-1234")
+
+
+def test_main_kill_multiple_tasks(monkeypatch, capsys):
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    with mock.patch(
+        "jobrunner.cli.agent.kill_task.docker", autospec=True
+    ) as mock_docker:
+        mock_docker.docker.return_value = mock.Mock(
+            stdout="'\"os-job-1234\"'\n'\"os-job-1245\"'\n"
+        )
+        mock_docker.container_exists.return_value = True
+        kill_task.main(["1234", "1245", "unk"])
+    out = capsys.readouterr().out
+    assert "Task for job 1234 killed" in out
+    assert "Task for job 1245 killed" in out
+    assert "No running tasks found matching 'unk'" in out
+    assert [call.args for call in mock_docker.kill.call_args_list] == [
+        ("os-job-1234",),
+        ("os-job-1245",),
+    ]
+
+
+def test_run(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    with mock.patch(
+        "jobrunner.cli.agent.kill_task.docker", autospec=True
+    ) as mock_docker:
+        mock_docker.docker.return_value = mock.Mock(stdout="'\"os-job-1234\"'\n")
+        mock_docker.container_exists.return_value = True
+        kill_task.run(["kill_task", "1234"])


### PR DESCRIPTION
Allows for partial job-id matching to kill running tasks for jobs. This just kills the docker container and cleans up; on the next agent loop, the task will still be active, but as there's no container, the agent will prepare it again and retry.

Fixes #959 