### PR TITLE
Spike using Django ORM to read DB and reimplement `calculate_workspace_state`

### DIFF
--- a/controller/queries.py
+++ b/controller/queries.py
@@ -38,7 +38,7 @@ def calculate_workspace_state(backend, workspace):
             ordered_jobs = sorted(jobs, key=attrgetter("created_at"), reverse=True)
             latest_jobs.append(ordered_jobs[0])
 
-    return latest_jobs
+    return (all_jobs, latest_jobs)
 
 
 def group_by(iterable, key):

--- a/controller/webapp/management/commands/compare_calculate_workspace_state.py
+++ b/controller/webapp/management/commands/compare_calculate_workspace_state.py
@@ -1,0 +1,52 @@
+import time
+
+from django.core.management.base import BaseCommand
+from django.db.models import F, Window
+from django.db.models.functions import FirstValue
+
+from controller.queries import calculate_workspace_state
+from controller.webapp.models import Job
+
+
+def time_func(func, *args, **kwargs):
+    start = time.perf_counter()
+    result = func(*args, **kwargs)
+    elapsed = time.perf_counter() - start
+    return result, elapsed
+
+
+def calculate_workspace_state_qs(backend, workspace):
+    included_qs = Job.objects.filter(
+        workspace=workspace, backend=backend, cancelled=False
+    ).exclude(action="__error__")
+    return included_qs.annotate(
+        latest_pk=Window(
+            expression=FirstValue("pk"),
+            partition_by=["action"],
+            order_by=F("created_at").desc(),
+        )
+    ).filter(pk=F("latest_pk"))
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("backend")
+        parser.add_argument("workspace")
+
+    def handle(self, *args, **options):
+        backend = options["backend"]
+        workspace = options["workspace"]
+
+        old_jobs, old_time = time_func(calculate_workspace_state, backend, workspace)
+        new_jobs, new_time = time_func(calculate_workspace_state_qs, backend, workspace)
+
+        self.stdout.write(f"Original: {len(old_jobs)} jobs, {old_time:.4f} sec")
+        self.stdout.write(f"Queryset: {len(new_jobs)}  jobs, {new_time:.4f} sec")
+        self.stdout.write(f"ratio: {old_time / new_time:.1f}")
+
+        old_ids = {job.id for job in old_jobs}
+        new_ids = {job.id for job in new_jobs}
+        if old_ids == new_ids:
+            self.stdout.write(self.style.SUCCESS("Results match"))
+        else:
+            self.stdout.write(self.style.ERROR("Results differ"))

--- a/controller/webapp/management/commands/compare_calculate_workspace_state.py
+++ b/controller/webapp/management/commands/compare_calculate_workspace_state.py
@@ -37,13 +37,14 @@ class Command(BaseCommand):
         backend = options["backend"]
         workspace = options["workspace"]
 
+        # Compare `calculate_workspace_state` performance.
         old_jobs, old_time = time_func(calculate_workspace_state, backend, workspace)
         new_jobs, new_time = time_func(calculate_workspace_state_qs, backend, workspace)
-
         self.stdout.write(f"Original: {len(old_jobs)} jobs, {old_time:.4f} sec")
-        self.stdout.write(f"Queryset: {len(new_jobs)}  jobs, {new_time:.4f} sec")
+        self.stdout.write(f"Queryset: {len(new_jobs)} jobs, {new_time:.4f} sec")
         self.stdout.write(f"ratio: {old_time / new_time:.1f}")
 
+        # Check we actually get same results.
         old_ids = {job.id for job in old_jobs}
         new_ids = {job.id for job in new_jobs}
         if old_ids == new_ids:

--- a/controller/webapp/models.py
+++ b/controller/webapp/models.py
@@ -1,0 +1,88 @@
+# This is an auto-generated Django model module.
+# You'll have to do the following manually to clean this up:
+#   * Rearrange models' order
+#   * Make sure each model has one field with primary_key=True
+#   * Make sure each ForeignKey and OneToOneField has `on_delete` set to the desired behavior
+#   * Remove `managed = False` lines if you wish to allow Django to create, modify, and delete the table
+# Feel free to rename the models, but don't rename db_table values or field names.
+from django.db import models
+
+
+class Flags(models.Model):
+    pk = models.CompositePrimaryKey("id", "backend")
+    id = models.TextField()
+    value = models.TextField()
+    backend = models.TextField()
+    timestamp = models.TextField()  # This field type is a guess.
+
+    class Meta:
+        managed = False
+        db_table = "flags"
+
+
+class Job(models.Model):
+    id = models.TextField(primary_key=True)
+    job_request_id = models.TextField()
+    state = models.TextField()
+    repo_url = models.TextField()
+    commit = models.TextField()
+    workspace = models.TextField()
+    database_name = models.TextField()
+    action = models.TextField()
+    action_repo_url = models.TextField()
+    action_commit = models.TextField()
+    requires_outputs_from = models.TextField()
+    wait_for_job_ids = models.TextField()
+    run_command = models.TextField()
+    image_id = models.TextField()
+    output_spec = models.TextField()
+    outputs = models.TextField()
+    unmatched_outputs = models.TextField()
+    status_message = models.TextField()
+    status_code = models.TextField()
+    cancelled = models.BooleanField()
+    created_at = models.IntegerField()
+    updated_at = models.IntegerField()
+    started_at = models.IntegerField()
+    completed_at = models.IntegerField()
+    trace_context = models.TextField()
+    status_code_updated_at = models.IntegerField()
+    level4_excluded_files = models.TextField()
+    requires_db = models.BooleanField()
+    backend = models.TextField()
+
+    class Meta:
+        managed = False
+        db_table = "job"
+
+
+class JobRequest(models.Model):
+    id = models.TextField(
+        primary_key=True,
+    )
+    original = models.TextField()
+
+    class Meta:
+        managed = False
+        db_table = "job_request"
+
+
+class Tasks(models.Model):
+    id = models.TextField(
+        primary_key=True,
+    )
+    backend = models.TextField()
+    type = models.TextField()
+    definition = models.TextField()
+    active = models.BooleanField()
+    created_at = models.IntegerField()
+    finished_at = models.IntegerField()
+    attributes = models.TextField()
+    agent_stage = models.TextField()
+    agent_complete = models.BooleanField()
+    agent_results = models.TextField()
+    agent_timestamp_ns = models.IntegerField()
+
+    class Meta:
+        managed = False
+        db_table = "tasks"

--- a/controller/webapp/settings.py
+++ b/controller/webapp/settings.py
@@ -102,7 +102,7 @@ WSGI_APPLICATION = "controller.webapp.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": ":memory:",
+        "NAME": "workdir/db.sqlite",
     }
 }
 


### PR DESCRIPTION
This is a proof-of-concept PR. Don't merge it.

Connect the controller webapp Django framework to the default location of its database and use `inspectdb` to generate some models.

In a management command, reimplement `calculate_workspace_state` using
querysets and a partition approach and compare perfomance with the extant
implementation that uses our homebrew ORM and some manipulation in Python.

Very brief initial profiling shows this as approximately 50 times faster on my
machine when tested against around 2000 jobs/action from the
https://github.com/opensafely/disparities-comparison repo.

This may demonstrate that this function can be optimized sufficiently to use
synchronously. Using the Django ORM may be a viable alternative to
optimizing the homebrew ORM code used. The Django ORM approach can be used
alongside code using the homebrew approach, which could enable a gradual
switchover, if that's where we want to arrive.

Clearly the homebrew-ORM-using code could be optimized further (eg it does some work
in Python that could be off-loaded to the database engine with `FIRST_VALUE`
and `PARTITION`, and I think we know the value-type unpacking is slow). Maybe
there's a better queryset approach, also.

My very brief assessment is that the queryset code needs at most three passes
through the rows, O(n), where the extant approach uses a sub-group and sorting
approach that may be O(n log n) or possibly O(n^2 log n).