### PR TITLE
Handle exceptions in the agent loop, rather than raising

### DIFF
--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -24,10 +24,7 @@ def main(exit_callback=lambda _: False):  # pragma: no cover
     api = get_executor_api()
 
     while True:
-        with tracer.start_as_current_span(
-            "AGENT_LOOP", attributes={"agent_loop": True}
-        ):
-            active_tasks = handle_tasks(api)
+        active_tasks = handle_tasks(api)
 
         if exit_callback(active_tasks):
             break
@@ -39,14 +36,28 @@ def handle_tasks(api: ExecutorAPI | None):
     active_tasks = task_api.get_active_tasks(backend=config.BACKEND)
 
     handled_tasks = []
+    errored_tasks = []
 
-    for task in active_tasks:
-        # `set_log_context` ensures that all log messages triggered anywhere
-        # further down the stack will have `task` set on them
-        with set_log_context(task=task):
-            handle_single_task(task, api)
+    with tracer.start_as_current_span("AGENT_LOOP") as span:
+        for task in active_tasks:
+            # `set_log_context` ensures that all log messages triggered anywhere
+            # further down the stack will have `task` set on them
+            with set_log_context(task=task):
+                try:
+                    handle_single_task(task, api)
+                except Exception:
+                    # do not raise now, but record and move on to the next task, so
+                    # we do not block loop.
+                    errored_tasks.append(task)
 
-        handled_tasks.append(task)
+            handled_tasks.append(task)
+
+        span.set_attributes(
+            {"handled_tasks": len(handled_tasks), "errored_tasks": len(errored_tasks)}
+        )
+
+    if errored_tasks:
+        raise Exception("Some tasks failed, restarting agent loop")
 
     return handled_tasks
 

--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -48,6 +48,7 @@ def handle_tasks(api: ExecutorAPI | None):
                 except Exception:
                     # do not raise now, but record and move on to the next task, so
                     # we do not block loop.
+                    log.exception("task error")
                     errored_tasks.append(task)
 
             handled_tasks.append(task)

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -27,7 +27,7 @@ def assert_state_change_logs(caplog, state_changes):
         ]
 
 
-def test_handle_tasks_error(db):
+def test_handle_tasks_error(db, caplog):
     api = StubExecutorAPI()
 
     task, job_id = api.add_test_runjob_task(ExecutorState.UNKNOWN)
@@ -45,6 +45,8 @@ def test_handle_tasks_error(db):
     assert spans[1].name == "AGENT_LOOP"
     assert spans[1].attributes["handled_tasks"] == 1
     assert spans[1].attributes["errored_tasks"] == 1
+
+    assert caplog.records[0].msg == "task error"
 
 
 def test_handle_job_full_execution(db, freezer, caplog):

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -27,6 +27,26 @@ def assert_state_change_logs(caplog, state_changes):
         ]
 
 
+def test_handle_tasks_error(db):
+    api = StubExecutorAPI()
+
+    task, job_id = api.add_test_runjob_task(ExecutorState.UNKNOWN)
+    api.set_job_transition(
+        job_id, ExecutorState.PREPARED, hook=Mock(side_effect=Exception("task error"))
+    )
+
+    msg = "Some tasks failed, restarting agent loop"
+    with pytest.raises(Exception, match=msg):
+        main.handle_tasks(api)
+
+    spans = get_trace("agent_loop")
+
+    assert spans[0].name == "LOOP_TASK"
+    assert spans[1].name == "AGENT_LOOP"
+    assert spans[1].attributes["handled_tasks"] == 1
+    assert spans[1].attributes["errored_tasks"] == 1
+
+
 def test_handle_job_full_execution(db, freezer, caplog):
     caplog.set_level(logging.INFO)
     # move to a whole second boundary for easier timestamp maths


### PR DESCRIPTION
This means we will move on to the next job, rather than restarting the
whole loop again.

We still track if any errors are produced, and raise at the end of loop
to be restarted by systemd.

Fixes: #1000
