### PR TITLE
Fix the upgrade-pipeline script and update pipeline to v2026.04.22.171515

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,7 +97,7 @@ bump-uv-cutoff days="7":
 update-dependencies: upgrade-pipeline bump-uv-cutoff upgrade-all
 
 # Upgrade version of opensafely-pipeline library
-upgrade-pipeline: && devenv
+upgrade-pipeline: && devenv uvmirror
     ./scripts/upgrade-pipeline.sh pyproject.toml
 
 # Run the tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "Django",
     "gunicorn",
     "jsonschema",
-    "opensafely-pipeline[fastparser]@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.03.12.140752.zip",
+    "opensafely-pipeline[fastparser]@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.04.22.171515.zip",
     "requests",
     "opentelemetry-exporter-otlp-proto-http",
     "opentelemetry-instrumentation-django",

--- a/requirements.uvmirror.txt
+++ b/requirements.uvmirror.txt
@@ -99,7 +99,7 @@ mdurl==0.1.2
     # via markdown-it-py
 nodeenv==1.10.0
     # via pre-commit
-opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.03.12.140752.zip
+opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.04.22.171515.zip
     # via opensafely-jobrunner
 opentelemetry-api==1.41.0
     # via

--- a/scripts/upgrade-pipeline.sh
+++ b/scripts/upgrade-pipeline.sh
@@ -2,7 +2,7 @@
 set -eu
 
 file=$1
-github_package_url="opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/"
+github_package_url="@https://github.com/opensafely-core/pipeline/archive/refs/tags/"
 latest=$(git ls-remote -h --refs --tags --heads https://github.com/opensafely-core/pipeline | grep -o "v20.*$" | sort | tail -1)
 echo "Latest version of pipeline is $latest"
 

--- a/uv.lock
+++ b/uv.lock
@@ -769,7 +769,7 @@ requires-dist = [
     { name = "django" },
     { name = "gunicorn" },
     { name = "jsonschema" },
-    { name = "opensafely-pipeline", extras = ["fastparser"], url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.03.12.140752.zip" },
+    { name = "opensafely-pipeline", extras = ["fastparser"], url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.04.22.171515.zip" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-django" },
     { name = "opentelemetry-instrumentation-requests" },
@@ -790,12 +790,12 @@ dev = [
 
 [[package]]
 name = "opensafely-pipeline"
-version = "2026.3.12.140752"
-source = { url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.03.12.140752.zip" }
+version = "2026.4.22.171515"
+source = { url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.04.22.171515.zip" }
 dependencies = [
     { name = "ruyaml" },
 ]
-sdist = { hash = "sha256:e6e45b5b17f884af263a4c01ead72347d0e63899a0eb1811d7c3d0d5e802401b" }
+sdist = { hash = "sha256:37a8ba18be79e604913da616904ae093f19c1f0d6869dd3165601e3c5bfe706b" }
 
 [package.optional-dependencies]
 fastparser = [


### PR DESCRIPTION
The upgrade-pipeline script was broken if the pipeline dependency in pyproject.toml was referenced as opensafely-pipeline[fastparser]@ rather than just opensafely-pipeline@. 

Note that the [update to the pipeline library](https://github.com/opensafely-core/pipeline/pull/467) is to allow action images that use the tag pattern `:vN-pre`; we'll use this tag for testing images pre-release.