### PR TITLE
Don't cancel jobs in sync loop.

### DIFF
--- a/controller/create_or_update_jobs.py
+++ b/controller/create_or_update_jobs.py
@@ -44,27 +44,6 @@ class NothingToDoError(JobRequestError):
     pass
 
 
-# Special case for the RAP API v2 initiative.
-SKIP_CANCEL_FOR_BACKEND = "test"
-
-
-def update_cancelled_jobs(job_request):
-    """
-    Update cancelled Jobs in response to a JobRequest
-    """
-    if (
-        related_jobs_exist(job_request) and job_request.cancelled_actions
-    ):  # pragma: no branch
-        if job_request.backend == SKIP_CANCEL_FOR_BACKEND:
-            # Special case for the RAP API v2 initiative.
-            log.debug("Not cancelling actions as backend is set to skip")
-        else:
-            log.debug("Cancelling actions: %s", job_request.cancelled_actions)
-            set_cancelled_flag_for_actions(
-                job_request.id, job_request.cancelled_actions
-            )
-
-
 def create_jobs(job_request):
     with tracer.start_as_current_span(
         "create_jobs", attributes=job_request.get_tracing_span_attributes()

--- a/controller/sync.py
+++ b/controller/sync.py
@@ -11,10 +11,9 @@ import requests
 from opentelemetry import trace
 
 from common import config as common_config
-from common.lib.log_utils import configure_logging, set_log_context
+from common.lib.log_utils import configure_logging
 from common.tracing import duration_ms_as_span_attr
 from controller import config
-from controller.create_or_update_jobs import update_cancelled_jobs
 from controller.models import JobRequest
 
 
@@ -62,11 +61,6 @@ def sync_backend(backend):
         # Bail early if there's nothing to do
         if not job_requests:
             return
-
-        with duration_ms_as_span_attr("create.duration_ms", span):
-            for job_request in job_requests:
-                with set_log_context(job_request=job_request):
-                    update_cancelled_jobs(job_request)
 
 
 def api_get(*args, backend, **kwargs):

--- a/tests/controller/test_sync.py
+++ b/tests/controller/test_sync.py
@@ -198,6 +198,5 @@ def test_sync_telemetry(db, monkeypatch, responses, test_repo):
     for attribute in [
         "api_get.duration_ms",
         "parse_requests.duration_ms",
-        "create.duration_ms",
     ]:
         assert attribute in span.attributes


### PR DESCRIPTION
We have tested sufficiently against the test backend in production using the Job Server route so can disable this in general now.

We should merge https://github.com/opensafely-core/job-server/pull/5376 before this so that there is a route to cancel any job. It is okay to cancel the same action multiple times.

fixes #1167