### PR TITLE
Rename `JOB_SERVER_TOKEN` to `TASK_API_TOKEN` in agent

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -31,8 +31,10 @@ DEFAULT_DATABASE_URL=mssql+pyodbc://xxxx
 TEMP_DATABASE_NAME=OPENCoronaTempTables
 
 # Token for authenticating with the controller task api
-# For now this will reuse the job-server token per backend
-JOB_SERVER_TOKEN=pass
+CONTROLLER_TASK_API_TOKEN=pass
+
+# URL for controller task api
+CONTROLLER_TASK_API_ENDPOINT=http://localhost:8000/
 
 
 # USED BY CONTROLLER ONLY
@@ -54,5 +56,3 @@ TEST_JOB_SERVER_TOKEN=pass
 DJANGO_CONTROLLER_SECRET_KEY=secret
 DJANGO_CONTROLLER_ALLOWED_HOSTS=*
 DJANGO_DEBUG=True
-
-CONTROLLER_TASK_API_ENDPOINT=http://localhost:8000/

--- a/jobrunner/agent/task_api.py
+++ b/jobrunner/agent/task_api.py
@@ -25,7 +25,7 @@ def request_json(method, path, data=None):
     base_url = urljoin(config.TASK_API_ENDPOINT, config.BACKEND)
     data = data or {}
     url = f"{base_url}/{path}"
-    headers = {"Authorization": config.JOB_SERVER_TOKEN}
+    headers = {"Authorization": config.TASK_API_TOKEN}
     response = session.request(method, url, data=data, headers=headers)
     try:
         response.raise_for_status()

--- a/jobrunner/config/agent.py
+++ b/jobrunner/config/agent.py
@@ -148,4 +148,4 @@ TASK_API_ENDPOINT = os.environ.get("CONTROLLER_TASK_API_ENDPOINT")
 
 # Token for authenticating with the controller task api
 # For now this will reuse the job-server token for this backend
-JOB_SERVER_TOKEN = os.environ.get("JOB_SERVER_TOKEN", "token")
+TASK_API_TOKEN = os.environ.get("CONTROLLER_TASK_API_TOKEN", "token")

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -7,7 +7,7 @@ def test_backend_api_tokens(monkeypatch):
     Ensures that the agent and controller both have the relevant tokens
     set for the agent to authenticate with the controller app
     """
-    monkeypatch.setattr("jobrunner.config.agent.JOB_SERVER_TOKEN", "test_token")
+    monkeypatch.setattr("jobrunner.config.agent.TASK_API_TOKEN", "test_token")
     monkeypatch.setattr(
         "jobrunner.config.controller.JOB_SERVER_TOKENS", {"test": "test_token"}
     )

--- a/tests/agent/test_task_api.py
+++ b/tests/agent/test_task_api.py
@@ -40,14 +40,14 @@ def test_get_active_tasks(db, monkeypatch, responses):
         url=f"{config.TASK_API_ENDPOINT}dummy/tasks/",
         status=200,
         json={"tasks": [AgentTask.from_task(task1).asdict()]},
-        match=[matchers.header_matcher({"Authorization": config.JOB_SERVER_TOKEN})],
+        match=[matchers.header_matcher({"Authorization": config.TASK_API_TOKEN})],
     )
     responses.add(
         method="GET",
         url=f"{config.TASK_API_ENDPOINT}another/tasks/",
         status=200,
         json={"tasks": [AgentTask.from_task(task3).asdict()]},
-        match=[matchers.header_matcher({"Authorization": config.JOB_SERVER_TOKEN})],
+        match=[matchers.header_matcher({"Authorization": config.TASK_API_TOKEN})],
     )
 
     active = task_api.get_active_tasks()
@@ -70,7 +70,7 @@ def test_get_active_tasks_api_error(db, monkeypatch, responses):
         method="GET",
         url=f"{config.TASK_API_ENDPOINT}dummy/tasks/",
         status=500,
-        match=[matchers.header_matcher({"Authorization": config.JOB_SERVER_TOKEN})],
+        match=[matchers.header_matcher({"Authorization": config.TASK_API_TOKEN})],
     )
 
     with pytest.raises(requests.HTTPError):

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -944,7 +944,7 @@ def test_handle_task_update_dbstatus(
     # Use the live_server url for our task api endpoint, for the agent to call in`run_agent_loop_once`
     monkeypatch.setattr("jobrunner.config.agent.TASK_API_ENDPOINT", live_server.url)
     # Ensure we have correct auth for the task api
-    monkeypatch.setattr("jobrunner.config.agent.JOB_SERVER_TOKEN", "test_token")
+    monkeypatch.setattr("jobrunner.config.agent.TASK_API_TOKEN", "test_token")
     monkeypatch.setattr(
         "jobrunner.config.controller.JOB_SERVER_TOKENS", {"test": "test_token"}
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,7 +29,7 @@ def set_agent_config(monkeypatch, tmp_work_dir):
     # Note that as we are running ehrql actions in this test, we need to set
     # the backend to a value that ehrql will accept
     monkeypatch.setattr("jobrunner.config.agent.BACKEND", "test")
-    monkeypatch.setattr("jobrunner.config.agent.JOB_SERVER_TOKEN", "test_token")
+    monkeypatch.setattr("jobrunner.config.agent.TASK_API_TOKEN", "test_token")
     # set all the tmp workdir config as we remove it for the controller phase
     set_tmp_workdir_config(monkeypatch, tmp_work_dir)
 
@@ -80,7 +80,7 @@ def set_controller_config(monkeypatch):
         "HIGH_PRIVACY_ARCHIVE_DIR",
         "HIGH_PRIVACY_VOLUME_DIR",
         "JOB_LOG_DIR",
-        "JOB_SERVER_TOKEN",
+        "TASK_API_TOKEN",
     ]
 
     for config_var in config_vars:


### PR DESCRIPTION
When doing some config cleanup I found this confusing and I think it would be better to be consistent here.

I've already added the relevant env vars to the TPP and Test backends so this should be safe to deploy.