### PR TITLE
Run cleanup() for cancelled jobs in the PREPARED stage

### DIFF
--- a/jobrunner/agent/main.py
+++ b/jobrunner/agent/main.py
@@ -159,14 +159,11 @@ def handle_cancel_job_task(task, api):
                     f"unexpected state of job {job.id}: {initial_job_status.state}"
                 )
 
-        # Clean up based on the starting job state
-        if initial_job_status.state in [
-            ExecutorState.EXECUTING,
-            ExecutorState.EXECUTED,
-            ExecutorState.FINALIZED,
-            ExecutorState.ERROR,
-        ]:
-            api.cleanup(job)
+        # Clean up containers and volumes
+        # Note that if the job hasn't started (initial status UNKNOWN) or has
+        # already finished (FINALIZED), there should be nothing to clean up, but
+        # cleanup() will handle that
+        api.cleanup(job)
 
         update_job_task(
             task, final_status, previous_status=pre_finalized_job_status, complete=True

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -334,14 +334,14 @@ def test_handle_canceljob_with_fatal_error(mock_update_controller, db):
 
 
 @pytest.mark.parametrize(
-    "initial_state,interim_state,terminate,finalize,cleanup",
+    "initial_state,interim_state,terminate,finalize",
     [
-        (ExecutorState.PREPARED, None, False, True, False),
-        (ExecutorState.EXECUTING, ExecutorState.EXECUTED, True, True, True),
-        (ExecutorState.UNKNOWN, None, False, True, False),
-        (ExecutorState.EXECUTED, None, False, True, True),
-        (ExecutorState.ERROR, None, False, True, True),
-        (ExecutorState.FINALIZED, None, False, False, True),
+        (ExecutorState.PREPARED, None, False, True),
+        (ExecutorState.EXECUTING, ExecutorState.EXECUTED, True, True),
+        (ExecutorState.UNKNOWN, None, False, True),
+        (ExecutorState.EXECUTED, None, False, True),
+        (ExecutorState.ERROR, None, False, True),
+        (ExecutorState.FINALIZED, None, False, False),
     ],
 )
 def test_handle_cancel_job(
@@ -351,7 +351,6 @@ def test_handle_cancel_job(
     interim_state,
     terminate,
     finalize,
-    cleanup,
     monkeypatch,
     responses,
     live_server,
@@ -386,7 +385,8 @@ def test_handle_cancel_job(
 
     assert (job_id in api.tracker["terminate"]) == terminate
     assert (job_id in api.tracker["finalize"]) == finalize
-    assert (job_id in api.tracker["cleanup"]) == cleanup
+    # clean up is run irrespective of initial state
+    assert job_id in api.tracker["cleanup"]
 
     spans = get_trace("agent_loop")
     assert len(spans) == 1


### PR DESCRIPTION
A job in the PREPARED state has no container yet, but it does have a volume (which is how get_status() identifies it as PREPARED. https://github.com/opensafely-core/job-runner/blob/4df192219032451622ce99818402a20abc8e21ca/jobrunner/executors/local.py#L305

We therefore also need to run cleanup after cancelling  a job that is PREPARED; cleanup will try to delete the container, but it ignores errors if there's no container to remove, and it will delete the volume.