### PR TITLE
Use JSON to encode ehrQL permissions

### DIFF
--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -917,15 +917,17 @@ def test_job_definition_ehrql_event_level_access(db, monkeypatch, repo_url, expe
     job_definition = main.job_to_job_definition(job, task_id="")
     if expect_env:
         assert job_definition.env["EHRQL_ENABLE_EVENT_LEVEL_QUERIES"] == "True"
+        assert job_definition.env["EHRQL_PERMISSIONS"] == '["event_level_data"]'
     else:
         assert "EHRQL_ENABLE_EVENT_LEVEL_QUERIES" not in job_definition.env
+        assert job_definition.env["EHRQL_PERMISSIONS"] == "[]"
 
 
 @pytest.mark.parametrize(
     "project,expected_env",
     [
-        ("project-with-no-permissions", ""),
-        ("project-with-some-permissions", "table1,table2"),
+        ("project-with-no-permissions", "[]"),
+        ("project-with-some-permissions", '["table1", "table2"]'),
     ],
 )
 def test_job_definition_ehrql_permissions(db, monkeypatch, project, expected_env):


### PR DESCRIPTION
This is instead of a comma-separated list. At present permissions are just lists of strings but we want to leave open the possibility of passing more complex structured data. Plus, using a "real" encoding seems better for this purpose than DIYing it, however simple the current implementation is.

We also include Event Level Data access in the permissions list, as well as setting the appropriate environment variable. Once ehrQL is updated we can drop the extra environment variable which gives us a much cleaner API.