### PR TITLE
Fix misleading prepare for reboot status

### DIFF
--- a/controller/cli/prepare_for_reboot.py
+++ b/controller/cli/prepare_for_reboot.py
@@ -14,7 +14,6 @@ from controller.queries import get_flag_value
 
 
 def main(backend, status=False, skip_confirm=False):
-
     paused = str(get_flag_value("paused", backend, default="False")).lower() == "true"
     running_jobs = find_where(Job, state=State.RUNNING, backend=backend)
 
@@ -31,7 +30,10 @@ def main(backend, status=False, skip_confirm=False):
         if cancel_tasks:
             report += f"3) {len(cancel_tasks)} job(s) are being cancelled\n"
 
-        if not running_jobs and not cancel_tasks:
+        if not paused:
+            # prepare_for_reboot was not run as it pauses the backend
+            report += f"Backend '{backend}' is not paused. Run prepare_for_reboot, then check the status again\n"
+        elif not running_jobs and not cancel_tasks:
             # No jobs are running, and there are no active canceljob tasks, we are ready to reboot
             report += "\n== READY TO REBOOT ==\n"
             report += "Safe to reboot now\n"

--- a/tests/controller/cli/test_prepare_for_reboot.py
+++ b/tests/controller/cli/test_prepare_for_reboot.py
@@ -169,8 +169,11 @@ def test_prepare_for_reboot_status_ready_to_reboot(db, paused, capsys):
     out, _ = capsys.readouterr()
     assert f"1) backend 'test' is {'not ' if not paused else ''}paused" in out
     assert "2) 0 job(s) are running" in out
-    assert "READY TO REBOOT" in out
     if paused:
-        assert "Safe to reboot now"
+        assert "READY TO REBOOT" in out
+        assert "Safe to reboot now" in out
     else:
-        assert "Pause backend 'test' before rebooting"
+        assert (
+            "Backend 'test' is not paused. Run prepare_for_reboot, then check the status again\n"
+            in out
+        )


### PR DESCRIPTION
There is a niche corner case where a dev runs the `prepare_for_reboot` status report before the `prepare_for_reboot` command itself, in which case the report misleadingly displays "Safe to reboot now".

Even though this is an unlikely scenario, we probably don't want to display the "Safe to reboot" message in any circumstances other than when it is truly safe. When the backend is not paused, prompt the dev to run `prepare_for_reboot` instead.

Maybe we could combine the command and the status check by adding a `while` loop that runs the status check until it's safe to reboot, but that seems like a task for another day and I have gone with the simplest change for now.