### PR TITLE
Make local repo support an explict setting

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -177,7 +177,8 @@ a backend to run it on e.g.
 just add-job https://github.com/opensafely/test-age-distribution run_all --backend test
 ```
 
-As well as URLs this will accept paths to local git repos e.g.
+As well as URLs this will accept paths to local git repos, as long as the
+`ALLOW_LOCAL_GIT_REPOS` environment variable is set to `True` e.g.
 ```
 git clone git@github.com:opensafely/test-age-distribution.git ../test-age-distribution
 just add-job ../test-age-distribution run_all --backend test

--- a/agent/main.py
+++ b/agent/main.py
@@ -219,6 +219,7 @@ def handle_run_job_task(task, api):
                     job.study.git_repo_url,
                     job.study.commit,
                     job.study.branch,
+                    allow_local_git_repos=common_config.ALLOW_LOCAL_GIT_REPOS,
                 )
                 # prepare is synchronous, which means set our code to PREPARING
                 # before calling  api.prepare(), and we expect it to be PREPARED

--- a/common/config.py
+++ b/common/config.py
@@ -63,3 +63,5 @@ ALLOWED_GITHUB_ORGS = (
     .strip()
     .split(",")
 )
+
+ALLOW_LOCAL_GIT_REPOS = os.environ.get("ALLOW_LOCAL_GIT_REPOS", "").lower() == "true"

--- a/common/lib/github_validators.py
+++ b/common/lib/github_validators.py
@@ -7,11 +7,14 @@ class GithubValidationError(Exception):
     pass
 
 
-def validate_repo_and_commit(allowed_gitub_orgs, repo_url, commit, branch):
-    # just validating http prefix allows local git repos, useful for tests
-    if repo_url.startswith("http"):
-        validate_repo_url(repo_url, allowed_gitub_orgs)
-        validate_branch_and_commit(repo_url, commit, branch)
+def validate_repo_and_commit(
+    allowed_gitub_orgs, repo_url, commit, branch, allow_local_git_repos=False
+):
+    # We support this for tests and local development
+    if allow_local_git_repos and repo_url.startswith("/"):
+        return
+    validate_repo_url(repo_url, allowed_gitub_orgs)
+    validate_branch_and_commit(repo_url, commit, branch)
 
 
 def validate_repo_url(repo_url, allowed_gitub_orgs):

--- a/controller/create_or_update_jobs.py
+++ b/controller/create_or_update_jobs.py
@@ -114,6 +114,7 @@ def validate_rap_create_request(rap_create_request):
         rap_create_request.repo_url,
         rap_create_request.commit,
         rap_create_request.branch,
+        allow_local_git_repos=common_config.ALLOW_LOCAL_GIT_REPOS,
     )
 
 

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -14,6 +14,10 @@ BACKENDS=test
 # A Github developer token that has read access to private repos
 PRIVATE_REPO_ACCESS_TOKEN=
 
+# Allow running jobs directly from local git repos to facilitate local development and
+# testing
+ALLOW_LOCAL_GIT_REPOS=True
+
 # How frequently to poll internal database and Docker for the current state of
 # active jobs
 JOB_LOOP_INTERVAL=1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from agent import config as agent_config
 from agent import metrics, task_api
+from common import config as common_config
 from common.tracing import add_exporter, get_provider
 from controller import config as controller_config
 from controller.lib import database, docker
@@ -363,3 +364,8 @@ def patch_image_shas(request, monkeypatch, responses):
     monkeypatch.setattr(docker, "get_current_image_sha", get_current_image_sha)
     # caller can modify sha_map if needed
     return sha_map
+
+
+@pytest.fixture(autouse=True)
+def allow_local_git_repos(monkeypatch):
+    monkeypatch.setattr(common_config, "ALLOW_LOCAL_GIT_REPOS", True)

--- a/tests/controller/test_main.py
+++ b/tests/controller/test_main.py
@@ -943,11 +943,11 @@ def test_job_definition_defaults(db):
         "study": {
             "branch": "main",
             "commit": "commit",
-            "git_repo_url": "repo",
+            "git_repo_url": "/repo",
         },
         "task_id": "task_id",
         "workspace": "workspace",
-        "repo_url": "repo",
+        "repo_url": "/repo",
         "commit": "commit",
     }
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,7 +15,7 @@ from tests.conftest import test_exporter
 
 
 DEFAULT_COMMIT = "commit"
-DEFAULT_REPO = "repo"
+DEFAULT_REPO = "/repo"
 
 CREATE_REQUEST_DEFAULTS = {
     "repo_url": DEFAULT_REPO,


### PR DESCRIPTION
We want to support local git repos in tests and in development but not in production. There's currently no exploitable pathway here given our deployment configuration, but it's best to be defensive.