### PR TITLE
Use separate worker pool for db and non-db jobs

### DIFF
--- a/controller/config.py
+++ b/controller/config.py
@@ -58,7 +58,9 @@ ALLOWED_IMAGES = {
 
 # Set workers per-backend. This will be used by the controller to
 # determine if there are enough resources available to start a new
-# job running.
+# job running. Note there are two separate limits:
+#  * `MAX_WORKERS` applies only to jobs which do not require access to the database
+#  * `MAX_DB_WORKERS` applies only to jobs which do access the database
 default_workers = {"test": 2, "tpp": 10, "emis": 10}
 MAX_WORKERS = {
     backend: int(

--- a/controller/main.py
+++ b/controller/main.py
@@ -594,13 +594,11 @@ def get_reason_job_not_started(job):
     resource_usage = get_resource_usage(job.backend)
     required_resources = get_job_resource_weight(job)
     if resource_usage.total + required_resources > config.MAX_WORKERS[job.backend]:
-        if required_resources > 1:
-            return (
-                StatusCode.WAITING_ON_WORKERS,
-                "Waiting on available workers for resource intensive job",
-            )
-        else:
-            return StatusCode.WAITING_ON_WORKERS, "Waiting on available workers"
+        return (
+            StatusCode.WAITING_ON_WORKERS,
+            "Waiting on available workers"
+            + (" for resource intensive job" if required_resources > 1 else ""),
+        )
 
     if job.requires_db:
         if (

--- a/controller/main.py
+++ b/controller/main.py
@@ -558,7 +558,7 @@ def refresh_job_timestamps(job):
 
 @dataclasses.dataclass(frozen=True)
 class ResourceUsage:
-    total: float
+    non_db_jobs: float
     db_jobs: float
 
 
@@ -585,22 +585,25 @@ def invalidate_resource_usage_cache(backend=None):
 def calculate_resource_usage(backend):
     running_jobs = find_where(Job, state=State.RUNNING, backend=backend)
     job_weights = [(job, get_job_resource_weight(job)) for job in running_jobs]
-    total = sum(weight for _, weight in job_weights)
+    non_db_jobs = sum(weight for job, weight in job_weights if not job.requires_db)
     db_jobs = sum(weight for job, weight in job_weights if job.requires_db)
-    return ResourceUsage(total=total, db_jobs=db_jobs)
+    return ResourceUsage(non_db_jobs=non_db_jobs, db_jobs=db_jobs)
 
 
 def get_reason_job_not_started(job):
     resource_usage = get_resource_usage(job.backend)
     required_resources = get_job_resource_weight(job)
-    if resource_usage.total + required_resources > config.MAX_WORKERS[job.backend]:
-        return (
-            StatusCode.WAITING_ON_WORKERS,
-            "Waiting on available workers"
-            + (" for resource intensive job" if required_resources > 1 else ""),
-        )
-
-    if job.requires_db:
+    if not job.requires_db:
+        if (
+            resource_usage.non_db_jobs + required_resources
+            > config.MAX_WORKERS[job.backend]
+        ):
+            return (
+                StatusCode.WAITING_ON_WORKERS,
+                "Waiting on available workers"
+                + (" for resource intensive job" if required_resources > 1 else ""),
+            )
+    else:
         if (
             resource_usage.db_jobs + required_resources
             > config.MAX_DB_WORKERS[job.backend]

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -229,8 +229,9 @@ def test_handle_job_waiting_on_workers_resource_intensive_job(monkeypatch, db):
 
     # This action requires 1.5 resources. No other jobs are running, so we have 2 resources (i.e.
     # the MAX_WORKERS) currently available.
-    # We set requires_db to ensure it's the first one run
-    job1 = job_factory(workspace="workspace", action="action1", requires_db=True)
+    job1 = job_factory(workspace="workspace", action="action1")
+    # Start it running
+    run_controller_loop_once()
 
     # This action requires 1.5 resources. job1 is already running and using 1.5 resources.
     # We have 2 max workers, so only 0.5 resources are left after first one is running
@@ -278,6 +279,35 @@ def test_handle_job_waiting_on_db_workers(monkeypatch, db):
     # tracing
     spans = get_trace("jobs")
     assert spans[-1].name == "CREATED"
+
+
+def test_handle_job_has_separate_worker_pools(monkeypatch, db):
+    monkeypatch.setattr(config, "MAX_WORKERS", {"test": 1})
+    monkeypatch.setattr(config, "MAX_DB_WORKERS", {"test": 1})
+
+    db_job1 = job_factory(requires_db=True)
+    run_controller_loop_once()
+    db_job1 = database.find_one(Job, id=db_job1.id)
+    assert db_job1.state == State.RUNNING
+
+    db_job2 = job_factory(requires_db=True)
+    run_controller_loop_once()
+    db_job2 = database.find_one(Job, id=db_job2.id)
+    assert db_job2.state == State.PENDING
+    assert db_job2.status_code == StatusCode.WAITING_ON_DB_WORKERS
+
+    # Even though there are no workers for the above db job, there should be an
+    # available worker for this non-db job
+    non_db_job1 = job_factory(requires_db=False)
+    run_controller_loop_once()
+    non_db_job1 = database.find_one(Job, id=non_db_job1.id)
+    assert non_db_job1.state == State.RUNNING
+
+    non_db_job2 = job_factory(requires_db=False)
+    run_controller_loop_once()
+    non_db_job2 = database.find_one(Job, id=non_db_job2.id)
+    assert non_db_job2.state == State.PENDING
+    assert non_db_job2.status_code == StatusCode.WAITING_ON_WORKERS
 
 
 def test_handle_job_waiting_on_db_workers_resource_intensive_job(monkeypatch, db):


### PR DESCRIPTION
The resources we're trying to protect when we limit the parallelism of db vs non-db jobs are distinct: database jobs use very little host CPU and RAM, but put load on the database server; other jobs consume lots of CPU and RAM but don't touch the database. As things stand, if we say that a job consumes three database worker slots then it also reduces the number of non-db jobs we can run which wastes resources. Likewise, if we're at our limit running memory heavy analysis jobs then we'll refuse to schedule any database jobs which also wastes resources.

See Slack thread:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1777634819960049