### PR TITLE
Use lookup table to check if actions are in the pipeline

### DIFF
--- a/controller/create_or_update_jobs.py
+++ b/controller/create_or_update_jobs.py
@@ -182,10 +182,11 @@ def get_project_file(job_request):
 
 
 def get_latest_jobs_for_actions_in_project(backend, workspace, pipeline_config):
+    pipeline_actions = {action for action in pipeline_config.all_actions}
     return [
         job
         for job in calculate_workspace_state(backend, workspace)
-        if job.action in pipeline_config.all_actions
+        if job.action in pipeline_actions
     ]
 
 


### PR DESCRIPTION
Fixes #1120.

This is more time-efficient.

The list comprehension in `get_latest_jobs_for_actions_in_project` is about a third of the execution time for large workspaces. Repeatedly checking if list items are present in another list requires repeatedly traversing the other list and doing many comparison operations.

That approach grew with the product of the length of the two lists, and the execution time of `all_actions`, which is an `@property` function (roughly cubic as those inputs grow). The new approach grows additively with the lengths
as `all_actions` is only called once then stored in a set, so each individual lookup takes constant time (roughly linear overall).

Creating 2082 jobs with a local copy of the production database for workspace https://jobs.opensafely.org/comparing-disparities-in-rsv-influenza-and-covid-19/disparities-comparison-rsv-flu-c19/ with hundreds of thousands of past jobs. The execution time averages around 2s, of which about 33% (650ms) is the list comprehension and almost all the rest is `calculate_workspace_state`.

Changing the list comprehension to use a lookup table removes almost all of that execution time so the functions runs in about 1.3s, almost all (>98%) of which comes from `calculate_workspace_state`.