### PR TITLE
Add attributes to agent task for telemetry

### DIFF
--- a/jobrunner/agent/metrics.py
+++ b/jobrunner/agent/metrics.py
@@ -197,7 +197,7 @@ def record_metrics_tick_trace(last_run):
 
             # annotate with job/task metadata
             if task := tasks_by_job_id.get(job_id):
-                # this will set backend
+                # this will set backend and any task attributes sent by the controller
                 tracing.set_task_span_metadata(span, task)
                 tracing.set_job_span_metadata(
                     span, JobDefinition.from_dict(task.definition)

--- a/jobrunner/agent/tracing.py
+++ b/jobrunner/agent/tracing.py
@@ -39,6 +39,7 @@ def trace_task_attributes(task: AgentTask):
         task_type=task.type.name,
         # convert seconds to ns integer
         task_created_at=int(task.created_at * 1e9),
+        **task.attributes,
     )
 
     return attrs

--- a/jobrunner/cli/controller/add_job.py
+++ b/jobrunner/cli/controller/add_job.py
@@ -49,6 +49,9 @@ def main(
             cancelled_actions=[],
             codelists_ok=True,
             backend=backend,
+            created_by="controller",
+            project="unknown",
+            orgs=[],
         )
     )
     print("Submitting JobRequest:\n")

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -140,8 +140,11 @@ class JobRequest:
 
 # This stores the original JobRequest as received from the job-server. Once
 # we've created the relevant Jobs we have no real need for the JobRequest
-# object, but we it's useful to store it for debugging/audit purposes so we
-# just save a blob of the original JSON as received from the job-server.
+# object, but elements from the original JSON data from job-server can be
+# useful for debugging/audit purposes. Certain fields are also added as telemetry
+# trace attributes (e.g. created_by user, project, orgs); these could change in
+# future depending on telemetry needs, so we just retrieve them from the
+# original JSON blob.
 @databaseclass
 class SavedJobRequest:
     __tablename__ = "job_request"

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -439,6 +439,7 @@ class Task:
             active BOOLEAN,
             created_at INT,
             finished_at INT,
+            attributes TEXT,
             agent_stage TEXT,
             agent_complete BOOLEAN,
             agent_results TEXT,
@@ -457,7 +458,9 @@ class Task:
     # default second resolution
     created_at: int = None
     finished_at: int = None
-
+    # attributes: any key-value pairs that the controller can send to
+    # the agent for tracing purposes
+    attributes: dict = dataclasses.field(default_factory=dict)
     # state sent from the agent
     agent_stage: str = None
     # the task is complete from the agent's POV once this is set
@@ -474,5 +477,12 @@ class Task:
         7,
         """
         ALTER TABLE tasks ADD COLUMN agent_timestamp_ns INT;
+        """,
+    )
+
+    migration(
+        9,
+        """
+        ALTER TABLE tasks ADD COLUMN attributes TEXT;
         """,
     )

--- a/jobrunner/queries.py
+++ b/jobrunner/queries.py
@@ -6,7 +6,7 @@ from operator import attrgetter
 from opentelemetry import trace
 
 from jobrunner.lib.database import find_one, find_where, upsert
-from jobrunner.models import Flag, Job
+from jobrunner.models import Flag, Job, SavedJobRequest
 
 
 tracer = trace.get_tracer("db")
@@ -83,3 +83,10 @@ def set_flag(name, value, backend, timestamp=None):
 def get_current_flags(backend):
     """Get all currently set flags for a backend"""
     return find_where(Flag, backend=backend)
+
+
+def get_saved_job_request(job):
+    try:
+        return find_one(SavedJobRequest, id=job.job_request_id).original
+    except ValueError:
+        return {}

--- a/jobrunner/schema.py
+++ b/jobrunner/schema.py
@@ -30,6 +30,7 @@ class AgentTask:
     backend: str
     type: TaskType  # noqa: A003
     definition: dict
+    attributes: dict
     created_at: int = None
 
     @classmethod
@@ -40,6 +41,7 @@ class AgentTask:
             type=task.type,
             definition=task.definition,
             created_at=task.created_at,
+            attributes=task.attributes,
         )
 
     def asdict(self):

--- a/jobrunner/tracing.py
+++ b/jobrunner/tracing.py
@@ -11,8 +11,9 @@ from opentelemetry.trace import propagation
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from jobrunner.config import common as common_config
-from jobrunner.lib import database, warn_assertions
-from jobrunner.models import Job, SavedJobRequest, State, StatusCode
+from jobrunner.lib import warn_assertions
+from jobrunner.models import Job, State, StatusCode
+from jobrunner.queries import get_saved_job_request
 
 
 logger = logging.getLogger(__name__)
@@ -300,12 +301,7 @@ def trace_attributes(job, results=None):
     # grab job request metadata, caching it on the job instance to avoid excess
     # queries/jsoning
     if job._job_request is None:
-        try:
-            job._job_request = database.find_one(
-                SavedJobRequest, id=job.job_request_id
-            ).original
-        except ValueError:  # pragma: no cover
-            job._job_request = {}
+        job._job_request = get_saved_job_request(job)
 
     attrs = dict(
         backend=job.backend,

--- a/tests/agent/test_metrics.py
+++ b/tests/agent/test_metrics.py
@@ -112,6 +112,13 @@ def test_record_metrics_tick_trace(
     assert span.attributes["job"] == job_id
     assert span.attributes["task"] == task_id
     assert span.attributes["backend"] == "test"
+    if task_present:
+        assert span.attributes["user"] == "testuser"
+        assert span.attributes["project"] == "project"
+        assert span.attributes["orgs"] == "org1,org2"
+    else:
+        for key in ["user", "project", "orgs"]:
+            assert key not in span.attributes
     assert span.parent.span_id == root.context.span_id
 
     assert span.attributes["stats_timeout"] is False

--- a/tests/agent/test_tracing.py
+++ b/tests/agent/test_tracing.py
@@ -55,12 +55,19 @@ def test_tracing_state_change_attributes(mock_update_controller, db):
         "memory_limit",
         "final_job_status",
         "complete",
+        # from the task attributes dict
+        "user",
+        "project",
+        "orgs",
     }
     # attributes added from the task
     assert span.attributes["backend"] == "test"
     assert span.attributes["task_type"] == "RUNJOB"
     assert span.attributes["task"] == task.id
     assert span.attributes["task_created_at"] == task.created_at * 1e9
+    assert span.attributes["user"] == "testuser"
+    assert span.attributes["project"] == "project"
+    assert span.attributes["orgs"] == "org1,org2"
     # attributes added from the job
     assert span.attributes["job"] == job_id
     assert spans[0].attributes["initial_job_status"] == "UNKNOWN"
@@ -105,6 +112,10 @@ def test_tracing_final_state_attributes(mock_update_controller, db):
         "memory_limit",
         "final_job_status",
         "complete",
+        # from the task attributes dict
+        "user",
+        "project",
+        "orgs",
         # results included on the final span
         "image_id",
         "executor_message",
@@ -121,6 +132,9 @@ def test_tracing_final_state_attributes(mock_update_controller, db):
     assert span.attributes["task_type"] == "RUNJOB"
     assert span.attributes["task"] == task.id
     assert span.attributes["task_created_at"] == task.created_at * 1e9
+    assert span.attributes["user"] == "testuser"
+    assert span.attributes["project"] == "project"
+    assert span.attributes["orgs"] == "org1,org2"
     # attributes added from the job
     assert span.attributes["job"] == job_id
     assert spans[0].attributes["initial_job_status"] == "EXECUTED"

--- a/tests/controller_app/test_views.py
+++ b/tests/controller_app/test_views.py
@@ -49,9 +49,14 @@ def test_active_tasks_view(db, client, monkeypatch):
             "type": "runjob",
             "definition": runtask.definition,
             "created_at": runtask.created_at,
-            "attributes": {},
+            # test factory defaults
+            "attributes": {
+                "user": "testuser",
+                "project": "project",
+                "orgs": "org1,org2",
+            },
         }
-    ]
+    ], response["tasks"][0]["attributes"]
 
 
 def test_active_tasks_view_multiple_backends(db, client, monkeypatch):

--- a/tests/controller_app/test_views.py
+++ b/tests/controller_app/test_views.py
@@ -49,6 +49,7 @@ def test_active_tasks_view(db, client, monkeypatch):
             "type": "runjob",
             "definition": runtask.definition,
             "created_at": runtask.created_at,
+            "attributes": {},
         }
     ]
 

--- a/tests/lib/test_log_utils.py
+++ b/tests/lib/test_log_utils.py
@@ -51,7 +51,9 @@ test_job_definition = JobDefinition(
     level4_max_csv_rows=0,
     level4_max_filesize=0,
 )
-test_task = AgentTask(id="id-001", type=TaskType.RUNJOB, backend="", definition={})
+test_task = AgentTask(
+    id="id-001", type=TaskType.RUNJOB, backend="", definition={}, attributes={}
+)
 
 
 def test_formatting_filter():

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,7 +1,8 @@
 import time
 
 from jobrunner.lib.database import get_connection
-from jobrunner.queries import get_flag_value, set_flag
+from jobrunner.queries import get_flag_value, get_saved_job_request, set_flag
+from tests.factories import job_factory, job_request_factory, job_request_factory_raw
 
 
 def test_get_flag_no_table_does_not_error(tmp_work_dir):
@@ -37,3 +38,16 @@ def test_set_flag_multiple_backends(tmp_work_dir):
     assert get_flag_value("foo", backend="test2") is None
     set_flag("foo", "baz", backend="test2")
     assert get_flag_value("foo", backend="test2") == "baz"
+
+
+def test_get_saved_job_request(db):
+    job_request = job_request_factory()
+    job = job_factory()
+    assert get_saved_job_request(job) == job_request.original
+
+
+def test_get_saved_job_request_no_match(db):
+    # create a job with an un-saved job_request
+    job_request = job_request_factory_raw()
+    job = job_factory(job_request=job_request)
+    assert get_saved_job_request(job) == {}


### PR DESCRIPTION
Fixes #987 

The ticket mentions adding an attribute dict to AgentTask, which the controller populates with any key-value pairs. Since the main ones that we want to add at the moment are only available on a SavedJobRequest, I've added the attribute dict to the Task model so it will be stored in the db.  Otherwise it will need to query SavedJobRequest for every task, every time the agent and metrics loops call get_active_tasks().