### PR TITLE
Cache resource usage for each backend

### DIFF
--- a/controller/main.py
+++ b/controller/main.py
@@ -59,6 +59,9 @@ def main(exit_callback=lambda _: False):
 
 
 def handle_jobs():
+    # Not strictly necessary but minimises the potential for weird issues
+    invalidate_resource_usage_cache()
+
     log.debug("Querying database for active jobs")
     active_jobs = find_where(Job, state__in=[State.PENDING, State.RUNNING])
     log.debug("Done query")
@@ -563,8 +566,11 @@ def get_resource_usage(backend):
     return resource_usage
 
 
-def invalidate_resource_usage_cache(backend):
-    RESOURCE_USAGE_CACHE.pop(backend, None)
+def invalidate_resource_usage_cache(backend=None):
+    if backend is not None:
+        RESOURCE_USAGE_CACHE.pop(backend, None)
+    else:
+        RESOURCE_USAGE_CACHE.clear()
 
 
 def calculate_resource_usage(backend):

--- a/controller/main.py
+++ b/controller/main.py
@@ -5,6 +5,7 @@ updates its state as appropriate.
 """
 
 import collections
+import dataclasses
 import datetime
 import json
 import logging
@@ -538,15 +539,23 @@ def refresh_job_timestamps(job):
     set_code(job, job.status_code, job.status_message)
 
 
+@dataclasses.dataclass(frozen=True)
+class ResourceUsage:
+    total: float
+    running_db_jobs: int
+
+
+def get_resource_usage(backend):
+    running_jobs = find_where(Job, state=State.RUNNING, backend=backend)
+    total = sum(get_job_resource_weight(job) for job in running_jobs)
+    running_db_jobs = len([job for job in running_jobs if job.requires_db])
+    return ResourceUsage(total=total, running_db_jobs=running_db_jobs)
+
+
 def get_reason_job_not_started(job):
-    log.debug("Querying for running jobs")
-    running_jobs = find_where(Job, state=State.RUNNING, backend=job.backend)
-    log.debug("Query done")
-    used_resources = sum(
-        get_job_resource_weight(running_job) for running_job in running_jobs
-    )
+    resource_usage = get_resource_usage(job.backend)
     required_resources = get_job_resource_weight(job)
-    if used_resources + required_resources > config.MAX_WORKERS[job.backend]:
+    if resource_usage.total + required_resources > config.MAX_WORKERS[job.backend]:
         if required_resources > 1:
             return (
                 StatusCode.WAITING_ON_WORKERS,
@@ -556,8 +565,7 @@ def get_reason_job_not_started(job):
             return StatusCode.WAITING_ON_WORKERS, "Waiting on available workers"
 
     if job.requires_db:
-        running_db_jobs = len([j for j in running_jobs if j.requires_db])
-        if running_db_jobs >= config.MAX_DB_WORKERS[job.backend]:
+        if resource_usage.running_db_jobs >= config.MAX_DB_WORKERS[job.backend]:
             return (
                 StatusCode.WAITING_ON_DB_WORKERS,
                 "Waiting on available database workers",

--- a/controller/main.py
+++ b/controller/main.py
@@ -432,6 +432,8 @@ def set_code(
     collisions when states transition in <1s. Due to this, timestamp parameter
     should be the output of time.time() i.e. a float representing seconds.
     """
+    original_state = job.state
+
     current_timestamp_ns = int(time.time() * 1e9)
     if task_timestamp_ns is None:
         task_timestamp_ns = current_timestamp_ns
@@ -531,6 +533,9 @@ def set_code(
         if datetime.datetime.fromtimestamp(timestamp_s).minute % 10 == 0:
             log.info(job.status_message, extra={"status_code": job.status_code})
 
+    if job.state != original_state:
+        invalidate_resource_usage_cache(job.backend)
+
 
 def refresh_job_timestamps(job):
     # `set_code()` already contains logic to handle updating timestamps at an
@@ -545,7 +550,24 @@ class ResourceUsage:
     running_db_jobs: int
 
 
+RESOURCE_USAGE_CACHE = {}
+
+
 def get_resource_usage(backend):
+    try:
+        return RESOURCE_USAGE_CACHE[backend]
+    except KeyError:
+        pass
+    resource_usage = calculate_resource_usage(backend)
+    RESOURCE_USAGE_CACHE[backend] = resource_usage
+    return resource_usage
+
+
+def invalidate_resource_usage_cache(backend):
+    RESOURCE_USAGE_CACHE.pop(backend, None)
+
+
+def calculate_resource_usage(backend):
     running_jobs = find_where(Job, state=State.RUNNING, backend=backend)
     total = sum(get_job_resource_weight(job) for job in running_jobs)
     running_db_jobs = len([job for job in running_jobs if job.requires_db])

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -1163,3 +1163,33 @@ def test_update_scheduled_task_for_db_data_check_in_db_maintenance(
     tasks = database.find_where(Task, type=TaskType.DBDATACHECK)
     assert len(tasks) == 1
     assert not tasks[0].active
+
+
+def test_resource_usage_cache(monkeypatch, db):
+    monkeypatch.setattr(config, "MAX_WORKERS", {"test": 1})
+
+    # Create a single job which should be started
+    job_1 = job_factory()
+    main.handle_single_job(job_1)
+    assert job_1.state == State.RUNNING
+
+    # Confirm there's no cache value for this backend
+    assert "test" not in main.RESOURCE_USAGE_CACHE
+
+    # Create a second job which will be waiting on workers
+    job_2 = job_factory()
+    main.handle_single_job(job_2)
+    assert job_2.state == State.PENDING
+
+    # Confirm that we've created a cache for this backend
+    assert "test" in main.RESOURCE_USAGE_CACHE
+
+    # Visit both jobs again and confirm the cache persists
+    main.handle_single_job(job_1)
+    main.handle_single_job(job_2)
+    assert "test" in main.RESOURCE_USAGE_CACHE
+
+    # Complete job 1 and confirm this invalidates the cache
+    set_job_task_results(job_1, job_task_results_factory())
+    main.handle_single_job(job_1)
+    assert "test" not in main.RESOURCE_USAGE_CACHE


### PR DESCRIPTION
As described in #1387, the existing code recalculates the current resource usage each time it considers whether to start a job. This involves retrieving some large-ish objects from the database and so when we have a very large number of pending jobs this adds up to a significant amount of work.

However the resource usage only changes when the set of running jobs changes, so we can cache the results so long as we invalidate this cache whenever we start or stop a job. Fortunately there's a common code path we can hook into here to achieve this.

For good measure we also reset the cache at the beginning of each loop over the active jobs. This means that if, somehow, there are changes to job state which have happened out-of-band then we'll correct our view of the world as soon we run the next loop.

I've tested this locally on a job queue container 12 running jobs and 2,000 pending ones. Previously each full loop over the queue took 120 seconds. With this patch it takes 850ms.

Closes #1387