### PR TITLE
Upgrade schemathesis and fix tests

### DIFF
--- a/requirements.uvmirror.txt
+++ b/requirements.uvmirror.txt
@@ -215,7 +215,7 @@ ruamel-yaml-clib==0.2.8
 ruff==0.15.12
 ruyaml==0.91.0
     # via opensafely-pipeline
-schemathesis==4.15.2
+schemathesis==4.16.1
 setuptools==82.0.1
     # via ruyaml
 six==1.17.0

--- a/tests/controller/webapp/test_api_spec.py
+++ b/tests/controller/webapp/test_api_spec.py
@@ -137,36 +137,19 @@ def test_expected_status_codes():
 @hypothesis.settings(deadline=None)
 @schema.parametrize()
 def test_api_with_auth(db, case, recorder):
-    # We pass good headers; schemathesis will typically generate a test case
-    # with bad auth too, so the 401 status is covered
-    case.headers = {"Authorization": "token"}
-    call_and_validate(case, recorder)
+    # We pass good headers; schemathesis will typically generate test cases
+    # with bad auth and no auth too, so the 401 status is covered
+    call_and_validate(
+        case, recorder, call_kwargs={"headers": {"Authorization": "token"}}
+    )
 
 
-# Tests for bad/no auth
-# We only test in the explicit phase (i.e. examples) for no/bad tokens, since
-# we expect them always to error
-@hypothesis.settings(deadline=None, phases=[hypothesis.Phase.explicit])
-@schema.parametrize()
-def test_api_no_token(db, case, recorder):
-    # We pass good headers; schemathesis will typically generate a test case
-    # with bad auth too, so the 401 status is covered
-    case.headers = {}
-    call_and_validate(case, recorder)
-
-
-@hypothesis.settings(deadline=None, phases=[hypothesis.Phase.explicit])
-@schema.parametrize()
-def test_api_bad_token(db, case, recorder):
-    case.headers = {"Authorization": "bad-token"}
-    call_and_validate(case, recorder)
-
-
-def call_and_validate(case, recorder):
+def call_and_validate(case, recorder, call_kwargs=None):
+    call_kwargs = call_kwargs or {}
     # Note: we're not using case.call_and_validate() here so that we can record the status
     # code prior to validating the response (otherwise status codes for check failures
     # won't be recorded).
-    response = case.call()
+    response = case.call(**call_kwargs)
     recorder.record_status_code(case.path, response.status_code)
     case.validate_response(response)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1459,7 +1459,7 @@ wheels = [
 
 [[package]]
 name = "schemathesis"
-version = "4.15.2"
+version = "4.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1482,9 +1482,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/a2/cec4166416ff2c08ccf7be71bec708d0b8adacf25f40232992157ff73960/schemathesis-4.15.2.tar.gz", hash = "sha256:66f264f270e2222ffc7ab11c23a5dd2277c93c5a1a329d3d82a0b6ddc05263ef", size = 59830215, upload-time = "2026-04-14T17:06:56.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/58/412c71cfa443d66ffc4e67426ccf1687ea1957519ff32c7c620c0d2e4646/schemathesis-4.16.1.tar.gz", hash = "sha256:475d3449b18f61534e1ce914971a4643c484990164530029eac7328fc54a63de", size = 1725454, upload-time = "2026-04-26T09:17:48.469Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/c5/d2430fd23fe2c447d3b023be26888fdf8cfff14b7d6fd70423ed44ae9c30/schemathesis-4.15.2-py3-none-any.whl", hash = "sha256:6e14c7bb800fe197cb981bbe1d0e21c2d2c12114f2a52f386698a0e376a52647", size = 517662, upload-time = "2026-04-14T17:06:53.38Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6645c2a0a10f3583721fca1b29c1464a8f7b89aba107bbdd61c7f35fb18e/schemathesis-4.16.1-py3-none-any.whl", hash = "sha256:8a02e30b0af1df0fe16cae777182a75f530df28c3b03909da3ac85f5b70163d0", size = 525060, upload-time = "2026-04-26T09:17:46.212Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We were passing auth headers in the tests by adding them on the pytest `case` fixture itself. This seems to have worked in the past, but with a recent upgrade, it looks like it means that the endpoint is called with the headers set directly on the `case` (so the response was correctly 200), even when schemathesis generated test case metadata with no headers, and expected to get a 401.  It also confusingly meant that the example `curl` command that it reported to use to replicate the test case _did_ include authorization headers.

In fact we should be passing the headers to the `case.call()` (which is sort of how it's described in the docs, for call_and_validate() https://schemathesis.readthedocs.io/en/stable/tutorials/pytest/

We also don't need separate tests for no/bad auth, because schemathesis will generate those as test cases anyway (if it didn't, we'd know because there would be no 401 cases for any endpoints)