### PR TITLE
Increase timeout for docker pull

### DIFF
--- a/agent/lib/docker.py
+++ b/agent/lib/docker.py
@@ -29,6 +29,12 @@ LABEL = "job-runner"
 # Docker. (Timeout value is in seconds.)
 DEFAULT_TIMEOUT = 5 * 60
 
+# Pulls of large images (especially from inside the secure env via the proxy) can
+# sometimes take a significant amount of time. We want some form of timeout here to
+# catch cases where something hangs indefinitely, but it needs to be much larger than
+# the default.
+IMAGE_PULL_TIMEOUT = 20 * 60
+
 
 class DockerTimeoutError(Exception):
     pass
@@ -255,7 +261,11 @@ def ensure_docker_sha_present(proxy_image_with_sha, registry_image_with_label):
     """Pull the image sha via the proxy."""
 
     # ensure the image/sha is present
-    docker(["pull", "--quiet", proxy_image_with_sha], check=True)
+    docker(
+        ["pull", "--quiet", proxy_image_with_sha],
+        check=True,
+        timeout=IMAGE_PULL_TIMEOUT,
+    )
 
     proxy_image_with_label, _, _ = proxy_image_with_sha.partition("@")
 


### PR DESCRIPTION
This [job request](https://jobs.opensafely.org/openpregnosis-developing-an-open-algorithm-to-identify-pregnancy-episodes-and-outcomes-in-opensafely/openpregnosis_main/25303/) was submitted after #1241 was merged; the first 2 ehrql jobs ran successfully, but the `analyze_diagnostic_event_counts` R action has been getting a docker timeout error on pulling the R image: 
https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/result/o78kwMML4Bh

The R image does take a while to pull (~3 mins locally for me, and almost certainly slower on tpp), so increasing the default timeout for the pull command.

Related discussion, including link to the incident thread:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1762245117527689