### PR TITLE
Changes to `Procfile` required for deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: /opt/venv/bin/gunicorn --config gunicorn.conf.py controller_app.wsgi
+service: /opt/venv/bin/python -m jobrunner.controller.service
 release: /opt/venv/bin/python -m jobrunner.cli.controller.migrate


### PR DESCRIPTION
Note that this means switching to running the control loop in a separate container, rather than as a background process in the web container. I believe that the [factors][1] which led us to do this were specific to the docker-compose deployment, and that running as a separate containers is a better fit for Dokku.

[1]: https://github.com/opensafely-core/job-runner/issues/967#issuecomment-2883537349