### PR TITLE
Tweak main controller code style

### DIFF
--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -125,12 +125,11 @@ def handle_jobs():
 
 def handle_job_telemetry_wrapper(job):
     """A wrapper for handle_job which adds OpenTelemetry"""
-    attrs = {
-        "initial_state": job.state.name,
-        "initial_code": job.status_code.name,
-    }
-
     with tracer.start_as_current_span("LOOP_JOB") as span:
+        attrs = {
+            "initial_state": job.state.name,
+            "initial_code": job.status_code.name,
+        }
         tracing.set_span_metadata(span, job, **attrs)
         try:
             handle_job(job)

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -139,9 +139,9 @@ def handle_single_job(job):
             # it has failed. If we have an internal error, a full restart
             # might recover better.
             raise
-        else:
-            span.set_attribute("final_state", job.state.name)
-            span.set_attribute("final_code", job.status_code.name)
+
+        span.set_attribute("final_state", job.state.name)
+        span.set_attribute("final_code", job.status_code.name)
 
 
 def is_fatal_job_error(exc: Exception) -> bool:


### PR DESCRIPTION
When pairing with Providence, we were finding it a bit fiddly with `handle_jobs`, `handle_single_job` & `handle_job`. This squeezes some stuff in either direction out of `handle_single_job` to reduce it to a telemetry-only wrapper (which could now be a decorator, I think). 

* Also reduce unnecessary indentation 