### PR TITLE
Add user-facing message for ehrQL timeout errors

### DIFF
--- a/controller/config.py
+++ b/controller/config.py
@@ -178,6 +178,10 @@ DATABASE_EXIT_CODES = {
     11: "There was a problem reading one of the supplied data files",
     12: "You do not have the required permissions for the ehrQL you are trying to run",
     13: "Assurance tests failed; please confirm the tests pass locally",
+    14: (
+        "Your job was making such slow progress that it was unlikely to complete "
+        "successfully; please contact tech support so we can help you to simplify it."
+    ),
 }
 
 


### PR DESCRIPTION
This follows the addition of a new dedicated exit code in ehrQL:
 * https://github.com/opensafely-core/ehrql/pull/2757

The wording here is deliberately not specific to measures. I'm not sure it helps much to metion them, and it's possible we'll want to add other sorts of timeout error.

See Slack thread:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1776151498356969