### PR TITLE
Always set user and group for Docker containers

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from pathlib import Path
 
 from common import config as common_config
@@ -132,12 +131,8 @@ HIGH_PRIVACY_VOLUME_DIR = Path(
 # docker will be looking for.
 DOCKER_HOST_VOLUME_DIR = os.environ.get("DOCKER_HOST_VOLUME_DIR")
 
-if sys.platform == "linux":
-    DOCKER_USER_ID = os.environ.get("DOCKER_USER_ID", str(os.geteuid()))
-    DOCKER_GROUP_ID = os.environ.get("DOCKER_GROUP_ID", str(os.getegid()))
-else:  # pragma: no cover
-    DOCKER_USER_ID = None
-    DOCKER_GROUP_ID = None
+DOCKER_USER_ID = os.environ.get("DOCKER_USER_ID", str(os.geteuid()))
+DOCKER_GROUP_ID = os.environ.get("DOCKER_GROUP_ID", str(os.getegid()))
 
 
 # The name of a Docker network configured to allow access to just the database and

--- a/agent/executors/local.py
+++ b/agent/executors/local.py
@@ -210,13 +210,12 @@ class LocalDockerAPI(ExecutorAPI):
                 )
             )
 
-        if config.DOCKER_USER_ID and config.DOCKER_GROUP_ID:  # pragma: no cover
-            extra_args.extend(
-                [
-                    "--user",
-                    f"{config.DOCKER_USER_ID}:{config.DOCKER_GROUP_ID}",
-                ]
-            )
+        extra_args.extend(
+            [
+                "--user",
+                f"{config.DOCKER_USER_ID}:{config.DOCKER_GROUP_ID}",
+            ]
+        )
         extra_args.extend(
             [
                 "-e",

--- a/tests/agent/test_local_executor.py
+++ b/tests/agent/test_local_executor.py
@@ -343,12 +343,10 @@ def test_execute_user_bindmount(docker_cleanup, job_definition, tmp_work_dir):
 
     container_config = docker.container_inspect(local.container_name(job_definition.id))
 
-    # do not test that this config is set on platforms that do not require this config
-    if config.DOCKER_USER_ID and config.DOCKER_GROUP_ID:
-        assert (
-            container_config["Config"]["User"]
-            == f"{config.DOCKER_USER_ID}:{config.DOCKER_GROUP_ID}"
-        )
+    assert (
+        container_config["Config"]["User"]
+        == f"{config.DOCKER_USER_ID}:{config.DOCKER_GROUP_ID}"
+    )
     assert container_config["State"]["ExitCode"] == 0
 
 


### PR DESCRIPTION
The previous conditional behaviour came from the time when we had deployment targets other than Linux. Now that the local run code has been forked this is no longer the case and we don't want a misconfiguration to result in containers being run as root.