### PR TITLE
Test for presence of `opensafely-pipeline[fastparser]`

### DIFF
--- a/tests/controller/test_create_or_update_jobs.py
+++ b/tests/controller/test_create_or_update_jobs.py
@@ -3,6 +3,7 @@ import uuid
 from pathlib import Path
 from unittest import mock
 
+import pipeline.loading
 import pytest
 
 import common.config
@@ -59,6 +60,14 @@ actions:
       moderately_sensitive:
         analysis: analysis.txt
 """
+
+
+def test_opensafely_pipeline_fastparser_available():
+    assert pipeline.loading.FAST_PARSER is not None, (
+        "opensafely-pipeline[fastparser] does not seem to be installed.\n"
+        "YAML parsing will fallback to the pure Python parser which is "
+        "significantly slower."
+    )
 
 
 def test_adding_job_creates_dependencies(tmp_work_dir):


### PR DESCRIPTION
If we manage to install `opensafely-pipeline` without the optional `fastparser` dependency then everything will appear to work fine but will be much, much slower on large `project.yaml` files.

This is exactly what happened to Job Server recently and it seems like a good idea to add their regression test here to make sure it doesn't happen to us. See:
 * https://github.com/opensafely-core/job-server/pull/5766