### PR TITLE
Parallelise tests

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -96,7 +96,7 @@ services:
     container_name: job-runner-test
     # override command
     command: >
-      python -m pytest
+      python -m pytest -n auto
     environment:
       IMAGE_PULL_TIMEOUT: 300
 

--- a/justfile
+++ b/justfile
@@ -102,7 +102,7 @@ upgrade-pipeline: && devenv uvmirror
 
 # Run the tests
 test *ARGS: _checkenv
-    IMAGE_PULL_TIMEOUT=300 uv run pytest --cov --cov-report=term --cov-report=html "$@"
+    IMAGE_PULL_TIMEOUT=300 uv run pytest --cov --cov-context=test --cov-report=term --cov-report=html "$@"
 
 test-fast *ARGS: _checkenv
     uv run python -m pytest tests -m "not slow_test" "$@"

--- a/justfile
+++ b/justfile
@@ -102,16 +102,16 @@ upgrade-pipeline: && devenv uvmirror
 
 # Run the tests
 test *ARGS: _checkenv
-    IMAGE_PULL_TIMEOUT=300 uv run pytest --cov --cov-context=test --cov-report=term --cov-report=html "$@"
+    IMAGE_PULL_TIMEOUT=300 uv run pytest -n auto --cov --cov-context=test --cov-report=term --cov-report=html "$@"
 
 test-fast *ARGS: _checkenv
-    uv run python -m pytest tests -m "not slow_test" "$@"
+    uv run python -m pytest tests -n auto -m "not slow_test" "$@"
 
 test-verbose *ARGS: _checkenv
     uv run python -m pytest tests/test_integration.py -o log_cli=true -o log_cli_level=INFO "$@"
 
 test-no-docker *ARGS: _checkenv
-    uv run python -m pytest -m "not needs_docker" "$@"
+    uv run python -m pytest -n auto -m "not needs_docker" "$@"
 
 # Run an agent cli command locally
 cli command *ARGS: _checkenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ extend-ignore = [
 isort.lines-after-imports = 2
 
 [tool.pytest.ini_options]
+addopts = "--dist=loadgroup"
 filterwarnings = [
     "error",
     "ignore::DeprecationWarning:opentelemetry.*:",
@@ -107,6 +108,7 @@ dev = [
     "pytest-django",
     "pytest-freezer",
     "pytest-responses",
+    "pytest-xdist>=3.8.0",
     "ruff",
     # OpenAPI tools
     "schemathesis",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ Source = "https://github.com/opensafely-core/job-runner"
 
 [tool.coverage.run]
 branch = true
-dynamic_context = "test_function"
 source = ["agent", "controller"]
 omit = [
     # These are covered by subprocess tests which aren't tracked properly
@@ -85,7 +84,6 @@ filterwarnings = [
     "ignore::DeprecationWarning:pytest_freezegun:17",
     "ignore::DeprecationWarning:pytest_responses:9",
     "ignore::DeprecationWarning:schemathesis.*:",
-    "ignore:.*dynamic_context.*:pytest_cov.CentralCovContextWarning",
     "ignore:ProjectWarning:UserWarning:pipeline.*:",
     "ignore:ProjectWarning:UserWarning:tests.*:",
 ]

--- a/requirements.uvmirror
+++ b/requirements.uvmirror
@@ -33,6 +33,8 @@ distro==1.9.0
     # via ruyaml
 django==6.0.5
     # via opensafely-jobrunner
+execnet==2.1.2
+    # via pytest-xdist
 filelock==3.29.0
     # via
     #   python-discovery
@@ -163,11 +165,13 @@ pytest==9.0.3
     #   pytest-django
     #   pytest-freezer
     #   pytest-responses
+    #   pytest-xdist
     #   schemathesis
 pytest-cov==7.1.0
 pytest-django==4.12.0
 pytest-freezer==0.4.9
 pytest-responses==0.5.1
+pytest-xdist==3.8.0
 python-dateutil==2.9.0.post0
     # via freezegun
 python-discovery==1.3.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,19 @@ def pytest_configure(config):
     )
 
 
+def pytest_itemcollected(item):
+    # Mark every docker test with a a xdist_group so they run with a single worker.
+    # The tests that use docker typically need to look at e.g. `docker stats`
+    # and `docker ps`, and assertions are non-deterministic if there are concurrent
+    # tests going on.
+    #
+    # Note: we add the marker in pytest_itemcollected rather than
+    # pytest_collection_modifyitems because xdist requires xdist_group markers
+    # to be present before modifyitems runs.
+    if item.get_closest_marker("needs_docker"):
+        item.add_marker(pytest.mark.xdist_group("docker_lib"))
+
+
 @pytest.fixture(scope="session", autouse=True)
 def close_task_api_session():
     # agent.task_api uses a module-level requests.Session. Disable keep-alive
@@ -162,6 +175,14 @@ def tmp_work_dir(request, monkeypatch, tmp_path):
         basetemp = (
             request.config.option.basetemp or Path(tempfile.gettempdir()).resolve()
         )
+        # Under pytest-xdist each worker sets its own --basetemp pointing at a
+        # That breaks the relative_to() below when we run tests in
+        # docker, because pytest_host_tmp mounts /tmp to /tmp/jobrunner-docker and loses
+        # the worker subdir
+        # Fall back to gettempdir() if we're running with xdist.
+        if hasattr(request.config, "workerinput"):
+            basetemp = Path(tempfile.gettempdir()).resolve()
+
         host_volume_path = pytest_host_tmp / tmp_path.relative_to(basetemp)
         monkeypatch.setattr(
             "agent.config.DOCKER_HOST_VOLUME_DIR",
@@ -172,8 +193,8 @@ def tmp_work_dir(request, monkeypatch, tmp_path):
 
 
 @pytest.fixture
-def docker_cleanup(monkeypatch):
-    label_for_tests = "jobrunner-pytest"
+def docker_cleanup(monkeypatch, worker_id):
+    label_for_tests = f"jobrunner-pytest-{worker_id}"
     monkeypatch.setattr("agent.lib.docker.LABEL", label_for_tests)
     monkeypatch.setattr("agent.executors.local.LABEL", label_for_tests)
     yield

--- a/tests/controller/webapp/test_api_spec.py
+++ b/tests/controller/webapp/test_api_spec.py
@@ -14,6 +14,12 @@ from tests.factories import job_factory, rap_create_request_factory
 FIXTURES_PATH = Path(__file__).parent.parent.parent.resolve() / "fixtures"
 
 
+# Keep all parametrised schemathesis cases on a single xdist worker so the
+# module-scoped `recorder` fixture sees every status code before its
+# teardown assertion runs.
+pytestmark = pytest.mark.xdist_group("api_spec")
+
+
 @schemathesis.hook
 def before_add_examples(context, examples: list[schemathesis.Case]):
     # Modify the rap/create/ example2 request body to use our fixture repo, so the

--- a/uv.lock
+++ b/uv.lock
@@ -157,6 +157,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -448,6 +457,7 @@ dev = [
     { name = "pytest-django" },
     { name = "pytest-freezer" },
     { name = "pytest-responses" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "schemathesis" },
 ]
@@ -472,6 +482,7 @@ dev = [
     { name = "pytest-django" },
     { name = "pytest-freezer" },
     { name = "pytest-responses" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff" },
     { name = "schemathesis" },
 ]
@@ -791,6 +802,19 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/0a/81b8cc3cf4b6605d97ed37217af9e2f82c97ebe130f60cf85fe82edfe0e1/pytest_responses-0.5.1-py2.py3-none-any.whl", hash = "sha256:4172e565b94ac1ea3b10aba6e40855ad60cd7f141476b2d8a47e4b5f250be734", size = 6693, upload-time = "2022-10-11T17:15:40.889Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This doesn't have a lot of impact in CI (the test workflow is reduced from ~4-4.5 mins to 3.5 mins) but it's a bigger relative speedup locally (for me, ~1m 30s down from 2m 45s for the full test run).

It doesn't involve big changes, but we do have to group the docker tests and api-spec tests into xdist groups so they run on the same workers.