### PR TITLE
Account for resource weighting when scheduling db jobs

### DIFF
--- a/controller/main.py
+++ b/controller/main.py
@@ -550,7 +550,7 @@ def refresh_job_timestamps(job):
 @dataclasses.dataclass(frozen=True)
 class ResourceUsage:
     total: float
-    running_db_jobs: int
+    db_jobs: float
 
 
 RESOURCE_USAGE_CACHE = {}
@@ -575,9 +575,10 @@ def invalidate_resource_usage_cache(backend=None):
 
 def calculate_resource_usage(backend):
     running_jobs = find_where(Job, state=State.RUNNING, backend=backend)
-    total = sum(get_job_resource_weight(job) for job in running_jobs)
-    running_db_jobs = len([job for job in running_jobs if job.requires_db])
-    return ResourceUsage(total=total, running_db_jobs=running_db_jobs)
+    job_weights = [(job, get_job_resource_weight(job)) for job in running_jobs]
+    total = sum(weight for _, weight in job_weights)
+    db_jobs = sum(weight for job, weight in job_weights if job.requires_db)
+    return ResourceUsage(total=total, db_jobs=db_jobs)
 
 
 def get_reason_job_not_started(job):
@@ -593,7 +594,10 @@ def get_reason_job_not_started(job):
             return StatusCode.WAITING_ON_WORKERS, "Waiting on available workers"
 
     if job.requires_db:
-        if resource_usage.running_db_jobs >= config.MAX_DB_WORKERS[job.backend]:
+        if (
+            resource_usage.db_jobs + required_resources
+            > config.MAX_DB_WORKERS[job.backend]
+        ):
             return (
                 StatusCode.WAITING_ON_DB_WORKERS,
                 "Waiting on available database workers",

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -280,6 +280,39 @@ def test_handle_job_waiting_on_db_workers(monkeypatch, db):
     assert spans[-1].name == "CREATED"
 
 
+def test_handle_job_waiting_on_db_workers_resource_intensive_job(monkeypatch, db):
+    monkeypatch.setattr(config, "MAX_DB_WORKERS", {"test": 3})
+    monkeypatch.setattr(
+        config,
+        "JOB_RESOURCE_WEIGHTS",
+        {"test": {"workspace": {re.compile(r"high_load.*"): 2.0}}},
+    )
+    # Set this high so we're only constrained by the db worker limit
+    monkeypatch.setattr(config, "MAX_WORKERS", {"test": 10})
+
+    # We have 3 available db workers and this job consumes 2 units, so it should start
+    # running
+    job1 = job_factory(workspace="workspace", action="high_load_1", requires_db=True)
+    run_controller_loop_once()
+    job1 = database.find_one(Job, id=job1.id)
+    assert job1.state == State.RUNNING
+
+    # We now have only 1 available db worker and this job consumes 2 units, so it should
+    # remaining pending
+    job2 = job_factory(workspace="workspace", action="high_load_2", requires_db=True)
+    run_controller_loop_once()
+    job2 = database.find_one(Job, id=job2.id)
+    assert job2.state == State.PENDING
+    assert job2.status_code == StatusCode.WAITING_ON_DB_WORKERS
+
+    # We have 1 available db worker but this job only needs 1 worker, so it should start
+    # running
+    job3 = job_factory(workspace="workspace", action="normal_load", requires_db=True)
+    run_controller_loop_once()
+    job3 = database.find_one(Job, id=job3.id)
+    assert job3.state == State.RUNNING
+
+
 def test_handle_job_finalized_success_with_large_file(db):
     # insert previous outputs
     job_factory(


### PR DESCRIPTION
This was originally introduced to deal with high memory usage in analysis jobs and so the logic was never applied to database jobs.

We discovered this here:
https://bennettoxford.slack.com/archives/C02GL3A9THD/p1776846076383939