### PR TITLE
Local dev improvements

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -122,7 +122,15 @@ just add-job ../test-age-distribution run_all --backend test
 ```
 
 In order to pick up and execute the job, you need to run the three job-runner
-components. In separate terminal windows, run:
+components.
+
+```
+just run
+```
+
+This will run all 3 components together. If you need to run only a subset, or you want to run
+them separately (e.g. to more easily see what each component is logging), you can run them each
+in separate terminal windows:
 
 ```
 # Controller service
@@ -136,7 +144,8 @@ just run-agent
 ```
 
 You should see the controller pick up the new job and create a RUNJOB task for it.
-In the controller app terminal, you'll see the agent poll for new tasks every second or so.
+Then you'll see the agent poll for new tasks every second or so (in the In the controller app terminal,
+if you're running the services separately).
 Then the agent will receive the new task, execute the job, and call the controller app
 to update the controller after each step.
 

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -47,9 +47,8 @@ CONTROLLER_TASK_API_ENDPOINT=http://localhost:3000/
 # USED BY CONTROLLER ONLY
 #########################
 # The endpoint to poll for jobs
-# JOB_SERVER_ENDPOINT=http://jobs.opensafely.org/api/v2/
-# If using a local job-server, running on port 8000
-JOB_SERVER_ENDPOINT=https://localhost:8000/api/v2/
+# If using a local job-server, running on port 8000:
+JOB_SERVER_ENDPOINT=http://localhost:8000/api/v2/
 
 # Credentials for authenticating with job server
 # Note this variable is per-backend i.e. <BACKEND>_JOB_SERVER_TOKEN for each backend

--- a/justfile
+++ b/justfile
@@ -186,8 +186,17 @@ run-agent-service: devenv
 run-controller-service: devenv
     $BIN/python -m controller.service
 
+_run-agent-after-app:
+    #!/usr/bin/env bash
+    while [[  $(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000) == "000" ]]; do
+        echo "Waiting for web app to start..."
+        sleep 1
+    done;
+    just run-agent-service
+
+# Run all services together
 run:
-    { just run-app & just run-agent-service & just run-controller-service; }
+    { just run-app & just _run-agent-after-app & just run-controller-service; }
 
 validate-api-spec: devenv
     $BIN/openapi-spec-validator controller/webapp/api_spec/openapi.yaml


### PR DESCRIPTION
Update docs for `just run`
Make `just run` wait for the web app before running the agent so it does actually run all 3 services instead of bailing on the agent.
s/https/http in dotenv localhost url 