### PR TITLE
Make canceljob_db_task_factory take an optional job

### DIFF
--- a/tests/agent/stubs.py
+++ b/tests/agent/stubs.py
@@ -62,7 +62,8 @@ class StubExecutorAPI:
         timestamp_ns=None,
         **kwargs,
     ) -> AgentTask:
-        task = AgentTask.from_task(canceljob_db_task_factory(**kwargs))
+        job = job_factory(**kwargs)
+        task = AgentTask.from_task(canceljob_db_task_factory(job=job))
         job = JobDefinition.from_dict(task.definition)
         self.set_job_status(job.id, executor_state, timestamp_ns)
         return task, job.id

--- a/tests/cli/controller/test_prepare_for_reboot.py
+++ b/tests/cli/controller/test_prepare_for_reboot.py
@@ -156,10 +156,10 @@ def test_prepare_for_reboot_status_with_running_job(db, paused, capsys):
 def test_prepare_for_reboot_status_with_cancelled_job(db, paused, capsys):
     pause_backend(paused)
     # reset job
-    t1 = canceljob_db_task_factory(
+    j1 = job_factory(
         state=State.PENDING, status_code=StatusCode.WAITING_ON_REBOOT, backend="test"
     )
-    j1 = database.find_one(Job, id=t1.id.split("-")[0])
+    t1 = canceljob_db_task_factory(job=j1)
 
     prepare_for_reboot.main("test", status=True, require_confirmation=False)
     job = database.find_one(Job, id=j1.id)
@@ -177,12 +177,10 @@ def test_prepare_for_reboot_status_with_cancelled_job(db, paused, capsys):
 def test_prepare_for_reboot_status_ready_to_reboot(db, paused, capsys):
     pause_backend(paused)
     # reset job, inactive task
-    t1 = canceljob_db_task_factory(
+    j1 = job_factory(
         state=State.PENDING, status_code=StatusCode.WAITING_ON_REBOOT, backend="test"
     )
-    t1.active = False
-    database.update(t1)
-    j1 = database.find_one(Job, id=t1.id.split("-")[0])
+    t1 = canceljob_db_task_factory(job=j1, active=False)
 
     prepare_for_reboot.main("test", status=True, require_confirmation=False)
     job = database.find_one(Job, id=j1.id)

--- a/tests/controller_app/test_views.py
+++ b/tests/controller_app/test_views.py
@@ -72,9 +72,7 @@ def test_active_tasks_view_multiple_backends(db, client, monkeypatch):
     canceltask1 = canceljob_db_task_factory(backend="test")
     # inactive tasks on test backend
     runjob_db_task_factory(backend="test", active=False)
-    canceltask2 = canceljob_db_task_factory(backend="test")
-    canceltask2.active = False
-    database.update(canceltask2)
+    canceljob_db_task_factory(backend="test", active=False)
     # active tasks on other backend
     runtask2 = runjob_db_task_factory(backend="foo")
     canceltask3 = canceljob_db_task_factory(backend="foo")


### PR DESCRIPTION
Makes canceljob_db_task_factory consistent with runjob_db_task_factory, which allows us to more easily make multiple tasks for the same job, and also simplifies some tests that need to make an inactive cancel task.