### PR TITLE
Update dotenv-sample client token to match job-server

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -61,7 +61,8 @@ TEST_JOB_SERVER_TOKEN=pass
 # and is a comma-separated list of client tokens that are allowed to access information
 # about this backend. These may be duplicated for clients that can request information about
 # multiple backends.
-TEST_CLIENT_TOKENS=token
+# Note: this corresponds to RAP_API_TOKEN in job-server
+TEST_CLIENT_TOKENS=rap_token
 
 # Change this to reduce parallelism (per backend)
 # Note this variable is per-backend i.e. <BACKEND>_MAX_WORKERS for each backend


### PR DESCRIPTION
In a local environment running job-server and the rap controller together, <BACKEND>_CLIENT_TOKENS must match the value of job-server's RAP_API_TOKEN in order for job-server to be able to authenticate with the controller.