### PR TITLE
Add emistest to default BACKENDS

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 # A list of known available backends
 # The controller uses this to validate each job is from a known backend
 # The agent uses it to validate its BACKEND config
-BACKENDS = os.environ.get("BACKENDS", "test,tpp,emis,ted").strip().split(",")
+BACKENDS = os.environ.get("BACKENDS", "test,tpp,emis,ted,emistest").strip().split(",")
 
 # Used for tracing in both agent and controller
 # This refers to a file created in the docker image by Dockerfile


### PR DESCRIPTION
For the test EMIS backend. The agent uses this to validate its BACKEND config is an allowed value.