### PR TITLE
Add agent cli command for emitting ehrQL telemetry

### DIFF
--- a/agent/cli/ehrql_telemetry.py
+++ b/agent/cli/ehrql_telemetry.py
@@ -54,7 +54,7 @@ def main(argv):
 
     # force our name to be used as dataset
     os.environ["OTEL_SERVICE_NAME"] = args.dataset
-    setup_default_tracing()
+    setup_default_tracing("agent")
 
     run(metadata, logs)
 

--- a/agent/cli/ehrql_telemetry.py
+++ b/agent/cli/ehrql_telemetry.py
@@ -96,8 +96,11 @@ def convert_ehrql_logs(logfile_path):  # pragma: nocover
     process = subprocess.run(
         [
             "docker",
-            "run--rm",
-            "ghcr.io/opensafely-core/ehrql:v1/app/scripts/parse_logs.py",
+            "run",
+            "--rm",
+            "--interactive",
+            "ghcr.io/opensafely-core/ehrql:v1",
+            "/app/scripts/parse_logs.py",
         ],
         input=logfile_path.read_text(),
         capture_output=True,

--- a/agent/cli/ehrql_telemetry.py
+++ b/agent/cli/ehrql_telemetry.py
@@ -13,8 +13,15 @@ from common.tracing import setup_default_tracing
 
 
 def main(argv):
-    parser = argparse.ArgumentParser(description="db_telemetry")
-    parser.add_argument("dataset", help="Honeycomb dataset to emit telemetry to")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Emit an ehrql job's query data as telemetry."
+            "Reads the job's log file, and converts the query timing to otel, and sends them out."
+        )
+    )
+    parser.add_argument(
+        "dataset", help="Temporary Honeycomb dataset to emit telemetry to."
+    )
     parser.add_argument(
         "job", help="job to emit telemetry for. Either job id or path to job log dir."
     )

--- a/agent/cli/ehrql_telemetry.py
+++ b/agent/cli/ehrql_telemetry.py
@@ -1,0 +1,134 @@
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from opentelemetry import context, trace
+
+from agent.executors.local import job_metadata_path
+from common.tracing import setup_default_tracing
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="db_telemetry")
+    parser.add_argument("dataset", help="Honeycomb dataset to emit telemetry to")
+    parser.add_argument(
+        "job", help="job to emit telemetry for. Either job id or path to job log dir."
+    )
+    args = parser.parse_args(argv)
+
+    if os.path.isdir(args.job):
+        log_dir = Path(args.job)
+    else:
+        log_dir = job_metadata_path(args.job).parent
+
+    metadata_path = log_dir / "metadata.json"
+    logfile_path = log_dir / "logs.txt"
+    metadata = json.loads(metadata_path.read_text())
+
+    assert "ehrql" in metadata["container_metadata"]["Config"]["Image"], (
+        "Cowardly refusing to emit telemetry for non-ehrql job"
+    )
+
+    raw_lines = convert_ehrql_logs(logfile_path)
+
+    logs = []
+    for line in raw_lines:
+        line = line.strip()
+        if not line:  # pragma: nocover
+            continue
+        try:
+            logs.append(json.loads(line))
+        except json.JSONDecodeError:
+            print(f"bad json from ehrql: {line}")
+
+    # force our name to be used as dataset
+    os.environ["OTEL_SERVICE_NAME"] = args.dataset
+    setup_default_tracing()
+
+    run(metadata, logs)
+
+
+def run(metadata, queries):
+    tracer = trace.get_tracer("queries")
+
+    # get the start/end times from the docker container metadata
+    container = metadata["container_metadata"]
+    start_time_ns = docker_datestr_to_ns(container["State"]["StartedAt"])
+    end_time_ns = docker_datestr_to_ns(container["State"]["FinishedAt"])
+    operation = "ehrql." + container["Args"][0]  # e.g. 'ehrql.generate-dataset'
+
+    attrs = get_attrs(metadata)
+    root = tracer.start_span(
+        operation, context={}, start_time=start_time_ns, attributes=attrs
+    )
+
+    # Set it as the active span
+    ctx = trace.set_span_in_context(root)
+    token = context.attach(ctx)
+
+    for query in queries:
+        emit(tracer, attrs, query, end_time_ns)
+
+    root.end(end_time=end_time_ns)
+    context.detach(token)
+
+
+def docker_datestr_to_ns(ts):
+    # Docker timestamps have ns precision and a Z. We strip the Z and reduce to
+    # ms precision, as strptime can't handle either
+    return int(
+        datetime.strptime(ts[0:-4], "%Y-%m-%dT%H:%M:%S.%f").timestamp() * 1_000_000_000
+    )
+
+
+def convert_ehrql_logs(logfile_path):  # pragma: nocover
+    process = subprocess.run(
+        [
+            "docker",
+            "run--rm",
+            "ghcr.io/opensafely-core/ehrql:v1/app/scripts/parse_logs.py",
+        ],
+        input=logfile_path.read_text(),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    return process.stdout.splitlines()
+
+
+def get_attrs(metadata):
+    container = metadata["container_metadata"]
+    return {
+        "job.id": metadata["job_definition_id"],
+        "task.id": metadata["task_id"],
+        "job.exit_code": metadata["exit_code"],
+        "job.oom_killed": metadata["oom_killed"],
+        "job.cancelled": metadata["cancelled"],
+        "job.workspace": container["Config"]["Labels"]["workspace"],
+        "job.action": container["Config"]["Labels"]["action"],
+        "job.run_command": " ".join(container["Args"]),
+        # older metadata.json do not have job_metrics
+        "job.cpu_peak": metadata["job_metrics"].get("cpu_peak", 0),
+        "job.cpu_mean": metadata["job_metrics"].get("cpu_mean", 0),
+        "job.mem_mb_peak": metadata["job_metrics"].get("mem_mb_peak", 0),
+        "job.mem_mb_mean": metadata["job_metrics"].get("mem_mb_mean", 0),
+    }
+
+
+def emit(tracer, job_attrs, query, end_time_ns):
+    name = query["name"]
+    start_time_ns = docker_datestr_to_ns(query["start"])
+    if query["end"]:
+        end_time_ns = docker_datestr_to_ns(query["end"])
+    attrs = job_attrs | query["attributes"]
+    span = tracer.start_span(name, start_time=start_time_ns, attributes=attrs)
+    span.end(end_time_ns)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tests/agent/cli/test_ehrql_telemetry.py
+++ b/tests/agent/cli/test_ehrql_telemetry.py
@@ -1,0 +1,162 @@
+import json
+
+import pytest
+
+from agent.cli import ehrql_telemetry
+from agent.executors import local
+from tests.conftest import get_trace
+
+
+def metadata(jobid="job_id"):
+    """Minimal metadata.json contents needed for telemetry"""
+    return {
+        "job_definition_id": jobid,
+        "task_id": "task_id",
+        "exit_code": "0",
+        "oom_killed": False,
+        "cancelled": False,
+        "error": False,
+        "workspace": "workspace",
+        "job_metrics": {
+            "cpu_peak": 0,
+            "cpu_mean": 0,
+            "mem_mb_peak": 0,
+            "mem_mb_mean": 0,
+        },
+        "container_metadata": {
+            "State": {
+                "StartedAt": "2025-07-02T10:23:45.123456789Z",
+                "FinishedAt": "2025-07-02T12:23:45.123456789Z",
+            },
+            "Args": ["foo", "bar"],
+            "Config": {
+                "Image": "ghcr.io/opensafely-core/ehrql:v1",
+                "Labels": {"action": "action", "workspace": "workspace"},
+            },
+        },
+    }
+
+
+def logdata(name="name", start=None, end=None, **kwargs):
+    """Minimal log data"""
+    return {
+        "name": name,
+        "start": start or "2025-07-02T10:23:45.123456789Z",
+        "end": end or "2025-07-02T12:23:45.123456789Z",
+        "attributes": kwargs,
+    }
+
+
+def set_logs(monkeypatch, lines):
+    monkeypatch.setattr(ehrql_telemetry, "convert_ehrql_logs", lambda _: lines)
+
+
+def test_ehrql_telemetry_run():
+    meta = metadata()
+    log = logdata(test=True)
+    ehrql_telemetry.run(meta, [log])
+    spans = get_trace()
+    assert spans[0].name == log["name"]
+    assert spans[0].start_time == ehrql_telemetry.docker_datestr_to_ns(log["start"])
+    assert spans[0].end_time == ehrql_telemetry.docker_datestr_to_ns(log["end"])
+    assert spans[0].attributes["test"]
+
+    assert spans[1].name == "ehrql.foo"
+
+    attrs = ehrql_telemetry.get_attrs(meta)
+    for span in spans:
+        for k, v in attrs.items():
+            assert span.attributes[k] == v
+
+
+def test_ehrql_telemetry_run_no_end_timestamp():
+    meta = metadata()
+    log = logdata(test=True)
+    log["end"] = None
+    ehrql_telemetry.run(meta, [log])
+    spans = get_trace()
+    assert spans[0].name == log["name"]
+    assert spans[0].start_time == ehrql_telemetry.docker_datestr_to_ns(log["start"])
+    assert spans[0].end_time == ehrql_telemetry.docker_datestr_to_ns(
+        meta["container_metadata"]["State"]["FinishedAt"]
+    )
+    assert spans[0].attributes["test"]
+
+    assert spans[1].name == "ehrql.foo"
+
+    attrs = ehrql_telemetry.get_attrs(meta)
+    for span in spans:
+        for k, v in attrs.items():
+            assert span.attributes[k] == v
+
+
+def test_ehrql_telemetry_main_with_dir(tmp_path, monkeypatch):
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(json.dumps(metadata()))
+    set_logs(
+        monkeypatch,
+        [
+            json.dumps(logdata(name="first")),
+            json.dumps(logdata(name="second")),
+        ],
+    )
+
+    ehrql_telemetry.main(["dataset", str(tmp_path)])
+    spans = get_trace()
+    assert spans[0].name == "first"
+    assert spans[1].name == "second"
+    assert spans[2].name == "ehrql.foo"
+
+
+def test_ehrql_telemetry_main_with_id(monkeypatch, tmp_path):
+    monkeypatch.setattr(local.config, "JOB_LOG_DIR", tmp_path)
+    job_id = "1234"
+    meta = metadata(job_id)
+    logdir = local.get_log_dir(job_id)
+    logdir.mkdir(parents=True)
+
+    metadata_path = logdir / "metadata.json"
+    metadata_path.write_text(json.dumps(meta))
+    set_logs(
+        monkeypatch,
+        [
+            json.dumps(logdata(name="first")),
+            json.dumps(logdata(name="second")),
+        ],
+    )
+
+    ehrql_telemetry.main(["dataset", job_id])
+    spans = get_trace()
+    assert spans[0].name == "first"
+    assert spans[1].name == "second"
+    assert spans[2].name == "ehrql.foo"
+
+
+def test_ehrql_telemetry_main_bad_json_line(tmp_path, monkeypatch):
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(json.dumps(metadata()))
+    set_logs(
+        monkeypatch,
+        [
+            json.dumps(logdata(name="first")),
+            "{[}",
+            "",
+            json.dumps(logdata(name="second")),
+        ],
+    )
+
+    ehrql_telemetry.main(["dataset", str(tmp_path)])
+    spans = get_trace()
+    assert spans[0].name == "first"
+    assert spans[1].name == "second"
+    assert spans[2].name == "ehrql.foo"
+
+
+def test_ehrql_telemetry_main_non_ehrql_job(tmp_path):
+    metadata_path = tmp_path / "metadata.json"
+    meta = metadata()
+    meta["container_metadata"]["Config"]["Image"] = "something else"
+    metadata_path.write_text(json.dumps(meta))
+
+    with pytest.raises(AssertionError, match="non-ehrql"):
+        ehrql_telemetry.main(["dataset", str(tmp_path)])

--- a/tests/agent/cli/test_ehrql_telemetry.py
+++ b/tests/agent/cli/test_ehrql_telemetry.py
@@ -160,3 +160,45 @@ def test_ehrql_telemetry_main_non_ehrql_job(tmp_path):
 
     with pytest.raises(AssertionError, match="non-ehrql"):
         ehrql_telemetry.main(["dataset", str(tmp_path)])
+
+
+ehrql_log = """
+2025-07-01T16:56:30.687958737Z [info   ] Compiling dataset definition from analysis/dataset_definition/dataset_definition_vax.py
+2025-07-01T16:56:46.227330349Z [info   ] Generating dataset
+2025-07-01T16:57:00.993809188Z [info   ] Running query 001 / 331
+2025-07-01T16:57:00.995883302Z [info   ] SQL:
+2025-07-01T16:57:00.995931727Z           SELECT * INTO [#tmp_1] FROM (SELECT patients.patient_id AS patient_id
+2025-07-01T16:57:00.995952045Z           FROM (
+2025-07-01T16:57:00.995970602Z                       SELECT
+2025-07-01T16:57:00.995988488Z                           Patient_ID as patient_id,
+2025-07-01T16:57:00.996005352Z                           DateOfBirth as date_of_birth,
+2025-07-01T16:57:00.996023614Z                           CASE
+2025-07-01T16:57:00.996043264Z                               WHEN Sex = 'M' THEN 'male' COLLATE Latin1_General_CI_AS
+2025-07-01T16:57:00.996061649Z                               WHEN Sex = 'F' THEN 'female' COLLATE Latin1_General_CI_AS
+2025-07-01T16:57:00.996210794Z                               WHEN Sex = 'I' THEN 'intersex' COLLATE Latin1_General_CI_AS
+2025-07-01T16:57:00.996234454Z                               ELSE 'unknown' COLLATE Latin1_General_CI_AS
+2025-07-01T16:57:00.996252317Z                           END AS sex,
+2025-07-01T16:57:00.996265184Z                           NULLIF(DateOfDeath, '99991231') AS date_of_death
+2025-07-01T16:57:00.996277761Z                       FROM Patient
+2025-07-01T16:57:00.996290041Z                   ) AS patients UNION SELECT [PatientsWithTypeOneDissent].[Patient_ID] AS patient_id
+2025-07-01T16:57:00.996302988Z           FROM [PatientsWithTypeOneDissent]) AS anon_1
+2025-07-01T16:57:01.010057734Z [info   ] scans logical physical read_ahead lob_logical lob_physical lob_read_ahead table
+2025-07-01T16:57:01.010114642Z           1     0       0        0          0           0            0              PatientsWithTypeOneDissent
+2025-07-01T16:57:01.010136538Z           1     0       0        0          0           0            0              Patient
+2025-07-01T16:57:01.010240821Z [info   ] 0 seconds: exec_cpu_ms=3 exec_elapsed_ms=3 exec_cpu_ratio=1.0 parse_cpu_ms=0 parse_elapsed_ms=0 query_id=query 001 / 331
+"""
+
+
+# this is not run by CI by default, as it is slow and brittle, hence the no-cover
+# run manually with just test -o python_functions=manual_test
+def manual_test_convert_ehrql_logs(tmp_path):  # pragma: nocover
+    logfile = tmp_path / "logs.txt"
+    logfile.write_text(ehrql_log)
+
+    lines = ehrql_telemetry.convert_ehrql_logs(logfile)
+    assert len(lines) == 1
+    data = json.loads(lines[0])
+    assert "name" in data
+    assert "start" in data
+    assert "end" in data
+    assert "attributes" in data


### PR DESCRIPTION
This adds an agent CLI command, which can be executed in the deployed environment with:
```
just ehrql_telemetry DATASET_NAME JOB_SPECIFIER
```

This will read the job's log file, parse out the relevant events, and push them as backdated otel records into the specified Honeycomb dataset. 

`DATASET_NAME` can be chosen pretty much arbitrarily as long as:
 * you avoid using one of our existing service names like `rap-controller`;
 * you use a consistent dataset name when processing all the jobs you want to analyse.

`JOB_SPECIFIER` can either be a job ID or a path to a job's log directory.

For more detail on why we are using this approach see the below document:
https://docs.google.com/document/d/1EXdQNSOUOvbx42JUw952GvCwh87C4sLbYlLkMQqe4EI/
