### PR TITLE
Remove references to the now unused JOBSERVER_API_ENDPOINT and POLL_INTERVAL

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -69,6 +69,10 @@ space to exclude from bash history):
   TPP_JOB_SERVER_TOKEN='[XXXXX]'
   TEST_JOB_SERVER_TOKEN='[XXXXX]'
 
+  # These allow job-server to call the RAP API; they should correspond to job-server's `RAP_API_TOKEN`
+  TEST_CLIENT_TOKENS='[XXXXX]'
+  TPP_CLIENT_TOKENS='[XXXXX]'
+
   # Get these from Bitwarden:
   PRIVATE_REPO_ACCESS_TOKEN='[XXXXX]'
   STATA_LICENSE='[XXXXX]'
@@ -91,7 +95,6 @@ config=(
   BACKENDS=tpp,test
 
   # Loop timings taken from current TPP backend settings
-  POLL_INTERVAL=60
   JOB_LOOP_INTERVAL=5.0
 
   # TPP specific config taken from current backend settings
@@ -102,10 +105,6 @@ config=(
 
   # Service specific honeycomb dataset name
   OTEL_SERVICE_NAME=rap-controller
-
-  # This is the default values in the codebase, but it seems clearer
-  # to set it explicitly here
-  JOB_SERVER_ENDPOINT=https://jobs.opensafely.org/api/v2/
 )
 ```
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -190,12 +190,14 @@ Ensure that the following variables are set in your `.env` file:
 # TEST_JOB_SERVER_TOKEN is used by the Controller when communicating with job-server
 CONTROLLER_TASK_API_TOKEN=<token obtained from local job-server for the test backend>
 TEST_JOB_SERVER_TOKEN=<token obtained from local job-server for the test backend>
+# This is a comma-separated list of tokens that can access the backend called "test" using
+# The RAP API; it should correspond to `RAP_API_TOKEN` inyour local job-server.
+TEST_CLIENT_TOKENS=<tokens>
 
 # These are all set by default in dotenv-sample
 BACKENDS=test
 BACKEND=test
 CONTROLLER_TASK_API_ENDPOINT=http://localhost:3000/
-JOB_SERVER_ENDPOINT=https://localhost:8000/api/v2/
 ```
 
 #### Run all the things

--- a/controller/config.py
+++ b/controller/config.py
@@ -16,10 +16,6 @@ DATABASE_FILE = common_config.WORKDIR / "db.sqlite"
 
 BACKUPS_PATH = Path(os.environ.get("BACKUPS_PATH", common_config.WORKDIR / "backups"))
 
-JOB_SERVER_ENDPOINT = os.environ.get(
-    "JOB_SERVER_ENDPOINT", "https://jobs.opensafely.org/api/v2/"
-)
-
 JOB_SERVER_TOKENS = {
     backend: os.environ.get(f"{backend.upper()}_JOB_SERVER_TOKEN", "token")
     for backend in common_config.BACKENDS

--- a/controller/main.py
+++ b/controller/main.py
@@ -687,7 +687,7 @@ def update_scheduled_task_for_db_maintenance_for_backend(backend):
     ):
         return
 
-    # If there's a task that was completed within POLL_INTERVAL seconds of now then
+    # If there's a task that was completed within MAINTENANCE_POLL_INTERVAL seconds of now then
     # there's nothing to do
     cutoff_time = int(time.time() - config.MAINTENANCE_POLL_INTERVAL)
     if exists_where(

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -113,9 +113,6 @@ services:
       DJANGO_CONTROLLER_SECRET_KEY: 12345789abcdefghi
       DJANGO_CONTROLLER_ALLOWED_HOSTS: "*"
       DJANGO_DEBUG: "False"
-      # Point it at a "reserved for future use" IP which just hangs and does
-      # nothing as we want
-      JOB_SERVER_ENDPOINT: "http://240.0.0.1"
     volumes:
       - ${TMP_WORKDIR:-/tmp/jobrunner-workdir}:/workdir
 

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -42,13 +42,8 @@ CONTROLLER_TASK_API_ENDPOINT=http://localhost:3000/
 
 # USED BY CONTROLLER ONLY
 #########################
-# The endpoint to poll for jobs
-# If using a local job-server, running on port 8000:
-JOB_SERVER_ENDPOINT=http://localhost:8000/api/v2/
-
-# Credentials for authenticating with job server
+# Credentials for authenticating Agents
 # Note this variable is per-backend i.e. <BACKEND>_JOB_SERVER_TOKEN for each backend
-# If using a local jobserver, obtain the token from http://localhost:8000/staff/backends
 TEST_JOB_SERVER_TOKEN=pass
 
 # Credentials for clients (e.g. job-server) to authenticate with the controller APIs

--- a/tests/controller/test_service.py
+++ b/tests/controller/test_service.py
@@ -15,13 +15,8 @@ def test_service_main(tmp_path):
 
     p = subprocess.Popen(
         [sys.executable, "-m", "controller.service"],
-        # For the purposes of this test we don't care if we can actually talk
-        # to the job-server endpoint, so to avoid spamming the real job-server
-        # we just point it to a "reserved for future use" IP4 block which hangs
-        # nicely as we want.
         env={
             "WORKDIR": str(tmp_path),
-            "JOB_SERVER_ENDPOINT": "https://240.0.0.1",
         },
     )
     assert p.returncode is None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,7 +38,6 @@ def set_agent_config(monkeypatch, tmp_work_dir):
     # e.g. MAX_WORKERS is based on BACKENDS so will always be populated for each
     # backend, with the default value. We set it explicitly here to confirm that it
     # doesn't trigger any errors if it is invalid for the agent i.e. it's not used)
-    monkeypatch.setattr("controller.config.JOB_SERVER_ENDPOINT", None)
     monkeypatch.setattr("controller.config.MAX_WORKERS", None)
 
     # This is controller config, but we need it to be set during the agent part of the
@@ -48,9 +47,6 @@ def set_agent_config(monkeypatch, tmp_work_dir):
 
 def set_controller_config(monkeypatch):
     # set controller config
-    monkeypatch.setattr(
-        "controller.config.JOB_SERVER_ENDPOINT", "http://testserver/api/v2/"
-    )
     monkeypatch.setattr("controller.config.JOB_SERVER_TOKENS", {"test": "token"})
     # Ensure that we have enough workers to start the jobs we expect in the test
     # (CI may have fewer actual available workers than this)


### PR DESCRIPTION
The controller no longer calls job server for anything.

Note: this doesn't deal with the confusingly named JOB_SERVER_TOKENS (see https://github.com/opensafely-core/job-runner/issues/1234)