### PR TITLE
Refactor task api session and fix test flakiness

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -30,17 +30,18 @@ def main(exit_callback=lambda _: False):  # pragma: no cover
     log.info("agent.main loop started")
     api = get_executor_api()
 
-    while True:
-        active_tasks = handle_tasks(api)
+    with task_api.TaskAPI() as task_api_client:
+        while True:
+            active_tasks = handle_tasks(api, task_api_client)
 
-        if exit_callback(active_tasks):
-            break
+            if exit_callback(active_tasks):
+                break
 
-        time.sleep(common_config.JOB_LOOP_INTERVAL)
+            time.sleep(common_config.JOB_LOOP_INTERVAL)
 
 
-def handle_tasks(api: ExecutorAPI | None):
-    active_tasks = task_api.get_active_tasks()
+def handle_tasks(api: ExecutorAPI | None, task_api_client: task_api.TaskAPI):
+    active_tasks = task_api_client.get_active_tasks()
 
     handled_tasks = []
     errored_tasks = []
@@ -51,7 +52,7 @@ def handle_tasks(api: ExecutorAPI | None):
             # further down the stack will have `task` set on them
             with set_log_context(task=task):
                 try:
-                    handle_single_task(task, api)
+                    handle_single_task(task, api, task_api_client)
                 except Exception:
                     # do not raise now, but record and move on to the next task, so
                     # we do not block loop.
@@ -70,7 +71,7 @@ def handle_tasks(api: ExecutorAPI | None):
     return handled_tasks
 
 
-def handle_single_task(task, api):
+def handle_single_task(task, api, task_api_client: task_api.TaskAPI):
     """The top level handler for a task.
 
     Calls the appropriate handle_*_job_task function for the new task, and
@@ -83,13 +84,13 @@ def handle_single_task(task, api):
         try:
             match task.type:
                 case TaskType.RUNJOB:
-                    handle_run_job_task(task, api)
+                    handle_run_job_task(task, api, task_api_client)
                 case TaskType.CANCELJOB:
-                    handle_cancel_job_task(task, api)
+                    handle_cancel_job_task(task, api, task_api_client)
                 case TaskType.DBSTATUS:
-                    handle_simple_task(db_status_task, task)
+                    handle_simple_task(db_status_task, task, task_api_client)
                 case TaskType.DBDATACHECK:
-                    handle_simple_task(db_data_check_task, task)
+                    handle_simple_task(db_data_check_task, task, task_api_client)
                 case _:
                     assert False, f"Unknown task type {task.type}"
         except Exception as exc:
@@ -99,6 +100,7 @@ def handle_single_task(task, api):
                     api,
                     task,
                     sys.exc_info(),
+                    task_api_client,
                 )
             else:
                 span.set_attribute("fatal_task_error", False)
@@ -119,7 +121,7 @@ def is_fatal_task_error(exc: Exception) -> bool:
     return "test_hard_failure" in str(exc)
 
 
-def handle_cancel_job_task(task, api):
+def handle_cancel_job_task(task, api, task_api_client: task_api.TaskAPI):
     """
     Handle cancelling a job. The actions required to terminate, finalize and clean
     up a job depend on its state at the point of cancellation.
@@ -138,7 +140,7 @@ def handle_cancel_job_task(task, api):
     pre_finalized_job_status = initial_job_status
 
     # tell the controller what stage we're at now
-    update_job_task(task, initial_job_status, previous_status=None)
+    update_job_task(task, initial_job_status, task_api_client, previous_status=None)
 
     with set_log_context(job_definition=job):
         match initial_job_status.state:
@@ -160,7 +162,10 @@ def handle_cancel_job_task(task, api):
                 api.terminate(job)
                 pre_finalized_job_status = api.get_status(job)
                 update_job_task(
-                    task, pre_finalized_job_status, previous_status=initial_job_status
+                    task,
+                    pre_finalized_job_status,
+                    task_api_client,
+                    previous_status=initial_job_status,
                 )
                 # call finalize to write the job logs
                 api.finalize(job, cancelled=True)
@@ -177,11 +182,15 @@ def handle_cancel_job_task(task, api):
         api.cleanup(job)
 
         update_job_task(
-            task, final_status, previous_status=pre_finalized_job_status, complete=True
+            task,
+            final_status,
+            task_api_client,
+            previous_status=pre_finalized_job_status,
+            complete=True,
         )
 
 
-def handle_run_job_task(task, api):
+def handle_run_job_task(task, api, task_api_client: task_api.TaskAPI):
     """Handle an active task.
 
     This contains the main state machine logic for a task. For the most part,
@@ -204,12 +213,18 @@ def handle_run_job_task(task, api):
             case ExecutorState.ERROR | ExecutorState.FINALIZED:
                 # No action needed, just inform the controller we are in this completed stage
                 update_job_task(
-                    task, job_status, previous_status=job_status, complete=True
+                    task,
+                    job_status,
+                    task_api_client,
+                    previous_status=job_status,
+                    complete=True,
                 )
 
             case ExecutorState.EXECUTING:
                 # Still waitin'
-                update_job_task(task, job_status, previous_status=job_status)
+                update_job_task(
+                    task, job_status, task_api_client, previous_status=job_status
+                )
 
             case ExecutorState.UNKNOWN:
                 # a new job
@@ -224,10 +239,14 @@ def handle_run_job_task(task, api):
                 # before calling  api.prepare(), and we expect it to be PREPARED
                 # when finished
                 preparing_status = JobStatus(ExecutorState.PREPARING)
-                update_job_task(task, preparing_status, previous_status=job_status)
+                update_job_task(
+                    task, preparing_status, task_api_client, previous_status=job_status
+                )
                 api.prepare(job)
                 new_status = api.get_status(job)
-                update_job_task(task, new_status, previous_status=preparing_status)
+                update_job_task(
+                    task, new_status, task_api_client, previous_status=preparing_status
+                )
 
             case ExecutorState.PREPARED:
                 if job.allow_database_access:
@@ -235,12 +254,16 @@ def handle_run_job_task(task, api):
 
                 api.execute(job)
                 new_status = api.get_status(job)
-                update_job_task(task, new_status, previous_status=job_status)
+                update_job_task(
+                    task, new_status, task_api_client, previous_status=job_status
+                )
 
             case ExecutorState.EXECUTED:
                 # finalize is also synchronous
                 finalizing_status = JobStatus(ExecutorState.FINALIZING)
-                update_job_task(task, finalizing_status, previous_status=job_status)
+                update_job_task(
+                    task, finalizing_status, task_api_client, previous_status=job_status
+                )
                 api.finalize(job)
                 new_status = api.get_status(job)
                 api.cleanup(job)
@@ -250,6 +273,7 @@ def handle_run_job_task(task, api):
                 update_job_task(
                     task,
                     new_status,
+                    task_api_client,
                     previous_status=finalizing_status,
                     complete=True,
                 )
@@ -260,6 +284,7 @@ def handle_run_job_task(task, api):
 def update_job_task(
     task,
     status: JobStatus,
+    task_api_client: task_api.TaskAPI,
     previous_status: JobStatus = None,
     complete: bool = False,
 ):
@@ -280,7 +305,7 @@ def update_job_task(
 
     tracing.set_job_results_metadata(span, redacted_results, attributes)
     log_state_change(task, status, previous_status)
-    task_api.update_controller(
+    task_api_client.update_controller(
         task=task,
         stage=status.state.value,
         results=redacted_results,
@@ -327,7 +352,7 @@ def log_state_change(task, status, previous_status):
     log.info(log_message)
 
 
-def mark_task_as_error(api, task, exc_info):
+def mark_task_as_error(api, task, exc_info, task_api_client: task_api.TaskAPI):
     """
     Pass error information on to the controller and mark this task as complete
     """
@@ -344,7 +369,7 @@ def mark_task_as_error(api, task, exc_info):
             # this will persist the exception info to disk
             api.finalize(job, error=error)
             status = api.get_status(job)
-            update_job_task(task, status, complete=True)
+            update_job_task(task, status, task_api_client, complete=True)
         case _:
             assert False
 
@@ -372,7 +397,7 @@ def inject_db_secrets(job):
         job.env["EMIS_ORGANISATION_HASH"] = config.EMIS_ORGANISATION_HASH
 
 
-def handle_simple_task(task_function, task):
+def handle_simple_task(task_function, task, task_api_client: task_api.TaskAPI):
     """
     A "simple" task function is one which takes keyword arguments as supplied in the
     Task definition and returns a dictionary which will be reported under the `results`
@@ -392,7 +417,7 @@ def handle_simple_task(task_function, task):
             "results": results,
             "error": None,
         }
-    task_api.update_controller(
+    task_api_client.update_controller(
         task,
         # `stage` is not relevant for simple tasks so we leave it blank
         stage="",

--- a/agent/metrics.py
+++ b/agent/metrics.py
@@ -110,18 +110,19 @@ def write_job_metrics(job_id, metrics):
 
 def main():  # pragma: no cover
     last_run = None
-    while True:
-        before = time.time()
-        last_run = record_metrics_tick_trace(last_run)
+    with task_api.TaskAPI() as task_api_client:
+        while True:
+            before = time.time()
+            last_run = record_metrics_tick_trace(last_run, task_api_client)
 
-        # record_tick_trace might have take a while, so sleep the remainding interval
-        # enforce a minimum time of 2s to ensure we don't hammer honeycomb or
-        # the docker api
-        elapsed = time.time() - before
-        time.sleep(max(2, config.STATS_POLL_INTERVAL - elapsed))
+            # record_tick_trace might have take a while, so sleep the remainding interval
+            # enforce a minimum time of 2s to ensure we don't hammer honeycomb or
+            # the docker api
+            elapsed = time.time() - before
+            time.sleep(max(2, config.STATS_POLL_INTERVAL - elapsed))
 
 
-def record_metrics_tick_trace(last_run):
+def record_metrics_tick_trace(last_run, task_api_client: task_api.TaskAPI):
     """Record a periodic metrics tick trace of current docker containers"""
 
     # first run since restart, do nothing.
@@ -150,7 +151,7 @@ def record_metrics_tick_trace(last_run):
         error_attrs["exit_code"] = exc.returncode
         error_attrs["output"] = exc.stderr + "\n\n" + exc.output
 
-    tasks = task_api.get_active_tasks()
+    tasks = task_api_client.get_active_tasks()
     # any task definition with an id is assumed to be a job id
     tasks_by_job_id = {t.definition["id"]: t for t in tasks if "id" in t.definition}
 

--- a/agent/task_api.py
+++ b/agent/task_api.py
@@ -10,61 +10,64 @@ from common.schema import AgentTask
 
 log = logging.getLogger(__name__)
 
-session = requests.Session()
 
+class TaskAPI:
+    def __init__(self):
+        self._session = requests.Session()
 
-def get_json(path):
-    return request_json("GET", path)
+    def __enter__(self):
+        return self
 
+    def __exit__(self, *args):
+        self._session.close()
 
-def post_json(path, data=None):
-    return request_json("POST", path, data)
+    def get_active_tasks(self) -> list[AgentTask]:
+        """Get a list of active tasks for this backend from the controller"""
+        agent_tasks = self._get_json("tasks/")["tasks"]
+        return [AgentTask.from_dict(t) for t in agent_tasks]
 
+    def update_controller(
+        self,
+        task,
+        stage: str,
+        results: dict = None,
+        complete: bool = False,
+        timestamp_ns: int = None,
+    ):
+        """Update the controller with the current state of the task.
 
-def request_json(method, path, data=None):
-    base_url = urljoin(config.TASK_API_ENDPOINT, config.BACKEND)
-    data = data or {}
-    url = f"{base_url}/{path}"
-    headers = {"Authorization": config.TASK_API_TOKEN}
-    response = session.request(method, url, data=data, headers=headers)
-    try:
-        response.raise_for_status()
-    except Exception as e:
-        log.exception(e)
-        raise
-    return response.json()
+        stage: the current stage of the task from the agent's perspective
+        results: optional dictionary of completed results of this task, expected to be immutable
+        complete: if the agent considers this task complete
+        timestamp_ns: Optional timestamp (in ns) of this state change. Can be None for tasks that
+        do not involve state changes.
 
+        Nb. If results contains an error key, the task is considered to have failed.
+        """
+        post_data = {
+            "task_id": task.id,
+            "stage": stage,
+            "results": results,
+            "complete": complete,
+            "timestamp_ns": timestamp_ns,
+        }
+        self._post_json("task/update/", {"payload": json.dumps(post_data)})
 
-def get_active_tasks() -> list[AgentTask]:
-    """Get a list of active tasks for this backend from the controller"""
-    agent_tasks = get_json("tasks/")["tasks"]
-    return [AgentTask.from_dict(t) for t in agent_tasks]
+    def _get_json(self, path):
+        return self._request_json("GET", path)
 
+    def _post_json(self, path, data=None):
+        return self._request_json("POST", path, data)
 
-def update_controller(
-    task: AgentTask,
-    stage: str,
-    results: dict = None,
-    complete: bool = False,
-    timestamp_ns: int = None,
-):
-    """Update the controller with the current state of the task.
-
-    stage: the current stage of the task from the agent's perspective
-    results: optional dictionary of completed results of this task, expected to be immutable
-    complete: if the agent considers this task complete
-    timestamp_ns: Optional timestamp (in ns) of this state change. Can be None for tasks that
-    do not involve state changes.
-
-    Nb. If results contains an error key, the task is considered to have failed.
-    """
-
-    post_data = {
-        "task_id": task.id,
-        "stage": stage,
-        "results": results,
-        "complete": complete,
-        "timestamp_ns": timestamp_ns,
-    }
-
-    post_json("task/update/", {"payload": json.dumps(post_data)})
+    def _request_json(self, method, path, data=None):
+        base_url = urljoin(config.TASK_API_ENDPOINT, config.BACKEND)
+        data = data or {}
+        url = f"{base_url}/{path}"
+        headers = {"Authorization": config.TASK_API_TOKEN}
+        response = self._session.request(method, url, data=data, headers=headers)
+        try:
+            response.raise_for_status()
+        except Exception as e:
+            log.exception(e)
+            raise
+        return response.json()

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -28,7 +28,9 @@ def assert_state_change_logs(caplog, state_changes):
         ]
 
 
-def test_handle_tasks_executor_error(db, caplog, responses, live_server, monkeypatch):
+def test_handle_tasks_executor_error(
+    db, caplog, responses, live_server, monkeypatch, task_api_client
+):
     monkeypatch.setattr("agent.config.TASK_API_ENDPOINT", live_server.url)
     responses.add_passthru(live_server.url)
 
@@ -41,7 +43,7 @@ def test_handle_tasks_executor_error(db, caplog, responses, live_server, monkeyp
 
     msg = "Some tasks failed, restarting agent loop"
     with pytest.raises(Exception, match=msg):
-        main.handle_tasks(api)
+        main.handle_tasks(api, task_api_client)
 
     spans = get_trace("agent_loop")
 
@@ -69,7 +71,16 @@ def test_handle_tasks_executor_error(db, caplog, responses, live_server, monkeyp
     ],
 )
 def test_handle_tasks_github_validation(
-    db, caplog, responses, live_server, monkeypatch, tmp_work_dir, repo, commit, exc_msg
+    db,
+    caplog,
+    responses,
+    live_server,
+    monkeypatch,
+    tmp_work_dir,
+    repo,
+    commit,
+    exc_msg,
+    task_api_client,
 ):
     monkeypatch.setattr("agent.config.TASK_API_ENDPOINT", live_server.url)
     responses.add_passthru(live_server.url)
@@ -84,13 +95,13 @@ def test_handle_tasks_github_validation(
 
     msg = "Some tasks failed, restarting agent loop"
     with pytest.raises(Exception, match=msg):
-        main.handle_tasks(api)
+        main.handle_tasks(api, task_api_client)
 
     assert exc_msg in str(caplog.records[-1].exc_info[1]), caplog.records
 
 
 def test_handle_job_full_execution(
-    db, freezer, caplog, responses, live_server, monkeypatch
+    db, freezer, caplog, responses, live_server, monkeypatch, task_api_client
 ):
     monkeypatch.setattr("agent.config.TASK_API_ENDPOINT", live_server.url)
     responses.add_passthru(live_server.url)
@@ -114,7 +125,7 @@ def test_handle_job_full_execution(
         hook=lambda j: freezer.tick(1),
     )
 
-    main.handle_single_task(task, api)
+    main.handle_single_task(task, api, task_api_client)
 
     task = controller_task_api.get_task(task.id)
     assert task.agent_stage == ExecutorState.PREPARED.value
@@ -128,7 +139,7 @@ def test_handle_job_full_execution(
     assert_state_change_logs(caplog, state_changes)
 
     freezer.tick(1)
-    main.handle_single_task(task, api)
+    main.handle_single_task(task, api, task_api_client)
     task = controller_task_api.get_task(task.id)
     assert task.agent_stage == ExecutorState.EXECUTING.value
 
@@ -150,7 +161,7 @@ def test_handle_job_full_execution(
         job_id, ExecutorState.FINALIZED, finalized_timestamp_ns, hook=finalize
     )
     assert job_id not in api.tracker["finalize"]
-    main.handle_single_task(task, api)
+    main.handle_single_task(task, api, task_api_client)
     assert job_id in api.tracker["finalize"]
     task = controller_task_api.get_task(task.id)
     assert task.agent_stage == ExecutorState.FINALIZED.value
@@ -200,18 +211,16 @@ def test_handle_job_stable_states(db, executor_state):
     task, job_id = api.add_test_runjob_task(executor_state, timestamp_ns=timestamp_ns)
     job = JobDefinition.from_dict(task.definition)
 
-    with patch(
-        "agent.task_api.update_controller", spec=task_api.update_controller
-    ) as mock_update_controller:
-        main.handle_single_task(task, api)
+    mock_client = Mock(spec=task_api.TaskAPI)
+    main.handle_single_task(task, api, mock_client)
 
     # should be in the same state
-    mock_update_controller.assert_called_with(
-        task,
-        executor_state.value,
-        {},
-        False if executor_state == ExecutorState.EXECUTING else True,
-        timestamp_ns,
+    mock_client.update_controller.assert_called_with(
+        task=task,
+        stage=executor_state.value,
+        results={},
+        complete=False if executor_state == ExecutorState.EXECUTING else True,
+        timestamp_ns=timestamp_ns,
     )
 
     assert job.id not in api.tracker["prepare"]
@@ -228,8 +237,7 @@ def test_handle_job_stable_states(db, executor_state):
     assert spans[0].attributes["final_job_status"] == executor_state.name
 
 
-@patch("agent.task_api.update_controller", spec=task_api.update_controller)
-def test_handle_job_requires_db_has_secrets(mock_update_controller, db, monkeypatch):
+def test_handle_job_requires_db_has_secrets(db, monkeypatch):
     api = StubExecutorAPI()
     monkeypatch.setattr(config, "USING_DUMMY_DATA_BACKEND", False)
     monkeypatch.setattr(config, "DATABASE_URLS", {None: "dburl"})
@@ -241,13 +249,13 @@ def test_handle_job_requires_db_has_secrets(mock_update_controller, db, monkeypa
 
     api.set_job_transition(job_id, ExecutorState.EXECUTING, hook=check_env)
 
-    main.handle_run_job_task(task, api)
+    mock_client = Mock(spec=task_api.TaskAPI)
+    main.handle_run_job_task(task, api, mock_client)
 
-    assert mock_update_controller.call_count == 1
+    assert mock_client.update_controller.call_count == 1
 
 
-@patch("agent.task_api.update_controller", spec=task_api.update_controller)
-def test_handle_runjob_with_fatal_error(mock_update_controller, db):
+def test_handle_runjob_with_fatal_error(db):
     api = StubExecutorAPI()
 
     preprared_timestamp_ns = time.time_ns()
@@ -262,11 +270,12 @@ def test_handle_runjob_with_fatal_error(mock_update_controller, db):
         timestamp_ns=executing_timestamp_ns,
         hook=Mock(side_effect=Exception("test_hard_failure")),
     )
+    mock_client = Mock(spec=task_api.TaskAPI)
     with pytest.raises(Exception, match="test_hard_failure"):
-        main.handle_single_task(task, api)
+        main.handle_single_task(task, api, mock_client)
 
-    assert mock_update_controller.call_count == 1
-    call_kwargs = mock_update_controller.call_args[1]
+    assert mock_client.update_controller.call_count == 1
+    call_kwargs = mock_client.update_controller.call_args[1]
     assert call_kwargs["task"] == task
     assert call_kwargs["stage"] == ExecutorState.ERROR.value
     results = call_kwargs["results"]
@@ -300,8 +309,7 @@ def test_handle_runjob_with_fatal_error(mock_update_controller, db):
         AssertionError("a bad thing"),
     ],
 )
-@patch("agent.task_api.update_controller", spec=task_api.update_controller)
-def test_handle_runjob_with_not_fatal_error(mock_update_controller, db, exc):
+def test_handle_runjob_with_not_fatal_error(db, exc):
     api = StubExecutorAPI()
 
     task, job_id = api.add_test_runjob_task(ExecutorState.PREPARED)
@@ -312,11 +320,12 @@ def test_handle_runjob_with_not_fatal_error(mock_update_controller, db, exc):
         hook=Mock(side_effect=exc),
     )
 
+    mock_client = Mock(spec=task_api.TaskAPI)
     with pytest.raises(Exception, match=str(exc)):
-        main.handle_single_task(task, api)
+        main.handle_single_task(task, api, mock_client)
 
     # Controller is not notified of transient error
-    assert mock_update_controller.call_count == 0
+    assert mock_client.update_controller.call_count == 0
 
     spans = get_trace("agent_loop")
     assert spans[0].status.status_code.name == "ERROR"
@@ -324,8 +333,7 @@ def test_handle_runjob_with_not_fatal_error(mock_update_controller, db, exc):
     assert spans[0].attributes["fatal_task_error"] is False
 
 
-@patch("agent.task_api.update_controller", spec=task_api.update_controller)
-def test_handle_canceljob_with_fatal_error(mock_update_controller, db):
+def test_handle_canceljob_with_fatal_error(db):
     api = StubExecutorAPI()
 
     executed_timestamp_ns = time.time_ns()
@@ -341,12 +349,13 @@ def test_handle_canceljob_with_fatal_error(mock_update_controller, db):
         hook=Mock(side_effect=Exception("test_hard_failure")),
     )
 
+    mock_client = Mock(spec=task_api.TaskAPI)
     with pytest.raises(Exception):
-        main.handle_single_task(task, api)
+        main.handle_single_task(task, api, mock_client)
 
     # canceljob handler always calls update first
-    assert mock_update_controller.call_count == 2
-    call_kwargs = mock_update_controller.call_args[1]
+    assert mock_client.update_controller.call_count == 2
+    call_kwargs = mock_client.update_controller.call_args[1]
     assert call_kwargs["task"] == task
     assert call_kwargs["stage"] == ExecutorState.ERROR.value
     results = call_kwargs["results"]
@@ -390,6 +399,7 @@ def test_handle_cancel_job(
     monkeypatch,
     responses,
     live_server,
+    task_api_client,
 ):
     monkeypatch.setattr("agent.config.TASK_API_ENDPOINT", live_server.url)
     responses.add_passthru(live_server.url)
@@ -400,7 +410,7 @@ def test_handle_cancel_job(
 
     task, job_id = api.add_test_canceljob_task(initial_state)
 
-    main.handle_single_task(task, api)
+    main.handle_single_task(task, api, task_api_client)
 
     # expected status transitions
     state_changes = [
@@ -432,10 +442,7 @@ def test_handle_cancel_job(
 
 
 @patch("agent.main.docker", autospec=True)
-@patch("agent.task_api.update_controller", spec=task_api.update_controller)
-def test_handle_db_status_job_with_image_sha(
-    mock_update_controller, mock_docker, monkeypatch
-):
+def test_handle_db_status_job_with_image_sha(mock_docker, monkeypatch):
     busybox_sha = (
         "sha256:dacd1aa51e0b27c0e36c4981a7a8d9d8ec2c4a74bf125c0a44d0709497a522e9"
     )
@@ -459,7 +466,8 @@ def test_handle_db_status_job_with_image_sha(
         created_at=time.time(),
     )
 
-    main.handle_single_task(task, api=None)
+    mock_client = Mock(spec=task_api.TaskAPI)
+    main.handle_single_task(task, api=None, task_api_client=mock_client)
 
     mock_docker.assert_called_with(
         [
@@ -482,7 +490,7 @@ def test_handle_db_status_job_with_image_sha(
         text=True,
     )
 
-    mock_update_controller.assert_called_with(
+    mock_client.update_controller.assert_called_with(
         task,
         stage="",
         results={"results": {"status": "db-maintenance"}, "error": None},
@@ -492,7 +500,6 @@ def test_handle_db_status_job_with_image_sha(
 
 @patch("agent.main.ensure_docker_sha_present", autospec=True)
 @patch("agent.main.docker", autospec=True)
-@patch("agent.task_api.update_controller", spec=task_api.update_controller)
 @pytest.mark.parametrize(
     "docker_stdout,status,build_count",
     [
@@ -507,7 +514,6 @@ def test_handle_db_status_job_with_image_sha(
     ],
 )
 def test_handle_db_status_job(
-    mock_update_controller,
     mock_docker,
     mock_ensure_docker_sha_present,
     monkeypatch,
@@ -532,7 +538,8 @@ def test_handle_db_status_job(
         created_at=time.time(),
     )
 
-    main.handle_single_task(task, api=None)
+    mock_client = Mock(spec=task_api.TaskAPI)
+    main.handle_single_task(task, api=None, task_api_client=mock_client)
 
     mock_docker.assert_called_with(
         [
@@ -555,7 +562,7 @@ def test_handle_db_status_job(
         text=True,
     )
 
-    mock_update_controller.assert_called_with(
+    mock_client.update_controller.assert_called_with(
         task,
         stage="",
         results={"results": {"status": status}, "error": None},
@@ -572,10 +579,7 @@ def test_handle_db_status_job(
 
 
 @patch("agent.main.ensure_docker_sha_present", autospec=True)
-@patch("agent.task_api.update_controller", spec=task_api.update_controller)
-def test_handle_db_status_job_with_error(
-    mock_update_controller, mock_ensure_docker_sha_present
-):
+def test_handle_db_status_job_with_error(mock_ensure_docker_sha_present):
     task = Task(
         id="test_id",
         backend="test",
@@ -588,9 +592,10 @@ def test_handle_db_status_job_with_error(
         created_at=time.time(),
     )
 
-    main.handle_single_task(task, api=None)
+    mock_client = Mock(spec=task_api.TaskAPI)
+    main.handle_single_task(task, api=None, task_api_client=mock_client)
 
-    mock_update_controller.assert_called_with(
+    mock_client.update_controller.assert_called_with(
         task,
         stage="",
         results={
@@ -603,10 +608,7 @@ def test_handle_db_status_job_with_error(
 
 @patch("agent.main.ensure_docker_sha_present", autospec=True)
 @patch("agent.main.run_db_task", autospec=True)
-@patch("agent.task_api.update_controller", spec=task_api.update_controller)
-def test_handle_db_data_check_task(
-    mock_update_controller, mock_run_db_task, mock_ensure_docker_sha_present
-):
+def test_handle_db_data_check_task(mock_run_db_task, mock_ensure_docker_sha_present):
     mock_run_db_task.return_value = "OK"
 
     task = Task(
@@ -621,7 +623,8 @@ def test_handle_db_data_check_task(
         created_at=time.time(),
     )
 
-    main.handle_single_task(task, api=None)
+    mock_client = Mock(spec=task_api.TaskAPI)
+    main.handle_single_task(task, api=None, task_api_client=mock_client)
 
     mock_run_db_task.assert_called_with(
         ["hes_cutoff_date_check", "202304"],
@@ -629,7 +632,7 @@ def test_handle_db_data_check_task(
         image_sha="sha123456",
     )
 
-    mock_update_controller.assert_called_with(
+    mock_client.update_controller.assert_called_with(
         task,
         stage="",
         results={"results": {"status": "OK"}, "error": None},
@@ -680,7 +683,7 @@ def test_db_data_check_task_rejects_unexpected_status(
 
 
 def test_handle_job_no_task_id_in_definition(
-    db, freezer, caplog, responses, live_server, monkeypatch
+    db, freezer, caplog, responses, live_server, monkeypatch, task_api_client
 ):
     monkeypatch.setattr("agent.config.TASK_API_ENDPOINT", live_server.url)
     responses.add_passthru(live_server.url)
@@ -696,7 +699,7 @@ def test_handle_job_no_task_id_in_definition(
     task.definition.pop("task_id")
     update_where(Task, {"definition": task.definition}, id=task.id)
 
-    main.handle_single_task(task, api)
+    main.handle_single_task(task, api, task_api_client)
 
     task = controller_task_api.get_task(task.id)
     assert task.agent_stage == ExecutorState.PREPARED.value

--- a/tests/agent/test_main.py
+++ b/tests/agent/test_main.py
@@ -1,8 +1,8 @@
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 
-from agent import config, main
+from agent import config, main, task_api
 from common.job_executor import ExecutorState, JobStatus
 from tests.factories import job_definition_factory, runjob_db_task_factory
 
@@ -69,7 +69,6 @@ def test_inject_db_secrets_invalid_db_name(monkeypatch, db):
 
 
 @patch("agent.tracing.set_job_results_metadata")
-@patch("agent.task_api.update_controller")
 @pytest.mark.parametrize(
     "output_results,expected_redacted_results",
     [
@@ -124,7 +123,6 @@ def test_inject_db_secrets_invalid_db_name(monkeypatch, db):
     ],
 )
 def test_update_job_task_results_redacted(
-    mock_update_controller,
     mock_set_job_results_metadata,
     db,
     output_results,
@@ -140,9 +138,12 @@ def test_update_job_task_results_redacted(
     job_status = JobStatus(ExecutorState.FINALIZED, results=job_results)
     previous_job_status = JobStatus(ExecutorState.EXECUTED, results={})
 
-    main.update_job_task(task, job_status, previous_job_status, complete=True)
+    mock_client = Mock(spec=task_api.TaskAPI)
+    main.update_job_task(
+        task, job_status, mock_client, previous_job_status, complete=True
+    )
 
-    mock_update_controller.assert_called_with(
+    mock_client.update_controller.assert_called_with(
         task=task,
         stage=job_status.state.value,
         results=expected_redacted_results,

--- a/tests/agent/test_metrics.py
+++ b/tests/agent/test_metrics.py
@@ -57,7 +57,7 @@ def test_read_write_job_metrics():
 
 @pytest.mark.parametrize("task_present", [True, False])
 def test_record_metrics_tick_trace(
-    db, freezer, monkeypatch, live_server, responses, task_present
+    db, freezer, monkeypatch, live_server, responses, task_present, task_api_client
 ):
     monkeypatch.setattr("agent.config.TASK_API_ENDPOINT", live_server.url)
     responses.add_passthru(live_server.url)
@@ -86,12 +86,12 @@ def test_record_metrics_tick_trace(
         },
     )
 
-    last_run1 = metrics.record_metrics_tick_trace(None)
+    last_run1 = metrics.record_metrics_tick_trace(None, task_api_client)
     assert len(get_trace("metrics")) == 0
 
     freezer.tick(10)
 
-    last_run2 = metrics.record_metrics_tick_trace(last_run1)
+    last_run2 = metrics.record_metrics_tick_trace(last_run1, task_api_client)
     assert last_run2 == last_run1 + 10 * 1e9
 
     spans = get_trace("metrics")
@@ -141,7 +141,7 @@ def test_record_metrics_tick_trace(
 
 
 def test_record_metrics_tick_trace_stats_timeout(
-    db, freezer, live_server, responses, monkeypatch
+    db, freezer, live_server, responses, monkeypatch, task_api_client
 ):
     monkeypatch.setattr("agent.config.TASK_API_ENDPOINT", live_server.url)
     responses.add_passthru(live_server.url)
@@ -154,7 +154,7 @@ def test_record_metrics_tick_trace_stats_timeout(
     last_run = time.time()
     freezer.tick(10)
 
-    metrics.record_metrics_tick_trace(last_run)
+    metrics.record_metrics_tick_trace(last_run, task_api_client)
     assert len(get_trace("metrics")) == 2
 
     spans = get_trace("metrics")
@@ -171,7 +171,7 @@ def test_record_metrics_tick_trace_stats_timeout(
 
 
 def test_record_metrics_tick_trace_stats_error(
-    db, freezer, monkeypatch, live_server, responses
+    db, freezer, monkeypatch, live_server, responses, task_api_client
 ):
     monkeypatch.setattr("agent.config.TASK_API_ENDPOINT", live_server.url)
     responses.add_passthru(live_server.url)
@@ -184,7 +184,7 @@ def test_record_metrics_tick_trace_stats_error(
     monkeypatch.setattr(metrics, "get_job_stats", error)
 
     last_run = time.time()
-    metrics.record_metrics_tick_trace(last_run)
+    metrics.record_metrics_tick_trace(last_run, task_api_client)
     assert len(get_trace("metrics")) == 2
 
     spans = get_trace("metrics")

--- a/tests/agent/test_task_api.py
+++ b/tests/agent/test_task_api.py
@@ -4,7 +4,7 @@ import pytest
 import requests
 from responses import matchers
 
-from agent import config, task_api
+from agent import config
 from common.schema import AgentTask
 from controller import task_api as controller_api
 from tests.factories import runjob_db_task_factory
@@ -26,7 +26,7 @@ def setup_config(monkeypatch):
     )
 
 
-def test_get_active_tasks(db, monkeypatch, responses):
+def test_get_active_tasks(db, monkeypatch, responses, task_api_client):
     monkeypatch.setattr("agent.config.BACKEND", "dummy")
 
     task1 = runjob_db_task_factory(backend="dummy")
@@ -49,18 +49,18 @@ def test_get_active_tasks(db, monkeypatch, responses):
         match=[matchers.header_matcher({"Authorization": config.TASK_API_TOKEN})],
     )
 
-    active = task_api.get_active_tasks()
+    active = task_api_client.get_active_tasks()
     assert len(active) == 1
     assert active[0].id == task1.id
 
     monkeypatch.setattr("agent.config.BACKEND", "another")
 
-    active = task_api.get_active_tasks()
+    active = task_api_client.get_active_tasks()
     assert len(active) == 1
     assert active[0].id == task3.id
 
 
-def test_get_active_tasks_api_error(db, monkeypatch, responses):
+def test_get_active_tasks_api_error(db, monkeypatch, responses, task_api_client):
     monkeypatch.setattr("agent.config.BACKEND", "dummy")
 
     runjob_db_task_factory(backend="dummy")
@@ -73,16 +73,16 @@ def test_get_active_tasks_api_error(db, monkeypatch, responses):
     )
 
     with pytest.raises(requests.HTTPError):
-        task_api.get_active_tasks()
+        task_api_client.get_active_tasks()
 
 
-def test_update_controller(db, monkeypatch, responses, live_server):
+def test_update_controller(db, monkeypatch, responses, live_server, task_api_client):
     monkeypatch.setattr("agent.config.TASK_API_ENDPOINT", live_server.url)
     responses.add_passthru(live_server.url)
 
     task = runjob_db_task_factory(backend="test")
 
-    task_api.update_controller(
+    task_api_client.update_controller(
         task,
         stage="FINALIZED",
         results={"test": "test"},
@@ -96,14 +96,16 @@ def test_update_controller(db, monkeypatch, responses, live_server):
     assert db_task.agent_timestamp_ns is None
 
 
-def test_update_controller_with_timestamp(db, monkeypatch, responses, live_server):
+def test_update_controller_with_timestamp(
+    db, monkeypatch, responses, live_server, task_api_client
+):
     monkeypatch.setattr("agent.config.TASK_API_ENDPOINT", live_server.url)
     responses.add_passthru(live_server.url)
 
     task = runjob_db_task_factory(backend="dummy")
 
     timestamp = time.time_ns()
-    task_api.update_controller(
+    task_api_client.update_controller(
         task,
         stage="FINALIZED",
         results={"test": "test"},
@@ -118,7 +120,7 @@ def test_update_controller_with_timestamp(db, monkeypatch, responses, live_serve
     assert db_task.agent_timestamp_ns == timestamp
 
 
-def test_full_job_stages(db, responses, monkeypatch, live_server):
+def test_full_job_stages(db, responses, monkeypatch, live_server, task_api_client):
     monkeypatch.setattr("agent.config.TASK_API_ENDPOINT", live_server.url)
     responses.add_passthru(live_server.url)
     task = runjob_db_task_factory(backend="dummy")
@@ -131,14 +133,15 @@ def test_full_job_stages(db, responses, monkeypatch, live_server):
     ]
 
     for stage in stages:
-        task_api.update_controller(task, stage)
+        task_api_client.update_controller(task, stage)
         db_task = controller_api.get_task(task.id)
         assert db_task.agent_stage == stage
         assert bool(db_task.agent_complete) is False
 
-    task_api.update_controller(
+    task_api_client.update_controller(
         task, "FINALIZED", results={"test": "test"}, complete=True
     )
+
     db_task = controller_api.get_task(task.id)
     assert db_task.agent_stage == "FINALIZED"
     assert db_task.agent_results == {"test": "test"}

--- a/tests/agent/test_tracing.py
+++ b/tests/agent/test_tracing.py
@@ -1,5 +1,5 @@
 import time
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from opentelemetry import trace
 
@@ -19,14 +19,13 @@ from tests.conftest import get_trace
 from tests.factories import job_definition_factory, runjob_db_task_factory
 
 
-@patch("agent.task_api.update_controller", spec=task_api.update_controller)
-def test_tracing_state_change_attributes(mock_update_controller, db):
+def test_tracing_state_change_attributes(db):
     api = StubExecutorAPI()
 
     task, job_id = api.add_test_runjob_task(ExecutorState.UNKNOWN)
     # prepare is synchronous
     api.set_job_transition(job_id, ExecutorState.PREPARED)
-    main.handle_single_task(task, api)
+    main.handle_single_task(task, api, Mock(spec=task_api.TaskAPI))
 
     spans = get_trace("agent_loop")
     # one span each time we called main.handle_single_task
@@ -75,15 +74,14 @@ def test_tracing_state_change_attributes(mock_update_controller, db):
     assert not spans[0].attributes["complete"]
 
 
-@patch("agent.task_api.update_controller", spec=task_api.update_controller)
-def test_tracing_final_state_attributes(mock_update_controller, db):
+def test_tracing_final_state_attributes(db):
     api = StubExecutorAPI()
 
     task, job_id = api.add_test_runjob_task(ExecutorState.EXECUTED)
     api.set_job_transition(
         job_id, ExecutorState.FINALIZED, hook=lambda job: api.set_job_metadata(job.id)
     )
-    main.handle_single_task(task, api)
+    main.handle_single_task(task, api, Mock(spec=task_api.TaskAPI))
 
     spans = get_trace("agent_loop")
     # one span each time we called main.handle_single_task
@@ -252,10 +250,7 @@ def test_set_task_span_metadata_tracing_errors_do_not_raise(db, caplog):
     assert f"failed to trace task {task.id}" in caplog.text
 
 
-@patch("agent.task_api.update_controller", spec=task_api.update_controller)
-def test_tracing_final_state_attributes_tracing_errors(
-    mock_update_controller, db, caplog
-):
+def test_tracing_final_state_attributes_tracing_errors(db, caplog):
     api = StubExecutorAPI()
 
     task, job_id = api.add_test_runjob_task(ExecutorState.EXECUTED)
@@ -263,7 +258,7 @@ def test_tracing_final_state_attributes_tracing_errors(
         job_id, ExecutorState.FINALIZED, hook=lambda job: api.set_job_metadata(job.id)
     )
     with patch("agent.tracing.set_span_attributes", side_effect=Exception("foo")):
-        main.handle_single_task(task, api)
+        main.handle_single_task(task, api, Mock(spec=task_api.TaskAPI))
 
     spans = get_trace("agent_loop")
     assert len(spans) == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 import sys
 import tempfile
-import threading
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -41,45 +40,10 @@ def pytest_configure(config):
     )
 
 
-@pytest.fixture(scope="session", autouse=True)
-def close_task_api_session():
-    # agent.task_api uses a module-level requests.Session. Disable keep-alive
-    # by sending Connection: close in the session headers so that the
-    # server's daemon request-handler threads exit after each response rather than
-    # lingering into interpreter shutdown.
-    task_api.session.headers["Connection"] = "close"
-    # On its own, the above fixed the intermittent threading errors, but introduced another
-    # intermittent RemoteDisconnected error.
-    # This appears to be because Django's ServerHandler.cleanup_headers() only writes
-    # Connection: close to the response when the response has no Content-Length
-    # or the server isn't a ThreadingMixIn. The live server is a ThreadingMixIn
-    # and API responses have Content-Length, so
-    # urllib3 never sees Connection: close in the response headers:
-    # https://github.com/django/django/blob/141e791f48592011b0f38fb30d44291e3ce74ee0/django/core/servers/basehttp.py
-    # Add a retry to avoid the RemoteDisconnected errors
-    task_api.session.mount(
-        "http://",
-        requests.adapters.HTTPAdapter(
-            max_retries=urllib3.util.Retry(
-                total=3,
-                read=3,
-                backoff_factor=0,
-                allowed_methods=urllib3.util.Retry.DEFAULT_ALLOWED_METHODS
-                | frozenset(["POST"]),
-            )
-        ),
-    )
-    yield
-
-    # If any process_request_thread threads are still alive the threading fix has regressed.
-    for t in threading.enumerate():
-        if t.daemon and "process_request_thread" in t.name:
-            t.join(timeout=2.0)
-            if t.is_alive():
-                raise RuntimeError(
-                    f"Daemon thread {t.name!r} still alive after session teardown — "
-                    "Connection: close may not be taking effect"
-                )
+@pytest.fixture
+def task_api_client():
+    with task_api.TaskAPI() as client:
+        yield client
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -83,7 +83,13 @@ def set_controller_config(monkeypatch):
 @pytest.mark.needs_docker
 @pytest.mark.needs_ghcr
 def test_integration(
-    live_server, tmp_work_dir, docker_cleanup, monkeypatch, test_repo, responses
+    live_server,
+    tmp_work_dir,
+    docker_cleanup,
+    monkeypatch,
+    test_repo,
+    responses,
+    task_api_client,
 ):
     api = get_executor_api()
     monkeypatch.setattr("common.config.BACKENDS", ["test"])
@@ -180,7 +186,7 @@ def test_integration(
     set_agent_config(monkeypatch, tmp_work_dir)
     # Execute one tick of the agent run loop to pick up the runjob task
     # After one tick, the task should have moved to the PREPARED stage
-    agent.main.handle_tasks(api)
+    agent.main.handle_tasks(api, task_api_client)
     active_tasks = get_active_db_tasks()
     assert len(active_tasks) == 1
     assert active_tasks[0].agent_stage == "prepared"
@@ -196,7 +202,7 @@ def test_integration(
     # AGENT
     set_agent_config(monkeypatch, tmp_work_dir)
     # After one tick of the agent loop, the task should have moved to EXECUTING status
-    agent.main.handle_tasks(api)
+    agent.main.handle_tasks(api, task_api_client)
     active_tasks = get_active_db_tasks()
     assert len(active_tasks) == 1
     assert active_tasks[0].agent_stage == "executing"


### PR DESCRIPTION
Remove the _catch_shutdown_errors threading excepthook. It tried to suppress errors with a try/catch during shutdown, and to print the error in case stdout was available. However, the threading errors weren't being suppressed properly, and possibly the print was actually triggering them. In any case, we've been seeing them quite frequently, and not with the except print statement.

The issue appears to actually be with the agent.task_api's module-level requests.Session, which was interacting badly with the live server's daemon request-handler. 

This PR refactors the task_api into a TaskAPI client which is used as a context manager to ensure that the session is closed on exit. The agent loops run inside the context manager, so the Session is reused across requests, as we want. In tests, we have a fixture that uses the client as a context manager too, and means that each test closes the session properly. 

I've tested this by running the docker tests repeatedly locally. Without this fix, they hit the threading error within the first few runs. With it, they ran 50x without hitting it. However, they did highlight another intermittent error in the few tests that make actual calls to ghcr.io, so there's also a retry added there; it retries a max of 3 times with a 1sec delay, so although it's a change in production code, it shouldn't have a huge impact. With this, my repeated docker tests ran successfully 50/50 times.

Note: there's an [alternative PR ](https://github.com/opensafely-core/job-runner/pull/1422)that leaves the main code as it is and handles the test errors in a fixture. That works, but the fixture workaround is complex. Although this solution involves more code change, I think it's better.