### PR TITLE
Increase OTel queue limits in ehrQL telemetry scripts

### DIFF
--- a/agent/cli/ehrql_log_telemetry.py
+++ b/agent/cli/ehrql_log_telemetry.py
@@ -52,6 +52,12 @@ def main(argv):
 
     # force our name to be used as dataset
     os.environ["OTEL_SERVICE_NAME"] = args.dataset
+    # This script is designed to dump a whole job's worth of telemetry over a very short
+    # time, so if we don't change some of the defaults we can end up overflowing the
+    # queue and dropping spans
+    # https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor
+    os.environ["OTEL_BSP_MAX_QUEUE_SIZE"] = "102400"  # default is 2048
+    os.environ["OTEL_BSP_EXPORT_TIMEOUT"] = "120000"  # default = 30000ms
     setup_default_tracing("agent")
 
     extra_attrs = args.attrs or []

--- a/agent/cli/ehrql_telemetry.py
+++ b/agent/cli/ehrql_telemetry.py
@@ -54,6 +54,12 @@ def main(argv):
 
     # force our name to be used as dataset
     os.environ["OTEL_SERVICE_NAME"] = args.dataset
+    # This script is designed to dump a whole job's worth of telemetry over a very short
+    # time, so if we don't change some of the defaults we can end up overflowing the
+    # queue and dropping spans
+    # https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor
+    os.environ["OTEL_BSP_MAX_QUEUE_SIZE"] = "102400"  # default is 2048
+    os.environ["OTEL_BSP_EXPORT_TIMEOUT"] = "120000"  # default = 30000ms
     setup_default_tracing("agent")
 
     run(metadata, logs)


### PR DESCRIPTION
These scripts are designed to dump a whole job's worth of telemetry over a very short time, so if we don't change some of the defaults we can end up overflowing the queue and dropping spans (as I recently observed).

The duplication between the `ehrql_telemetry` and `ehrql_log_telemetry` isn't ideal and we should refactor these at some point but I'm not going to do it now.

Thanks @bloodearnest for pointing this config out.