### PR TITLE
Return run_command as '' instead of None for run_all jobs

### DIFF
--- a/controller/webapp/views/rap_views.py
+++ b/controller/webapp/views/rap_views.py
@@ -359,7 +359,7 @@ def job_to_api_format(job):
         "rap_id": job.job_request_id,
         "backend": job.backend,
         "action": job.action,
-        "run_command": job.run_command,
+        "run_command": job.run_command or "",
         "status": job.state.value,
         "status_code": job.status_code.value,
         "status_message": job.status_message or "",


### PR DESCRIPTION
* The db schema on job-server does not allow a null value for the
  run_command, so by returning the empty string we can make the
  client code a little simpler
* this is also consistent what the previous run loop implementation
  did - for reasons which I had not got to the bottom of
* the api spec does say that this field is a string, so `None` isn't ideal