### PR TITLE
Add initial configuration and plumbing for restricted datasets

### DIFF
--- a/controller/permissions/datasets.py
+++ b/controller/permissions/datasets.py
@@ -1,0 +1,72 @@
+PERMISSIONS = {
+    # project 37
+    "factors-associated-with-covid-19-vaccination": ["icnarc"],
+    # no project number
+    "immunosuppresant-medication": ["icnarc"],
+    # project 54
+    "school-age-children": ["icnarc"],
+    # project 9
+    "impact-of-covid-19-on-long-term-healthcare-use-and-costs-in-children-and-young-people": [
+        "isaric"
+    ],
+    # project 87
+    "validation-of-the-opensafely-kidney-codes": ["ukrr"],
+    # project 110
+    "covid-19-vaccine-coverage-and-effectiveness-in-chronic-kidney-disease-patients": [
+        "ukrr"
+    ],
+    # project 106
+    "effectiveness-safety-sotrovimab-molnupiravir": ["ukrr"],
+    # project 137
+    "healthcare-needs-for-people-with-chronic-kidney-disease-in-the-covid-19-era": [
+        "ukrr",
+        "appointments",
+    ],
+    # project 154
+    "validation-of-isaric-sus-phosp-data-for-covid-related-hospital-admissions": [
+        "isaric"
+    ],
+    # project 155
+    "the-effect-of-long-covid-on-quality-adjusted-life-years-using-openprompt": [
+        "open_prompt"
+    ],
+    # project 71
+    "openprompt": ["open_prompt"],
+    # project 122
+    "opioid-prescribing-trends-and-changes-during-covid-19": [
+        "wl_clockstops",
+        "wl_clockstops_raw",
+        "wl_openpathways",
+        "wl_openpathways_raw",
+    ],
+    # project 129
+    "curation-of-gp-appointments-data-short-data-report": ["appointments"],
+    # no project number
+    "opensafely-internal": ["appointments"],
+    # project 152
+    "digital-access-to-primary-care-for-older-people-during-covid": ["appointments"],
+    # project 148
+    "the-impact-of-covid-19-on-pregnancy-treatment-pathways-and-outcomes": [
+        "appointments"
+    ],
+    # project 12
+    "investigating-events-following-sars-cov-2-infection": ["appointments"],
+    # project 78
+    "long-term-kidney-outcomes-after-sars-cov-2-infection": ["appointments"],
+    # project 185
+    "investigating-events-following-covid-19": ["appointments"],
+    # project 136
+    "gp-appointments-during-covid": ["appointments"],
+    # project 34
+    "deaths-at-home-during-covid-19": ["appointments"],
+    # project 172
+    "impact-and-inequalities-of-winter-pressures-in-primary-care-providing-the-evidence-base-for-mitigation-strategies": [
+        "appointments"
+    ],
+    # project 178
+    "long-term-complications-after-sars-cov-2-infection-in-relation-to-dialysis-and-kidney-transplantation": [
+        "ukrr"
+    ],
+    # project 175
+    "implications-of-metformin-for-long-covid": ["appointments"],
+}

--- a/controller/permissions/datasets.py
+++ b/controller/permissions/datasets.py
@@ -1,72 +1,116 @@
 PERMISSIONS = {
     # project 37
+    # opensafely/risk-factors-research
     "factors-associated-with-covid-19-vaccination": ["icnarc"],
-    # no project number
-    "immunosuppresant-medication": ["icnarc"],
+    # project None
+    # opensafely/immunosuppressant-meds-research opensafely/with-gp-consultations-curation
+    "opensafely-internal": ["icnarc", "appointments"],
     # project 54
+    # opensafely/school-age-children-and-covid
     "school-age-children": ["icnarc"],
     # project 9
+    # opensafely/hdruk-os-covid-paeds
     "impact-of-covid-19-on-long-term-healthcare-use-and-costs-in-children-and-young-people": [
         "isaric"
     ],
     # project 87
+    # opensafely/renal-short-data-report
     "validation-of-the-opensafely-kidney-codes": ["ukrr"],
     # project 110
+    # opensafely/ckd-coverage-ve
     "covid-19-vaccine-coverage-and-effectiveness-in-chronic-kidney-disease-patients": [
         "ukrr"
     ],
     # project 106
+    # opensafely/sotrovimab-and-molnupiravir
     "effectiveness-safety-sotrovimab-molnupiravir": ["ukrr"],
     # project 137
+    # opensafely/ckd-healthcare-use
+    # ambiguous from repo alone
     "healthcare-needs-for-people-with-chronic-kidney-disease-in-the-covid-19-era": [
-        "ukrr",
         "appointments",
+        "ukrr",
+    ],
+    # project 171
+    # opensafely/ckd-healthcare-use
+    # ambiguous from repo alone
+    "healthcare-needs-for-people-with-chronic-kidney-disease-in-the-covid-19-era-project-continuation-of-approved-project-no-137": [
+        "appointments",
+        "ukrr",
     ],
     # project 154
+    # opensafely/isaric-exploration
     "validation-of-isaric-sus-phosp-data-for-covid-related-hospital-admissions": [
         "isaric"
     ],
     # project 155
+    # opensafely/openprompt-hrqol
     "the-effect-of-long-covid-on-quality-adjusted-life-years-using-openprompt": [
         "open_prompt"
     ],
     # project 71
+    # opensafely/openprompt-cohort-profile
     "openprompt": ["open_prompt"],
     # project 122
+    # opensafely/waiting-list
     "opioid-prescribing-trends-and-changes-during-covid-19": [
-        "wl_clockstops",
+        "wl_openpathways_raw",
         "wl_clockstops_raw",
         "wl_openpathways",
-        "wl_openpathways_raw",
+        "wl_clockstops",
     ],
     # project 129
+    # opensafely/appointments-short-data-report
     "curation-of-gp-appointments-data-short-data-report": ["appointments"],
-    # no project number
-    "opensafely-internal": ["appointments"],
     # project 152
+    # opensafely/digital-access-to-primary-care
     "digital-access-to-primary-care-for-older-people-during-covid": ["appointments"],
     # project 148
+    # opensafely/uom_pregnancy_tx_pathways
+    # ambiguous from repo alone
     "the-impact-of-covid-19-on-pregnancy-treatment-pathways-and-outcomes": [
         "appointments"
     ],
+    # project 166
+    # opensafely/uom_pregnancy_tx_pathways
+    # ambiguous from repo alone
+    "the-impact-of-covid-19-on-pregnancy-treatment-pathways-and-outcomes-project-continuation-of-approved-project-no-148": [
+        "appointments"
+    ],
     # project 12
+    # opensafely/post-covid-renal opensafely/post-covid-autoimmune opensafely/post-covid-neurodegenerative opensafely/post-covid-cvd opensafely/post-covid-cvd-methods opensafely/post-covid-respiratory
+    # ambiguous from repo alone
     "investigating-events-following-sars-cov-2-infection": ["appointments"],
-    # project 78
-    "long-term-kidney-outcomes-after-sars-cov-2-infection": ["appointments"],
     # project 185
+    # opensafely/post-covid-renal opensafely/post-covid-neurodegenerative opensafely/post-covid-cvd opensafely/post-covid-cvd-methods opensafely/post-covid-respiratory
+    # ambiguous from repo alone
     "investigating-events-following-covid-19": ["appointments"],
+    # project 78
+    # opensafely/post-covid-kidney-outcomes
+    "long-term-kidney-outcomes-after-sars-cov-2-infection": ["appointments"],
+    # project 156
+    # opensafely/post-covid-cvd opensafely/post-covid-cvd-methods
+    # ambiguous from repo alone
+    "investigating-events-following-sars-cov-2-infection-project-continuation-of-approved-project-no-12": [
+        "appointments"
+    ],
     # project 136
+    # opensafely/winter-pressures
+    # ambiguous from repo alone
     "gp-appointments-during-covid": ["appointments"],
-    # project 34
-    "deaths-at-home-during-covid-19": ["appointments"],
     # project 172
+    # opensafely/winter-pressures opensafely/winter-pressures-phase-II
+    # ambiguous from repo alone
     "impact-and-inequalities-of-winter-pressures-in-primary-care-providing-the-evidence-base-for-mitigation-strategies": [
         "appointments"
     ],
-    # project 178
-    "long-term-complications-after-sars-cov-2-infection-in-relation-to-dialysis-and-kidney-transplantation": [
-        "ukrr"
-    ],
+    # project 34
+    # opensafely/deaths-at-home-covid19 opensafely/end-of-life-carequality
+    "deaths-at-home-during-covid-19": ["appointments"],
     # project 175
+    # opensafely/metformin_covid
     "implications-of-metformin-for-long-covid": ["appointments"],
+    # project UNKNOWN
+    # opensafely/ckd-post-covid-outcomes
+    "opensafely/ckd-post-covid-outcomes": ["ukrr"],
 }


### PR DESCRIPTION
The initial permissions configuration is taken from the current yaml
config in opensafely cli, with a number of changes made to match the way
t1oo's work in job-server, which is where we intended this config to
live long term.

 - key by project rather than repo
 - use project slug rather than number, as job-runner doesn't know that.
 - use python rather than yaml

Have used the names of the tables as defined in opensafely-cli for now,
we may want to change the string values once we know what they will be.

The plumbing is fairly straightforward, it just sets a job env var with
the values of any permitted tables as a comma separate string for ehrql
to parse.

Lots of design discussion here: https://bennettoxford.slack.com/archives/C069YDR4NCA/p1752683993581859
