### PR TITLE
Fix bug in update timestamps

### DIFF
--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -297,7 +297,7 @@ def handle_running_job(job):
             job,
             StatusCode.from_value(task.agent_stage, default=job.status_code),
             job.status_message,
-            task.agent_timestamp_ns,
+            task_timestamp_ns=task.agent_timestamp_ns,
         )
 
 
@@ -332,7 +332,7 @@ def save_results(job, results, timestamp_ns):
             message += ", but some file(s) marked as moderately_sensitive were excluded. See job log for details."
 
     set_code(
-        job, code, message, error=error, results=results, timestamp_ns=timestamp_ns
+        job, code, message, error=error, results=results, task_timestamp_ns=timestamp_ns
     )
 
 
@@ -408,7 +408,14 @@ def mark_job_as_failed(job, code, message, error=None, **attrs):
 
 
 def set_code(
-    job, new_status_code, message, error=None, results=None, timestamp_ns=None, **attrs
+    job,
+    new_status_code,
+    message,
+    *,
+    error=None,
+    results=None,
+    task_timestamp_ns=None,
+    **attrs,
 ):
     """Set the granular status code state.
 


### PR DESCRIPTION
A bug in the previous implementation of using set_code with a timestamp meant that we actually never set the timestamp to the agent-provided timestamp for running jobs.  However, we still don't want to _always_ set the timestamp to the agent-provided timestamp, because then we'd never change the updated_at time for a job whose status code hadn't changed.

This fixes the bug with the positional/keyword args, and also updaes set_code() so that we use the agent-provided task timestamp only when a status code has changed. If it hasn't changed, we use the current time instead.

(Note that we could perhaps add a field to the Task to record the time it was updated in `task_api.handle_task_update()`, and use that for running jobs. That would be more accurate in recording the time the _agent_ last updated, but would involve database changes so I'm leaving it for now)