### PR TITLE
Stop `sync` cancelling jobs for `test` backend.

### DIFF
--- a/controller/create_or_update_jobs.py
+++ b/controller/create_or_update_jobs.py
@@ -45,6 +45,10 @@ class NothingToDoError(JobRequestError):
     pass
 
 
+# Special case for the RAP API v2 initiative.
+SKIP_CANCEL_FOR_BACKEND = "test"
+
+
 def create_or_update_jobs(job_request):
     """
     Create or update Jobs in response to a JobRequest
@@ -73,10 +77,14 @@ def create_or_update_jobs(job_request):
             create_job_from_exception(job_request, JobRequestError("Internal error"))
     else:
         if job_request.cancelled_actions:
-            log.debug("Cancelling actions: %s", job_request.cancelled_actions)
-            set_cancelled_flag_for_actions(
-                job_request.id, job_request.cancelled_actions
-            )
+            if job_request.backend == SKIP_CANCEL_FOR_BACKEND:
+                # Special case for the RAP API v2 initiative.
+                log.debug("Not cancelling actions as backend is set to skip")
+            else:
+                log.debug("Cancelling actions: %s", job_request.cancelled_actions)
+                set_cancelled_flag_for_actions(
+                    job_request.id, job_request.cancelled_actions
+                )
         else:
             log.debug("Ignoring already processed JobRequest")
 

--- a/tests/controller/test_create_or_update_jobs.py
+++ b/tests/controller/test_create_or_update_jobs.py
@@ -316,6 +316,9 @@ def test_run_all_ignores_failed_actions_that_have_been_removed(tmp_work_dir):
 def test_cancelled_jobs_are_flagged(tmp_work_dir):
     job_request = make_job_request(action="analyse_data")
     create_jobs_with_project_file(job_request, TEST_PROJECT)
+    # Special case for the RAP API v2 initiative.
+    # Without this nothing would be cancelled due to backend being test.
+    job_request.backend = "not test"
     job_request.cancelled_actions = ["prepare_data_1", "prepare_data_2"]
     create_or_update_jobs(job_request)
     analyse_job = find_one(Job, action="analyse_data")
@@ -325,6 +328,22 @@ def test_cancelled_jobs_are_flagged(tmp_work_dir):
     assert analyse_job.cancelled == 0
     assert prepare_1_job.cancelled == 1
     assert prepare_2_job.cancelled == 1
+    assert generate_job.cancelled == 0
+
+
+def test_cancelled_test_jobs_are_not_flagged(tmp_work_dir):
+    # Special case for the RAP API v2 initiative.
+    job_request = make_job_request(action="analyse_data")
+    create_jobs_with_project_file(job_request, TEST_PROJECT)
+    job_request.cancelled_actions = ["prepare_data_1", "prepare_data_2"]
+    create_or_update_jobs(job_request)
+    analyse_job = find_one(Job, action="analyse_data")
+    prepare_1_job = find_one(Job, action="prepare_data_1")
+    prepare_2_job = find_one(Job, action="prepare_data_2")
+    generate_job = find_one(Job, action="generate_dataset")
+    assert analyse_job.cancelled == 0
+    assert prepare_1_job.cancelled == 0
+    assert prepare_2_job.cancelled == 0
     assert generate_job.cancelled == 0
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -79,6 +79,9 @@ def set_controller_config(monkeypatch):
     for config_var in config_vars:
         monkeypatch.setattr(f"agent.config.{config_var}", None)
 
+    # Special case for the RAP API v2 initiative.
+    monkeypatch.setattr("controller.create_or_update_jobs.SKIP_CANCEL_FOR_BACKEND", "")
+
 
 @pytest.mark.slow_test
 @pytest.mark.needs_docker


### PR DESCRIPTION
Towards RAP API v2. Now that the Job Server UI can be used to cancel `test` jobs via `webapp`, the synchronisation loop does not need to. This allows us to test the RAP API cancel without any use of the loop, end to end. 

If this works well we will eventually do the same for all backends, deleting the code path.

Partially fixes https://github.com/opensafely-core/job-runner/issues/1167