### PR TITLE
Only resolve Docker image SHA when we actually need it

### DIFF
--- a/controller/main.py
+++ b/controller/main.py
@@ -685,7 +685,7 @@ def update_scheduled_task_for_db_maintenance_for_backend(
     schedule_regular_task(
         backend=backend,
         task_type=TaskType.DBSTATUS,
-        task_definition={
+        get_task_definition=lambda: {
             "database_name": "default",
             "image": db_task_image,
             "image_sha": db_task_image_sha,
@@ -701,7 +701,7 @@ def update_scheduled_task_for_db_data_check_for_backend(
     schedule_regular_task(
         backend=backend,
         task_type=TaskType.DBDATACHECK,
-        task_definition={
+        get_task_definition=lambda: {
             "hes_expected_activity_month": config.DATA_CHECK_HES_EXPECTED_ACTIVITY_MONTH,
             "image": db_task_image,
             "image_sha": db_task_image_sha,
@@ -712,7 +712,7 @@ def update_scheduled_task_for_db_data_check_for_backend(
 
 
 def schedule_regular_task(
-    *, backend, task_type, task_definition, task_interval, is_active
+    *, backend, task_type, get_task_definition, task_interval, is_active
 ):
     # If we're not supposed to be active then deactivate any currently active tasks and
     # exit
@@ -755,7 +755,7 @@ def schedule_regular_task(
             id=f"{task_type.value}-{datetime.date.today()}-{secrets.token_hex(10)}",
             type=task_type,
             backend=backend,
-            definition=task_definition,
+            definition=get_task_definition(),
         )
     )
 

--- a/controller/main.py
+++ b/controller/main.py
@@ -666,49 +666,46 @@ def cancel_job(job):
 
 
 def update_scheduled_tasks():
-    db_image_name = "tpp-database-utils:latest"
-    db_task_image = f"{common_config.DOCKER_REGISTRY}/{db_image_name}"
-    db_task_image_sha = docker.get_current_image_sha(db_image_name)
     for backend in config.MAINTENANCE_ENABLED_BACKENDS:
-        update_scheduled_task_for_db_maintenance_for_backend(
-            backend, db_task_image, db_task_image_sha
-        )
+        update_scheduled_task_for_db_maintenance_for_backend(backend)
     for backend in config.DATA_CHECK_ENABLED_BACKENDS:
-        update_scheduled_task_for_db_data_check_for_backend(
-            backend, db_task_image, db_task_image_sha
-        )
+        update_scheduled_task_for_db_data_check_for_backend(backend)
 
 
-def update_scheduled_task_for_db_maintenance_for_backend(
-    backend, db_task_image, db_task_image_sha
-):
+def update_scheduled_task_for_db_maintenance_for_backend(backend):
     schedule_regular_task(
         backend=backend,
         task_type=TaskType.DBSTATUS,
         get_task_definition=lambda: {
             "database_name": "default",
-            "image": db_task_image,
-            "image_sha": db_task_image_sha,
+            **get_database_utils_image_details(),
         },
         task_interval=config.MAINTENANCE_POLL_INTERVAL,
         is_active=not get_flag_value("manual-db-maintenance", backend),
     )
 
 
-def update_scheduled_task_for_db_data_check_for_backend(
-    backend, db_task_image, db_task_image_sha
-):
+def update_scheduled_task_for_db_data_check_for_backend(backend):
     schedule_regular_task(
         backend=backend,
         task_type=TaskType.DBDATACHECK,
         get_task_definition=lambda: {
             "hes_expected_activity_month": config.DATA_CHECK_HES_EXPECTED_ACTIVITY_MONTH,
-            "image": db_task_image,
-            "image_sha": db_task_image_sha,
+            **get_database_utils_image_details(),
         },
         task_interval=config.DATA_CHECK_POLL_INTERVAL,
         is_active=get_flag_value("mode", backend) != "db-maintenance",
     )
+
+
+def get_database_utils_image_details():
+    image_name = "tpp-database-utils:latest"
+    image_uri = f"{common_config.DOCKER_REGISTRY}/{image_name}"
+    image_sha = docker.get_current_image_sha(image_name)
+    return {
+        "image": image_uri,
+        "image_sha": image_sha,
+    }
 
 
 def schedule_regular_task(


### PR DESCRIPTION
Previously we would attempt to resolve the SHA for the `tpp-database-utils` Docker image every time we ran the control loop. This is probably relatively harmless but I could see the extra HTTP traffic while debugging and it offended my sense of parsimony.