### PR TITLE
Cache reusable actions when creating jobs

### DIFF
--- a/controller/reusable_actions.py
+++ b/controller/reusable_actions.py
@@ -46,9 +46,12 @@ def resolve_reusable_action_references(jobs):
     Raises:
         ReusableActionError
     """
+    reusable_action_cache = dict()
     for job in jobs:
         try:
-            run_command, repo_url, commit = handle_reusable_action(job.run_command)
+            run_command, repo_url, commit = handle_reusable_action(
+                job.run_command, reusable_action_cache
+            )
         except ReusableActionError as e:
             # Annotate the exception with the context of the action in which it
             # occured
@@ -59,7 +62,7 @@ def resolve_reusable_action_references(jobs):
         job.action_commit = commit
 
 
-def handle_reusable_action(run_command):
+def handle_reusable_action(run_command, reusable_action_cache):
     """
     If `run_command` refers to a reusable action then rewrite it appropriately
     and return it along with the repo_url and commit of the reusable action.
@@ -82,8 +85,13 @@ def handle_reusable_action(run_command):
     if image in config.ALLOWED_IMAGES:
         # This isn't a reusable action, nothing to do
         return run_command, None, None
+    try:
+        reusable_action = reusable_action_cache[(image, tag)]
+    except KeyError:
+        # First time seeing this reusable action
+        reusable_action = fetch_reusable_action(image, tag)
+        reusable_action_cache[(image, tag)] = reusable_action
 
-    reusable_action = fetch_reusable_action(image, tag)
     new_run_args = apply_reusable_action(run_args, reusable_action)
     new_run_command = shlex.join(new_run_args)
     return new_run_command, reusable_action.repo_url, reusable_action.commit


### PR DESCRIPTION
This is a lot faster when the pipeline contains many instance of the same reusable action, as it involves only one remote git call per `(image, tag)`, instead of one per use of each action.

WIP

There is only one distinct reusable actions in this project:

```
{job.run_command.split(':')[0] for job in jobs}
{'r', 'ehrql', 'cox-ipw'}
```

... but we call `fetch_reusable_action` once per action that reuses it, 560 times, taking around 20 minutes. Almost all of which is waiting for the remote API.

```
2025-07-31 16:30:33.669Z Created 1149 new jobs 
real	19m36.062s
user	0m38.433s
```

(local dev example against [post-covid-cvd-v2](https://jobs.opensafely.org/investigating-events-following-covid-19/post-covid-cvd-v2/) which resulted in a >6m trace [here](https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/datasets/rap-controller/result/eePb4YksASf/trace/z1iiVNH5D93?fields[]=s_name&fields[]=s_serviceName&source=query&span=9078a452479c459f), but in a different workspace)

We can instead fetch it once and cache it by `(image, tag)`, resulting in only 1 call, taking a more reasonable <1 second spent on `fetch_reusable_action`:

```
2025-07-31 16:30:33.669Z Created 1149 new jobs 
real	0m6.588s
user	0m5.479s
```

This is caching in within a resolve_reusable_action_references call. If it's acceptable to only do this once between requests (guaranteed not to change) we could also cache this at module-level.