### PR TITLE
Only mark actual errors as errors in telemetry

### DIFF
--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -269,13 +269,12 @@ def handle_running_job(job):
                     error=job_error,
                 )
             else:
-                # mark task as inactive, this will trigger the loop to respawn it
+                # mark task as waiting on new task, this will trigger the loop to respawn it
                 set_code(
                     job,
                     StatusCode.WAITING_ON_NEW_TASK,
                     "This job returned an error that could be retriedwith a new task.",
                     error=False,
-                    active=False,
                 )
 
         else:
@@ -400,11 +399,11 @@ def get_states_of_awaited_jobs(job):
     return states
 
 
-def mark_job_as_failed(job, code, message, error=None, **attrs):
+def mark_job_as_failed(job, code, message, error=None):
     if error is None:
         error = True
 
-    set_code(job, code, message, error=error, **attrs)
+    set_code(job, code, message, error=error)
 
 
 def set_code(
@@ -415,7 +414,6 @@ def set_code(
     error=None,
     results=None,
     task_timestamp_ns=None,
-    **attrs,
 ):
     """Set the granular status code state.
 
@@ -480,7 +478,7 @@ def set_code(
 
         # job trace: we finished the previous state
         tracing.finish_current_state(
-            job, timestamp_ns, error=error, message=message, results=results, **attrs
+            job, timestamp_ns, error=error, message=message, results=results
         )
 
         # update db object
@@ -500,7 +498,6 @@ def set_code(
                 error=error,
                 message=message,
                 results=results,
-                **attrs,
             )
 
         log.info(job.status_message, extra={"status_code": job.status_code})

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -371,7 +371,7 @@ def create_job_from_exception(job_request, exception):
     )
     tracing.initialise_trace(job)
     insert_into_database(job_request, [job])
-    tracing.record_final_state(job, job.status_code_updated_at, error=error)
+    tracing.record_final_state(job, job.status_code_updated_at, exception=error)
 
 
 def insert_into_database(job_request, jobs):

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -393,7 +393,7 @@ def test_handle_job_finalized_failed_exit_code(
     # data about outputs or filename patterns is excluded
     for key in ["outputs", "unmatched_patterns", "unmatched_outputs"]:
         assert key not in completed_span.attributes
-    assert not completed_span.status.is_ok
+    assert completed_span.status.is_ok
     assert spans[-1].name == "JOB"
 
 

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -121,9 +121,9 @@ def test_handle_job_pending_dependency_failed(db):
     assert all(s.attributes["backend"] == "test" for s in spans)
     assert spans[-3].name == "CREATED"
     assert spans[-2].name == "DEPENDENCY_FAILED"
-    assert not spans[-2].status.is_ok
+    assert spans[-2].status.is_ok
     assert spans[-1].name == "JOB"
-    assert not spans[-1].status.is_ok
+    assert spans[-1].status.is_ok
 
 
 def test_handle_pending_job_waiting_on_dependency(db):
@@ -845,19 +845,6 @@ def test_job_definition_stata_license(db, monkeypatch, run_command, expect_env):
         assert job_definition.env["STATA_LICENSE"] == "dummy-license"
     else:
         assert "STATA_LICENSE" not in job_definition.env
-
-
-def test_mark_job_as_failed_adds_error(db):
-    job = job_factory()
-    main.mark_job_as_failed(job, StatusCode.INTERNAL_ERROR, "error")
-
-    # tracing
-    spans = get_trace("jobs")
-    assert spans[-3].name == "CREATED"
-    assert spans[-2].name == "INTERNAL_ERROR"
-    assert not spans[-2].status.is_ok
-    assert spans[-1].name == "JOB"
-    assert not spans[-1].status.is_ok
 
 
 @patch("jobrunner.controller.main.handle_job")

--- a/tests/test_create_or_update_jobs.py
+++ b/tests/test_create_or_update_jobs.py
@@ -531,9 +531,9 @@ def test_create_job_from_exception_stale_codelist(db):
     spans = get_trace("jobs")
 
     assert spans[0].name == "STALE_CODELISTS"
-    assert not spans[0].status.is_ok
+    assert spans[0].status.is_ok
     assert spans[1].name == "JOB"
-    assert not spans[1].status.is_ok
+    assert spans[1].status.is_ok
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Previously, all failed jobs were marked errors in the telemetry, by
setting the span status to ERROR. We are really only interested in
internal or platform errors being marked that way, as there are many
reasons jobs fail that are expected and normal

Addded a succeeded attribute to make it easier to filter on failed jobs
in honeycomb.

Fixes #982
