### PR TITLE
Continue running DBSTATUS tasks in manual maintenance mode

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -19,7 +19,7 @@
 - [job-runner docker image](#job-runner-docker-image)
 - [Database schema and migrations](#database-schema-and-migrations)
 - [Deployment](#deploying)
-- [Running controller commands in production](running-controller-commands-in-production)
+- [Running controller commands in production](#running-controller-commands-in-production)
   - [Turn manual database maintenance mode on/off](#turn-manual-database-maintenance-mode-onoff-on-a-specific-backend)
   - [Pause a backend](#pause-a-backend)
   - [Prepare for reboot](#prepare-for-reboot)
@@ -777,6 +777,18 @@ dokku run rap-controller python manage.py db_maintenance <on/off> <backend slug>
 
 # i.e. to turn maintenance mode on for the tpp backend
 dokku run rap-controller python manage.py db_maintenance on tpp
+```
+
+By default, checks for db-maintenance via DBSTATUS tasks continue to run during
+manual maintenance mode. If we want to prevent any connections to the database,
+including checks for maintenance mode, disable the checks with the `--disable-checks` option.
+
+i.e. to turn maintenance mode on for the tpp backend, deactivate any existing
+DBSTATUS tasks and prevent new ones being created:
+
+```
+dokku run rap-controller python manage.py db_maintenance on tpp --disable-checks
+
 ```
 
 ### Pause a backend

--- a/controller/main.py
+++ b/controller/main.py
@@ -723,6 +723,9 @@ def update_scheduled_tasks():
 
 
 def update_scheduled_task_for_db_maintenance_for_backend(backend):
+    manual_db_maintenance = get_flag_value("manual-db-maintenance", backend)
+    db_checks_disabled = get_flag_value("db-maintenance-checks-disabled", backend)
+
     schedule_regular_task(
         backend=backend,
         task_type=TaskType.DBSTATUS,
@@ -731,7 +734,7 @@ def update_scheduled_task_for_db_maintenance_for_backend(backend):
             **get_database_utils_image_details(),
         },
         task_interval=config.MAINTENANCE_POLL_INTERVAL,
-        is_active=not get_flag_value("manual-db-maintenance", backend),
+        is_active=not (manual_db_maintenance and db_checks_disabled),
     )
 
 

--- a/controller/webapp/management/commands/db_maintenance.py
+++ b/controller/webapp/management/commands/db_maintenance.py
@@ -6,7 +6,9 @@ from controller.cli import flags as flags_cli
 
 class Command(BaseCommand):
     """
-    Manually enable or disable database maintenance mode
+    Manually enable or disable database maintenance mode.
+    By default, checks for automatically detected maintenance mode (i.e. DBSTATUS tasks)
+    continue to run during manual maintenance mode.
     """
 
     def add_arguments(self, parser):
@@ -20,11 +22,26 @@ class Command(BaseCommand):
             type=str.lower,
             choices=common_config.BACKENDS,
         )
+        parser.add_argument(
+            "--disable-checks",
+            action="store_true",
+            help="Disable DB_STATUS task checks",
+        )
 
     def handle(self, action, backend, **options):
         if action == "on":
             flags = [("mode", "db-maintenance"), ("manual-db-maintenance", "on")]
+            if options["disable_checks"]:
+                flags.append(("db-maintenance-checks-disabled", "true"))
+            else:
+                # If the disable-checks option isn't present, make sure that any previously
+                # set flag has been cleared
+                flags.append(("db-maintenance-checks-disabled", None))
         else:
-            flags = [("mode", None), ("manual-db-maintenance", None)]
+            flags = [
+                ("mode", None),
+                ("manual-db-maintenance", None),
+                ("db-maintenance-checks-disabled", None),
+            ]
 
         flags_cli.main(backend, "set", flags)

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -1112,10 +1112,20 @@ def test_update_scheduled_task_for_db_maintenance(db, monkeypatch, freezer):
     assert tasks[0].active is False
     assert tasks[1].active is True
 
-    # Enable manual database maintenance mode
+    # Enable manual database maintenance mode; checks remain enabled by default
     set_flag("manual-db-maintenance", "true", backend="test")
 
-    # Now running the loop should deactivate any active tasks
+    # Running the loop should NOT deactivate any active tasks
+    run_controller_loop_once()
+    tasks = database.find_where(Task, type=TaskType.DBSTATUS)
+    assert len(tasks) == 2
+    assert tasks[0].active is False
+    assert tasks[1].active is True
+
+    # Disable checks
+    set_flag("db-maintenance-checks-disabled", "true", backend="test")
+
+    # Running the loop deactivates any active tasks
     run_controller_loop_once()
     tasks = database.find_where(Task, type=TaskType.DBSTATUS)
     assert len(tasks) == 2

--- a/tests/controller/webapp/test_management.py
+++ b/tests/controller/webapp/test_management.py
@@ -105,25 +105,51 @@ def test_pause(db, freezer, capsys, monkeypatch):
 
 def test_db_maintenance(db, freezer, capsys):
     freezer.move_to(TEST_DATESTR)
+    # enable manual maintenance, checks are NOT disabled by default
     call_command("db_maintenance", "on", "test")
     stdout, stderr = capsys.readouterr()
     assert (
         stdout
-        == f"[test] mode=db-maintenance ({TEST_DATESTR})\n[test] manual-db-maintenance=on ({TEST_DATESTR})\n"
+        == f"[test] mode=db-maintenance ({TEST_DATESTR})\n[test] manual-db-maintenance=on ({TEST_DATESTR})\n[test] db-maintenance-checks-disabled=None ({TEST_DATESTR})\n"
     )
     assert stderr == ""
     assert queries.get_flag("mode", "test").value == "db-maintenance"
     assert queries.get_flag("manual-db-maintenance", "test").value == "on"
+    assert queries.get_flag("db-maintenance-checks-disabled", "test").value is None
 
     call_command("db_maintenance", "off", "test")
     stdout, stderr = capsys.readouterr()
     assert (
         stdout
-        == f"[test] mode=None ({TEST_DATESTR})\n[test] manual-db-maintenance=None ({TEST_DATESTR})\n"
+        == f"[test] mode=None ({TEST_DATESTR})\n[test] manual-db-maintenance=None ({TEST_DATESTR})\n[test] db-maintenance-checks-disabled=None ({TEST_DATESTR})\n"
     )
     assert stderr == ""
     assert queries.get_flag("mode", "test").value is None
     assert queries.get_flag("manual-db-maintenance", "test").value is None
+    assert queries.get_flag("db-maintenance-checks-disabled", "test").value is None
+
+    # enable manual maintenance with checks diabled
+    call_command("db_maintenance", "on", "test", disable_checks=True)
+    stdout, stderr = capsys.readouterr()
+    assert (
+        stdout
+        == f"[test] mode=db-maintenance ({TEST_DATESTR})\n[test] manual-db-maintenance=on ({TEST_DATESTR})\n[test] db-maintenance-checks-disabled=true ({TEST_DATESTR})\n"
+    )
+    assert stderr == ""
+    assert queries.get_flag("mode", "test").value == "db-maintenance"
+    assert queries.get_flag("manual-db-maintenance", "test").value == "on"
+    assert queries.get_flag("db-maintenance-checks-disabled", "test").value == "true"
+
+    call_command("db_maintenance", "off", "test")
+    stdout, stderr = capsys.readouterr()
+    assert (
+        stdout
+        == f"[test] mode=None ({TEST_DATESTR})\n[test] manual-db-maintenance=None ({TEST_DATESTR})\n[test] db-maintenance-checks-disabled=None ({TEST_DATESTR})\n"
+    )
+    assert stderr == ""
+    assert queries.get_flag("mode", "test").value is None
+    assert queries.get_flag("manual-db-maintenance", "test").value is None
+    assert queries.get_flag("db-maintenance-checks-disabled", "test").value is None
 
 
 def test_snapshot_database(tmp_path, monkeypatch, freezer):


### PR DESCRIPTION
Usually, when we turn on manual maintenance mode it's because we want to kill running db jobs and reduce load on the db, e.g if it's late entering actual maintenance. We still want to know when we enter actual maintenance mode, so usually we still want the DBSTATUS tasks to continue to run.

This adds a --disable-check option to the db-maintenance management command, for the cases where we want to prevent any tasks that connect to the database, including the db-maintenance checks. A DBSTATUS scheduled task is only considered not active if we're in manual maintenance mode AND it's been run with disable-checks.

Closes #1429