### PR TITLE
Use `app.json` to configure which processes we run

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,10 @@
+{
+  "formation": {
+    "web": {
+      "quantity": 1
+    },
+    "service": {
+      "quantity": 1
+    }
+  }
+}


### PR DESCRIPTION
By default, Dokku will run a single instance of the `web` process but not the `service` process which we have to start using `ps:scale`.

Configuring them in `app.json` like this means that `service` runs automatically and, additionally, that it only runs a single process and can't accidentally be scaled up beyond that – which would be bad.