### PR TITLE
Add concurrency to build and deploy workflow

### DIFF
--- a/.github/workflows/build_publish_and_deploy.yaml
+++ b/.github/workflows/build_publish_and_deploy.yaml
@@ -20,6 +20,10 @@ permissions:
   packages: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-publish-and-deploy-docker-image:
     runs-on: ubuntu-22.04
@@ -35,7 +39,7 @@ jobs:
         just docker/build prod # explicitly build prod as well
     - name: Test image
       run: just docker/test
-    
+
     - name: Publish docker image
       run: |
         echo ${{ secrets.GITHUB_TOKEN }} | docker login "$REGISTRY" -u ${{ github.actor }} --password-stdin


### PR DESCRIPTION
This prevents two deployments running at the same time, which can trigger a deploy lock and cause the second deployment to fail.

I used the same config [as we do in Airlock](https://github.com/opensafely-core/airlock/blob/e13b11825c715abbc4abd1d6f2b3546abcd98535/.github/workflows/main.yml#L15-L17), including the concurrency group name.
We expect `${{ github.ref }}` to always refer to the `main` branch here, but there is no harm in including it in the group name anyway.