### PR TITLE
Disable gunicorn access logs

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -19,6 +19,10 @@ port = 5000
 bind = "0.0.0.0"
 
 
+# disable access logging, as not needed
+accesslog = None
+
+
 # Because of Gunicorn's pre-fork web server model, we need to initialise opentelemetry
 # in gunicorn's post_fork method in order to instrument our application process, see:
 # https://opentelemetry-python.readthedocs.io/en/latest/examples/fork-process-model/README.html


### PR DESCRIPTION
They are not necessary

- nginx on dokku4 has access logs
- we have otel traces
- its noisy, hides more useful services logs
- completely different format, thats a bit hard to usefuly change
