### PR TITLE
Fix intermittent daemon threads error and other test flakiness

### DIFF
--- a/agent/lib/docker.py
+++ b/agent/lib/docker.py
@@ -7,6 +7,7 @@ import logging
 import os
 import socket
 import subprocess
+import time
 import urllib.parse
 
 from agent import config
@@ -272,12 +273,25 @@ def get_hostname_ip_from_url(url):
 def ensure_docker_sha_present(proxy_image_with_sha, registry_image_with_label):
     """Pull the image sha via the proxy."""
 
-    # ensure the image/sha is present
-    docker(
-        ["pull", "--quiet", proxy_image_with_sha],
-        check=True,
-        timeout=IMAGE_PULL_TIMEOUT,
-    )
+    # Retry on transient registry errors (e.g. intermittent network failures).
+    retry_delay = 1
+    for attempt in range(1, 4):  # pragma: no cover
+        try:
+            docker(
+                ["pull", "--quiet", proxy_image_with_sha],
+                check=True,
+                timeout=IMAGE_PULL_TIMEOUT,
+            )
+            break
+        except subprocess.CalledProcessError:  # pragma: no cover
+            if attempt == 3:
+                raise
+            logger.warning(
+                "docker pull failed (attempt %d/3), retrying in %ds",
+                attempt,
+                retry_delay,
+            )
+            time.sleep(retry_delay)
 
     proxy_image_with_label, _, _ = proxy_image_with_sha.partition("@")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,34 +10,17 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+import requests
+import urllib3
 from opentelemetry import trace
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from agent import config as agent_config
-from agent import metrics
+from agent import metrics, task_api
 from common.tracing import add_exporter, get_provider
 from controller import config as controller_config
 from controller.lib import database, docker
-
-
-_original_excepthook = threading.excepthook
-
-
-def _catch_shutdown_errors(args):
-    # During interpreter shutdown, sys.stderr may be None but a lingering thread
-    # may try to write to it. Ignore threading errors that happen during shutdown
-    if not sys.is_finalizing():
-        _original_excepthook(args)
-    try:
-        # Try to print the error for information if we can; stdin/out may not be
-        # available here, so we just catch any exception
-        print(f"Threading exception in shutdown: {args}")
-    except Exception:
-        ...
-
-
-threading.excepthook = _catch_shutdown_errors
 
 
 # set up test tracing
@@ -56,6 +39,47 @@ def pytest_configure(config):
         "markers",
         "needs_ghcr: mark test as needing access to ghcr api for resolving image shas",
     )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def close_task_api_session():
+    # agent.task_api uses a module-level requests.Session. Disable keep-alive
+    # by sending Connection: close in the session headers so that the
+    # server's daemon request-handler threads exit after each response rather than
+    # lingering into interpreter shutdown.
+    task_api.session.headers["Connection"] = "close"
+    # On its own, the above fixed the intermittent threading errors, but introduced another
+    # intermittent RemoteDisconnected error.
+    # This appears to be because Django's ServerHandler.cleanup_headers() only writes
+    # Connection: close to the response when the response has no Content-Length
+    # or the server isn't a ThreadingMixIn. The live server is a ThreadingMixIn
+    # and API responses have Content-Length, so
+    # urllib3 never sees Connection: close in the response headers:
+    # https://github.com/django/django/blob/141e791f48592011b0f38fb30d44291e3ce74ee0/django/core/servers/basehttp.py
+    # Add a retry to avoid the RemoteDisconnected errors
+    task_api.session.mount(
+        "http://",
+        requests.adapters.HTTPAdapter(
+            max_retries=urllib3.util.Retry(
+                total=3,
+                read=3,
+                backoff_factor=0,
+                allowed_methods=urllib3.util.Retry.DEFAULT_ALLOWED_METHODS
+                | frozenset(["POST"]),
+            )
+        ),
+    )
+    yield
+
+    # If any process_request_thread threads are still alive the threading fix has regressed.
+    for t in threading.enumerate():
+        if t.daemon and "process_request_thread" in t.name:
+            t.join(timeout=2.0)
+            if t.is_alive():
+                raise RuntimeError(
+                    f"Daemon thread {t.name!r} still alive after session teardown — "
+                    "Connection: close may not be taking effect"
+                )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Remove the `_catch_shutdown_errors` threading excepthook. It tried to suppress errors with a try/catch during shutdown, and to print the error in case stdout was available. However, the threading errors weren't being suppressed properly, and possibly the print was actually triggering them. In any case, we've been seeing them quite frequently, and not with the except print statement.

The issue appears to actually be with the agent.task_api's module-level requests.Session. We now have a session-scoped fixture that sets `Connection: close` on `agent.task_api`'s Session. This ensures the live server's daemon request-handler threads exit cleanly after each response rather than persisting into interpreter shutdown. It also adds a retry, for the cases where the Connection close wasn't registered by django in the tests, which resulted in an intermittent RemoteDisconnected error.

Also adds a regression check in fixture teardown that fails loudly if any `process_request_thread` daemon threads are still alive after the session ends.

I've tested this by running the docker tests repeatedly locally. Without this fix, they hit the threading error within the first few runs. With it, they ran 50x without hitting it. However, they did highlight another intermittent error in the few tests that make actual calls to ghcr.io, so there's also a retry added there; it retries a max of 3 times with a 1sec delay, so although it's a change in production code, it shouldn't have a huge impact. With this, my repeated docker tests ran successfully 50/50 times.