### PR TITLE
Use lookup table to find new jobs.

### DIFF
--- a/controller/create_or_update_jobs.py
+++ b/controller/create_or_update_jobs.py
@@ -206,7 +206,8 @@ def get_new_jobs_to_run(job_request, pipeline_config, current_jobs):
         recursively_build_jobs(jobs_by_action, job_request, pipeline_config, action)
 
     # Pick out the new jobs we've added and return them
-    return [job for job in jobs_by_action.values() if job not in current_jobs]
+    current_job_ids = {job.id for job in current_jobs}
+    return [job for job in jobs_by_action.values() if job.id not in current_job_ids]
 
 
 def get_actions_to_run(job_request, pipeline_config):


### PR DESCRIPTION
This is more time-efficient.

The list comprehension in `get_new_jobs_to_run` is almost all of the execution time of `get_latest_jobs_for_actions_in_project`. Repeatedly checking if list items are present in another list requires repeatedly traversing the other list and doing many comparison operations.

That approach grew with the product of the length of the lists (roughly quadratic). This approach grows additively with the lengths as each lookup takes constant time (roughly linear overall).

In local testing, this reduces the `get_new_jobs_to_run` execution time with 2k jobs from 5.2s to 0.485s (90% speedup).

Relates to #1105. Don't merge until telemetry is in place and has run for a bit.