### PR TITLE
Enable specific repos to use ehrQL's event level data

### DIFF
--- a/jobrunner/config/controller.py
+++ b/jobrunner/config/controller.py
@@ -144,3 +144,10 @@ def job_limits_from_env(env, limit_name, default, transform=str):
 
 DEFAULT_JOB_CPU_COUNT = job_limits_from_env(os.environ, "job_cpu_count", 2, float)
 DEFAULT_JOB_MEMORY_LIMIT = job_limits_from_env(os.environ, "job_memory_limit", "4G")
+
+
+# Repos associated with projects approved by NOD to try out the new Event Level Data
+# features in ehrQL against real data
+REPOS_WITH_EHRQL_EVENT_LEVEL_ACCESS = {
+    "https://github.com/opensafely/ve-ccw",
+}

--- a/jobrunner/controller/main.py
+++ b/jobrunner/controller/main.py
@@ -340,6 +340,9 @@ def job_to_job_definition(job, task_id):
     if image.startswith("stata-mp"):
         env["STATA_LICENSE"] = str(config.STATA_LICENSE)
 
+    if job.requires_db and job.repo_url in config.REPOS_WITH_EHRQL_EVENT_LEVEL_ACCESS:
+        env["EHRQL_ENABLE_EVENT_LEVEL_QUERIES"] = "True"
+
     # Jobs which are running reusable actions pull their code from the reusable
     # action repo, all other jobs pull their code from the study repo
     study = Study(job.action_repo_url or job.repo_url, job.action_commit or job.commit)

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -847,6 +847,27 @@ def test_job_definition_stata_license(db, monkeypatch, run_command, expect_env):
         assert "STATA_LICENSE" not in job_definition.env
 
 
+@pytest.mark.parametrize(
+    "repo_url,expect_env",
+    [
+        ("https://github.com/opensafely/ok-repo", True),
+        ("https://github.com/opensafely/not-ok-repo", False),
+    ],
+)
+def test_job_definition_ehrql_event_level_access(db, monkeypatch, repo_url, expect_env):
+    monkeypatch.setattr(
+        config,
+        "REPOS_WITH_EHRQL_EVENT_LEVEL_ACCESS",
+        {"https://github.com/opensafely/ok-repo"},
+    )
+    job = job_factory(requires_db=True, repo_url=repo_url)
+    job_definition = main.job_to_job_definition(job, task_id="")
+    if expect_env:
+        assert job_definition.env["EHRQL_ENABLE_EVENT_LEVEL_QUERIES"] == "True"
+    else:
+        assert "EHRQL_ENABLE_EVENT_LEVEL_QUERIES" not in job_definition.env
+
+
 @patch("jobrunner.controller.main.handle_job")
 def test_handle_error(patched_handle_job, db, monkeypatch):
     monkeypatch.setattr(common_config, "JOB_LOOP_INTERVAL", 0)


### PR DESCRIPTION
Hardcoding the list like this is obviously not particularly lovely, but there's precendent for it (e.g. in [job-server][1]) and it has certain advantages in forcing everything through code review and leaving an audit trail.

The number of repos is expected to remain small, and the feature as a whole has a limited lifespan: NOD have agreed that after a period of testing, event-level data access needs to be either made generally available or canned completely.

[1]: https://github.com/opensafely-core/job-server/pull/3558