### PR TITLE
Make tests error if they need the db fixture

### DIFF
--- a/jobrunner/lib/database.py
+++ b/jobrunner/lib/database.py
@@ -175,6 +175,9 @@ def transaction():
 def filename_or_get_default(filename=None):
     if filename is None:
         filename = config.DATABASE_FILE
+        assert filename is not None, (
+            "DATABASE_FILE config must not be None; did you omit the `db` fixture in a test?"
+        )
     return filename
 
 

--- a/tests/lib/test_database.py
+++ b/tests/lib/test_database.py
@@ -24,6 +24,7 @@ from jobrunner.lib.database import (
 )
 from jobrunner.models import Job, State
 from tests.conftest import get_trace
+from tests.factories import job_factory
 
 
 def test_get_connection():
@@ -368,3 +369,8 @@ def test_is_database_locked_error(tmp_path):
         captured = exc
     assert isinstance(captured, sqlite3.OperationalError)
     assert not is_database_locked_error(captured)
+
+
+def test_needs_db_fixture():
+    with pytest.raises(AssertionError, match="DATABASE_FILE config must not be None"):
+        job_factory()


### PR DESCRIPTION
Tests that need a database use the `db` fixture, which patches the DATABASE_FILE config to a temporary filepath. If you write a test and forget to add the db fixture, but you have a local db, the test will pass, but it'll use your (real) local db. This means that it (a) messes with your local environment and (b) makes the test fail in CI only, where there's no local db for it to use.

This adds an autouse fixture that always sets the DATABASE_FILE config variable to a temporary path. If a test attempts to use the database without the db fixture, it will fail because the db fixture runs the actual database setup, which we only want to do if it's required.