### PR TITLE
Store fine-grained agent stage in the controller

### DIFF
--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -235,7 +235,7 @@ def handle_job(job, mode=None, paused=None):
         task = create_task_for_job(job)
         with transaction():
             insert_task(task)
-            set_code(job, StatusCode.EXECUTING, "Executing job on the backend")
+            set_code(job, StatusCode.INITIATED, "Job executing on the backend")
     else:
         assert job.state == State.RUNNING
         task = get_task_for_job(job)
@@ -390,6 +390,7 @@ def set_code(job, new_status_code, message, error=None, results=None, **attrs):
 
         # update coarse state and timings for user
         if new_status_code in [
+            StatusCode.INITIATED,
             StatusCode.PREPARED,
             StatusCode.PREPARING,
             StatusCode.EXECUTING,

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -44,6 +44,8 @@ class StatusCode(Enum):
     #
     # initial state of a job, not yet running
     CREATED = "created"
+    # initiated; task created and sent to agent, but not yet running
+    INITIATED = "initiated"
     # waiting for pause mode to exit
     WAITING_PAUSED = "paused"
     # waiting db maintenance mode to exit

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -87,6 +87,10 @@ class StatusCode(Enum):
         order = list(self.__class__)
         return order.index(self) < order.index(other)
 
+    @classmethod
+    def from_value(cls, value, default=None):
+        return next((item for item in cls if item.value == value), default)
+
 
 # used for tracing to know if a state is final or not
 StatusCode._FINAL_STATUS_CODES = [

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -241,7 +241,7 @@ def test_handle_job_waiting_on_workers_resource_intensive_job(monkeypatch, db):
     job3 = database.find_one(Job, id=job3.id)
 
     assert job1.state == State.RUNNING
-    assert job1.status_code == StatusCode.EXECUTING
+    assert job1.status_code == StatusCode.INITIATED
 
     assert job2.state == State.PENDING
     assert (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 
+import pytest
+
+from jobrunner.models import StatusCode
 from tests.factories import (
     job_factory,
 )
@@ -16,3 +19,20 @@ def test_job_asdict_timestamps(db):
 
     assert d["created_at"] == "2022-10-07T14:59:12Z"
     assert d["status_code_updated_at"] == "2022-10-07T14:59:12.345678Z"
+
+
+@pytest.mark.parametrize(
+    "value,default,expected",
+    [
+        ("preparing", None, StatusCode.PREPARING),
+        ("prepared", None, StatusCode.PREPARED),
+        ("executing", None, StatusCode.EXECUTING),
+        ("unknown", None, None),
+        ("unknown", StatusCode.CREATED, StatusCode.CREATED),
+    ],
+)
+def test_status_code_from_value(value, default, expected):
+    kwargs = {}
+    if default is not None:
+        kwargs = {"default": default}
+    assert StatusCode.from_value(value, **kwargs) == expected


### PR DESCRIPTION
This was slightly more complex than I initially thought, because I didn't want to set jobs to `PREPARING` when the task is created, because we want `status_code` to reflect the agent stage, and not change to to `PREPARING` until the agent says it is. But `set_code()` still needs to receive a new code when the task is created, so I've added a new `INITIATED` state.

Fixes #986