### PR TITLE
Add logging config for the webapp

### DIFF
--- a/controller/webapp/settings.py
+++ b/controller/webapp/settings.py
@@ -147,3 +147,41 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "default": {
+            "format": "{asctime} web  {message}",
+            "datefmt": "%Y-%m-%d %H:%M:%S.%03dZ",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "console": {"class": "logging.StreamHandler", "formatter": "default"},
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": os.environ.get("LOGLEVEL", "INFO"),
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": os.environ.get("DJANGO_LOG_LEVEL", default="INFO"),
+            "propagate": False,
+        },
+        "gunicorn.access": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "gunicorn.error": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "webapp": {"handlers": ["console"], "level": "INFO", "propagate": False},
+    },
+}

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -50,7 +50,7 @@ def test_handle_tasks_executor_error(db, caplog, responses, live_server, monkeyp
     assert spans[1].attributes["handled_tasks"] == 1
     assert spans[1].attributes["errored_tasks"] == 1
 
-    assert caplog.records[0].msg == "task error"
+    assert caplog.records[-1].msg == "task error"
 
 
 @pytest.mark.parametrize(
@@ -86,7 +86,7 @@ def test_handle_tasks_github_validation(
     with pytest.raises(Exception, match=msg):
         main.handle_tasks(api)
 
-    assert exc_msg in str(caplog.records[0].exc_info[1])
+    assert exc_msg in str(caplog.records[-1].exc_info[1]), caplog.records
 
 
 def test_handle_job_full_execution(


### PR DESCRIPTION
Format matches the agent/controller/sync format (see `common/lib/log_utils.py`)

I've added basic loggers (django, guinicorn and the webapp); open to suggestions about what logging config we actually want though

Fixes #1156 