### PR TITLE
Send state change timestamps from agent to controller

### DIFF
--- a/controller_app/views.py
+++ b/controller_app/views.py
@@ -40,12 +40,17 @@ def update_task(request, backend):
     # If the agent posts an empty results dict, it won't be present in the POST data
     results = update_task_info.get("results", {})
     complete = update_task_info["complete"]
+    timestamp_ns = update_task_info["timestamp_ns"]
 
     trace_attributes(backend=backend, task_id=task_id)
 
     try:
         handle_task_update(
-            task_id=task_id, stage=stage, results=results, complete=complete
+            task_id=task_id,
+            stage=stage,
+            results=results,
+            complete=complete,
+            timestamp_ns=timestamp_ns,
         )
     except Exception:
         log.exception("Error updating task")

--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -267,7 +267,13 @@ def update_job_task(
 
     tracing.set_job_results_metadata(span, redacted_results, attributes)
     log_state_change(task, status, previous_status)
-    task_api.update_controller(task, status.state.value, redacted_results, complete)
+    task_api.update_controller(
+        task=task,
+        stage=status.state.value,
+        results=redacted_results,
+        complete=complete,
+        timestamp_ns=status.timestamp_ns,
+    )
 
 
 def redact_results(results):

--- a/jobrunner/agent/task_api.py
+++ b/jobrunner/agent/task_api.py
@@ -15,15 +15,22 @@ def update_controller(
     stage: str,
     results: dict = None,
     complete: bool = False,
+    timestamp_ns: int = None,
 ):
     """Update the controller with the current state of the task.
 
     stage: the current stage of the task from the agent's perspective
     results: optional dictionary of completed results of this task, expected to be immutable
     complete: if the agent considers this task complete
+    timestamp_ns: Optional timestamp (in ns) of this state change. Can be None for tasks that
+    do not involve state changes.
     """
     # Cheating! This will eventaully be an HTTP API call to the controller but we just
     # do a direct function call for now
     controller_task_api.handle_task_update(
-        task_id=task.id, stage=stage, results=results, complete=complete
+        task_id=task.id,
+        stage=stage,
+        results=results,
+        complete=complete,
+        timestamp_ns=timestamp_ns,
     )

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -246,7 +246,7 @@ def handle_job(job, mode=None, paused=None):
                 raise PlatformError(job_error)
             else:
                 results = JobTaskResults.from_dict(task.agent_results)
-                save_results(job, results)
+                save_results(job, results, task.agent_timestamp_ns)
                 # TODO: Delete obsolete files
         else:
             # A task exists for this job already and it hasn't completed yet
@@ -263,10 +263,11 @@ def handle_job(job, mode=None, paused=None):
                 job,
                 StatusCode.from_value(task.agent_stage, default=job.status_code),
                 job.status_message,
+                task.agent_timestamp_ns,
             )
 
 
-def save_results(job, results):
+def save_results(job, results, timestamp_ns):
     """Extract the results of the execution and update the job accordingly."""
     message = None
     error = False
@@ -296,7 +297,9 @@ def save_results(job, results):
         if results.has_level4_excluded_files:
             message += ", but some file marked as moderately_sensitive were excluded. See job log for details."
 
-    set_code(job, code, message, error=error, results=results)
+    set_code(
+        job, code, message, error=error, results=results, timestamp_ns=timestamp_ns
+    )
 
 
 def job_to_job_definition(job):
@@ -368,7 +371,9 @@ def mark_job_as_failed(job, code, message, error=None, **attrs):
     set_code(job, code, message, error=error, **attrs)
 
 
-def set_code(job, new_status_code, message, error=None, results=None, **attrs):
+def set_code(
+    job, new_status_code, message, error=None, results=None, timestamp_ns=None, **attrs
+):
     """Set the granular status code state.
 
     We also trace this transition with OpenTelemetry traces.
@@ -381,7 +386,7 @@ def set_code(job, new_status_code, message, error=None, results=None, **attrs):
     """
     t = time.time()
     timestamp_s = int(t)
-    timestamp_ns = int(t * 1e9)
+    timestamp_ns = int(timestamp_ns or t * 1e9)
 
     # if status code has changed then trace it and update
     if job.status_code != new_status_code:

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -384,9 +384,12 @@ def set_code(
     collisions when states transition in <1s. Due to this, timestamp parameter
     should be the output of time.time() i.e. a float representing seconds.
     """
-    t = time.time()
-    timestamp_s = int(t)
-    timestamp_ns = int(timestamp_ns or t * 1e9)
+    if timestamp_ns is not None:
+        timestamp_s = int(timestamp_ns / 1e9)
+    else:
+        t = time.time()
+        timestamp_s = int(t)
+        timestamp_ns = int(timestamp_ns or t * 1e9)
 
     # if status code has changed then trace it and update
     if job.status_code != new_status_code:

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -414,7 +414,9 @@ def set_code(
         ]:
             # we've started running
             job.state = State.RUNNING
-            job.started_at = timestamp_s
+            # Only update started_at if it hasn't already been set
+            if not job.started_at:
+                job.started_at = timestamp_s
         elif new_status_code in [StatusCode.CANCELLED_BY_USER]:
             # only set this cancelled status after any finalize/cleanup processes
             job.state = State.FAILED

--- a/jobrunner/controller/task_api.py
+++ b/jobrunner/controller/task_api.py
@@ -44,7 +44,7 @@ def get_active_tasks(backend: str) -> list[Task]:
     return active_tasks
 
 
-def handle_task_update(*, task_id, stage, results, complete):
+def handle_task_update(*, task_id, stage, results, complete, timestamp_ns=None):
     # This is the function we expect to eventually be invoked via an HTTP API call.
     # This currently just updates the task table, and lets the main controller loop
     # update the jobs table as needed, and handle a completed task. In the future, we
@@ -55,6 +55,8 @@ def handle_task_update(*, task_id, stage, results, complete):
     task.agent_stage = stage
     task.agent_results = results
     task.agent_complete = complete
+    if timestamp_ns:
+        task.agent_timestamp_ns = int(timestamp_ns)
     if complete:
         task.active = False
         task.finished_at = int(time.time())

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -406,11 +406,12 @@ class Task:
             type TEXT,
             definition TEXT,
             active BOOLEAN,
-            created_at int,
-            finished_at int,
+            created_at INT,
+            finished_at INT,
             agent_stage TEXT,
             agent_complete BOOLEAN,
             agent_results TEXT,
+            agent_timestamp_ns INT,
             PRIMARY KEY (id)
         )
     """
@@ -432,6 +433,15 @@ class Task:
     agent_complete: bool = False
     # results of the task, including any error information
     agent_results: dict = None
+    # timestamp of state change sent by agent, default ns resolution
+    agent_timestamp_ns: int = None
 
     # ensure this table exists
     migration(4, __tableschema__)
+
+    migration(
+        7,
+        """
+        ALTER TABLE tasks ADD COLUMN agent_timestamp_ns INT;
+        """,
+    )

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -61,13 +61,18 @@ def test_handle_job_full_execution(db, freezer, caplog):
     freezer.tick(1)
 
     # prepare is synchronous
+    prepared_timestamp_ns = time.time_ns()
     api.set_job_transition(
-        job_id, ExecutorState.PREPARED, hook=lambda j: freezer.tick(1)
+        job_id,
+        ExecutorState.PREPARED,
+        prepared_timestamp_ns,
+        hook=lambda j: freezer.tick(1),
     )
     main.handle_single_task(task, api)
 
     task = controller_task_api.get_task(task.id)
     assert task.agent_stage == ExecutorState.PREPARED.value
+    assert task.agent_timestamp_ns == prepared_timestamp_ns
 
     # expected status transitions so far
     state_changes = [
@@ -94,7 +99,10 @@ def test_handle_job_full_execution(db, freezer, caplog):
         freezer.tick(1)
         api.set_job_metadata(job.id)
 
-    api.set_job_transition(job_id, ExecutorState.FINALIZED, hook=finalize)
+    finalized_timestamp_ns = prepared_timestamp_ns + 1000
+    api.set_job_transition(
+        job_id, ExecutorState.FINALIZED, finalized_timestamp_ns, hook=finalize
+    )
     assert job_id not in api.tracker["finalize"]
     main.handle_single_task(task, api)
     assert job_id in api.tracker["finalize"]
@@ -102,6 +110,7 @@ def test_handle_job_full_execution(db, freezer, caplog):
     assert task.agent_stage == ExecutorState.FINALIZED.value
     assert task.agent_complete
     assert task.agent_results
+    assert task.agent_timestamp_ns == finalized_timestamp_ns
 
     # Note EXECUTING -> EXECUTED happens outside of the agent loop
     # handler, so in this last call to handle_single_task, the job
@@ -141,7 +150,8 @@ def test_handle_job_full_execution(db, freezer, caplog):
 )
 def test_handle_job_stable_states(db, executor_state):
     api = StubExecutorAPI()
-    task, job_id = api.add_test_runjob_task(executor_state)
+    timestamp_ns = time.time_ns()
+    task, job_id = api.add_test_runjob_task(executor_state, timestamp_ns=timestamp_ns)
     job = JobDefinition.from_dict(task.definition)
 
     with patch(
@@ -155,6 +165,7 @@ def test_handle_job_stable_states(db, executor_state):
         executor_state.value,
         {},
         False if executor_state == ExecutorState.EXECUTING else True,
+        timestamp_ns,
     )
 
     assert job.id not in api.tracker["prepare"]
@@ -190,25 +201,33 @@ def test_handle_job_requires_db_has_secrets(db, monkeypatch):
 def test_handle_runjob_with_fatal_error(mock_update_controller, db):
     api = StubExecutorAPI()
 
-    task, job_id = api.add_test_runjob_task(ExecutorState.PREPARED)
+    preprared_timestamp_ns = time.time_ns()
+    task, job_id = api.add_test_runjob_task(
+        ExecutorState.PREPARED, timestamp_ns=preprared_timestamp_ns
+    )
 
+    executing_timestamp_ns = preprared_timestamp_ns + 10
     api.set_job_transition(
         job_id,
         ExecutorState.EXECUTING,
+        timestamp_ns=executing_timestamp_ns,
         hook=Mock(side_effect=Exception("test_hard_failure")),
     )
-
     with pytest.raises(Exception, match="test_hard_failure"):
         main.handle_single_task(task, api)
 
     assert mock_update_controller.call_count == 1
-    task2, stage, results, complete = mock_update_controller.call_args[0]
-    assert task2 == task
-    assert stage == ExecutorState.ERROR.value
+    call_kwargs = mock_update_controller.call_args[1]
+    assert call_kwargs["task"] == task
+    assert call_kwargs["stage"] == ExecutorState.ERROR.value
+    results = call_kwargs["results"]
     assert results["error"]["exception"] == "Exception"
     assert results["error"]["message"] == "test_hard_failure"
     assert "traceback" in results["error"]
-    assert complete is True
+    assert call_kwargs["complete"] is True
+    # The fatal error triggers a call to finalize, which sets the timestamp_ns
+    # to the current time_ns
+    assert call_kwargs["timestamp_ns"] > executing_timestamp_ns
 
     spans = get_trace("agent_loop")
     assert all(s.attributes["backend"] == "test" for s in spans)
@@ -260,11 +279,16 @@ def test_handle_runjob_with_not_fatal_error(mock_update_controller, db, exc):
 def test_handle_canceljob_with_fatal_error(mock_update_controller, db):
     api = StubExecutorAPI()
 
-    task, job_id = api.add_test_canceljob_task(ExecutorState.EXECUTED)
+    executed_timestamp_ns = time.time_ns()
+    task, job_id = api.add_test_canceljob_task(
+        ExecutorState.EXECUTED, executed_timestamp_ns
+    )
 
+    finalized_timestamp_ns = executed_timestamp_ns + 10
     api.set_job_transition(
         job_id,
         ExecutorState.FINALIZED,
+        timestamp_ns=finalized_timestamp_ns,
         hook=Mock(side_effect=Exception("test_hard_failure")),
     )
 
@@ -273,13 +297,17 @@ def test_handle_canceljob_with_fatal_error(mock_update_controller, db):
 
     # canceljob handler always calls update first
     assert mock_update_controller.call_count == 2
-    task2, stage, results, complete = mock_update_controller.call_args[0]
-    assert task2 == task
-    assert stage == ExecutorState.ERROR.value
+    call_kwargs = mock_update_controller.call_args[1]
+    assert call_kwargs["task"] == task
+    assert call_kwargs["stage"] == ExecutorState.ERROR.value
+    results = call_kwargs["results"]
     assert results["error"]["exception"] == "Exception"
     assert results["error"]["message"] == "test_hard_failure"
     assert "traceback" in results["error"]
-    assert complete is True
+    assert call_kwargs["complete"] is True
+    # The fatal error triggers a call to finalize, which sets the timestamp_ns
+    # to the current time_ns
+    assert call_kwargs["timestamp_ns"] > executed_timestamp_ns
 
     spans = get_trace("agent_loop")
     assert len(spans) == 1

--- a/tests/agent/test_main.py
+++ b/tests/agent/test_main.py
@@ -144,10 +144,11 @@ def test_update_job_task_results_redacted(
     main.update_job_task(task, job_status, previous_job_status, complete=True)
 
     mock_update_controller.assert_called_with(
-        task,
-        job_status.state.value,
-        expected_redacted_results,
-        True,
+        task=task,
+        stage=job_status.state.value,
+        results=expected_redacted_results,
+        complete=True,
+        timestamp_ns=ANY,
     )
     mock_set_job_results_metadata.assert_called_with(
         ANY,

--- a/tests/agent/test_task_api.py
+++ b/tests/agent/test_task_api.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from jobrunner.agent import task_api
@@ -49,6 +51,26 @@ def test_update_controller(db):
     assert db_task.agent_stage == "FINALIZED"
     assert db_task.agent_results == {"test": "test"}
     assert bool(db_task.agent_complete) is True
+    assert db_task.agent_timestamp_ns is None
+
+
+def test_update_controller_with_timestamp(db):
+    task = runjob_db_task_factory(backend="dummy")
+
+    timestamp = time.time_ns()
+    task_api.update_controller(
+        task,
+        stage="FINALIZED",
+        results={"test": "test"},
+        complete=True,
+        timestamp_ns=timestamp,
+    )
+
+    db_task = controller_api.get_task(task.id)
+    assert db_task.agent_stage == "FINALIZED"
+    assert db_task.agent_results == {"test": "test"}
+    assert bool(db_task.agent_complete) is True
+    assert db_task.agent_timestamp_ns == timestamp
 
 
 def test_full_job_stages(db):


### PR DESCRIPTION
Fixes #1009 

The state change timestamp is computed and stored already on JobStatus, so in `update_job_task` we now send it to `update_controller`.  (It can also be None, for non-job-related tasks - i.e. DBSTATUS)

For running jobs, the controller uses the task's agent_timestamp_ns (if available) instead of the current time to set the job's status_code_updated_at timestamp and for tracing.