### PR TITLE
Update job metadata message for cancelled jobs

### DIFF
--- a/jobrunner/executors/local.py
+++ b/jobrunner/executors/local.py
@@ -450,7 +450,7 @@ def finalize_job(job_definition, cancelled, error=None):
                 )
 
         elif exit_code == 137 and cancelled:
-            message = "Job cancelled by user"
+            message = "Job cancelled by system"
         # Nb. this flag has been observed to be unreliable on some versions of Linux
         elif (
             container_metadata["State"]["ExitCode"] == 137
@@ -465,7 +465,7 @@ def finalize_job(job_definition, cancelled, error=None):
             message = config.DOCKER_EXIT_CODES.get(exit_code)
 
     elif cancelled:
-        message = "Job cancelled by user"
+        message = "Job cancelled by system"
 
     elif error:
         message = "Job errored"

--- a/tests/test_local_executor.py
+++ b/tests/test_local_executor.py
@@ -1078,7 +1078,7 @@ def test_running_job_cancelled(docker_cleanup, job_definition, tmp_work_dir):
     assert status.results["cancelled"]
     assert status.state == ExecutorState.FINALIZED
     assert status.results["exit_code"] == str(137)
-    assert status.results["status_message"] == "Job cancelled by user"
+    assert status.results["status_message"] == "Job cancelled by system"
 
     # Calling terminate again on a finalized job just returns the current status
     api.terminate(job_definition)
@@ -1109,7 +1109,7 @@ def test_running_job_cancelled_retry(docker_cleanup, job_definition, tmp_work_di
     assert status.results["cancelled"]
     assert status.state == ExecutorState.FINALIZED
     assert status.results["exit_code"] == str(137)
-    assert status.results["status_message"] == "Job cancelled by user"
+    assert status.results["status_message"] == "Job cancelled by system"
 
     # Calling get_status again on the same job definition, with the same task id
     # returns our existing finialized state


### PR DESCRIPTION
The previous wording ("job cancelled by user") was confusing, because a CANCELJOB task receive by the agent is not necessarily a result of a job that has been cancelled by a user. It can also be a job that's been cancelled by db maintenance, or by a prepare-for-reboot.

If a user cancels a job, the Job will have the cancelled flag set in the db, and the controller will [mark it as failed with the "Cancelled by user" status message](https://github.com/opensafely-core/job-runner/blob/afe1e4219284dab1ebfef3538774a41cf0e804b3/jobrunner/controller/main.py#L174).

So if we're displaying a cancellation message from the job metadata, it will be for a job that's been cancelled by some non-user requested means. (Note that for a user-cancelled job, the job metadata will still record "cancelled by system" - which is accurate - but the job's status_message will show the right thing to the user)