### PR TITLE
Remove unused env var from ehrQL jobs

### DIFF
--- a/controller/main.py
+++ b/controller/main.py
@@ -346,10 +346,6 @@ def job_to_job_definition(job, task_id):
         permissions = datasets.PERMISSIONS.get(job_request["project"], [])
         if job.repo_url in config.REPOS_WITH_EHRQL_EVENT_LEVEL_ACCESS:
             permissions = [*permissions, "event_level_data"]
-            # We currently still set this env var because ehrQL has yet to be updated to
-            # handle ELD via the generic permissions system. Once it has been updated
-            # this can be removed.
-            env["EHRQL_ENABLE_EVENT_LEVEL_QUERIES"] = "True"
         env["EHRQL_PERMISSIONS"] = json.dumps(permissions)
 
     # we need branch information, which is currently only in the original job

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -916,10 +916,8 @@ def test_job_definition_ehrql_event_level_access(db, monkeypatch, repo_url, expe
     job = job_factory(requires_db=True, repo_url=repo_url)
     job_definition = main.job_to_job_definition(job, task_id="")
     if expect_env:
-        assert job_definition.env["EHRQL_ENABLE_EVENT_LEVEL_QUERIES"] == "True"
         assert job_definition.env["EHRQL_PERMISSIONS"] == '["event_level_data"]'
     else:
-        assert "EHRQL_ENABLE_EVENT_LEVEL_QUERIES" not in job_definition.env
         assert job_definition.env["EHRQL_PERMISSIONS"] == "[]"
 
 


### PR DESCRIPTION
As the below PR is now merged and deployed this env var is no longer read:
 * https://github.com/opensafely-core/ehrql/pull/2552