### PR TITLE
Add breadcrumbs linking token names to env vars

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -73,8 +73,11 @@ space to exclude from bash history):
   TEST_CLIENT_TOKENS='[XXXXX]'
   TPP_CLIENT_TOKENS='[XXXXX]'
 
-  # Get these from Bitwarden:
+  # This is a token called `rap-controller-token` belonging to the `opensafely-readonly`
+  # Github user. The token is not stored anywhere else but login details for the user
+  # are in Bitwarden so the token can be regenerated.
   PRIVATE_REPO_ACCESS_TOKEN='[XXXXX]'
+  # This is stored in Bitwarden
   STATA_LICENSE='[XXXXX]'
 
   # Use the "jobrunner" key from:

--- a/common/config.py
+++ b/common/config.py
@@ -39,6 +39,14 @@ GIT_REPO_DIR = WORKDIR / "repos"
 GITHUB_PROXY_DOMAIN = os.environ.get(
     "GITHUB_PROXY_DOMAIN", "github-proxy.opensafely.org"
 )
+# This is a token belonging to the `opensafely-readonly` Github user:
+#
+#  * the controller uses a token called `rap-controller-token`
+#  * the agents use tokens called `rap-agent-token-<backend>` e.g.
+#    `rap-agent-token-tpp`
+#
+# The tokens are not stored anywhere else, but login details for the user are in
+# Bitwarden so they can be regenerated.
 PRIVATE_REPO_ACCESS_TOKEN = os.environ.get("PRIVATE_REPO_ACCESS_TOKEN", "")
 
 # Used by the controller to validate database name passed in a job request


### PR DESCRIPTION
Given an arbitrary Github token that's about to expire we want to be able to search across all repos to find where it is used.