### PR TITLE
Keep manual maintenance mode on

### DIFF
--- a/controller/task_api.py
+++ b/controller/task_api.py
@@ -2,7 +2,7 @@ import time
 
 from controller.lib import database
 from controller.models import Task, TaskType
-from controller.queries import set_flag
+from controller.queries import get_flag_value, set_flag
 
 
 def insert_task(task):
@@ -72,7 +72,10 @@ def handle_task_update(*, task_id, stage, results, complete, timestamp_ns=None):
 
 def handle_task_update_dbstatus(task):
     with database.transaction():
-        if results := task.agent_results.get("results"):
-            mode = results["status"]
-            set_flag("mode", mode, backend=task.backend)
+        # If we're in manual maintenance mode, we stay there, irrespective of
+        # the actual maintenance mode status
+        if not get_flag_value("manual-db-maintenance", task.backend):
+            if results := task.agent_results.get("results"):
+                mode = results["status"]
+                set_flag("mode", mode, backend=task.backend)
         database.update(task)

--- a/tests/controller/test_task_api.py
+++ b/tests/controller/test_task_api.py
@@ -4,6 +4,7 @@ from common.job_executor import JobDefinition
 from controller import task_api
 from controller.main import job_to_job_definition
 from controller.models import Task, TaskType
+from controller.queries import get_flag_value, set_flag
 from tests.factories import job_factory
 
 
@@ -70,3 +71,50 @@ def test_handle_task_update(db, task_type, complete):
         assert updated_task.finished_at > 0
     else:
         assert updated_task.finished_at is None
+
+
+@pytest.mark.parametrize(
+    "manual_mode,result_mode,end_mode",
+    [
+        # # manual mode on; always stay in maintenance mode
+        ("on", "db-maintenance", "db-maintenance"),
+        ("on", "", "db-maintenance"),
+        # # manual mode off; results say no-maintenance mode, maintenance mode turned off
+        (None, "", ""),
+        # # manual mode off; results say still in maintenance mode, maintenance mode stays on
+        (None, "db-maintenance", "db-maintenance"),
+    ],
+)
+def test_handle_db_status_task_update(db, manual_mode, result_mode, end_mode):
+
+    # Start in db-maintenance mode
+    set_flag("mode", "db-maintenance", backend="test")
+    set_flag("manual-db-maintenance", manual_mode, backend="test")
+
+    task = Task(
+        id="task1",
+        backend="test",
+        type=TaskType.DBSTATUS,
+        definition={"some_key": "some_value"},
+    )
+    task_api.insert_task(task)
+
+    results = {"results": {"status": result_mode}}
+    task_api.handle_task_update(
+        task_id="task1",
+        stage="stage1",
+        results=results,
+        complete=True,
+    )
+
+    # The task is always correctly updated
+    updated_task = task_api.get_task("task1")
+    assert not updated_task.active
+    assert updated_task.agent_stage == "stage1"
+    assert updated_task.agent_results == results
+    assert updated_task.finished_at > 0
+
+    # Maintenance mode is only turned off if we're actual out of it AND we're not in manual mode
+    assert get_flag_value("mode", backend="test") == end_mode
+    # Manual mode always stays as set
+    assert get_flag_value("manual-db-maintenance", backend="test") == manual_mode


### PR DESCRIPTION
If we're in manual maintenance mode, we can now optionally continue to run the DBSTATUS tasks to check for real maintenance mode. If we do so, we don't want the result of that check to take us out of maintenance mode again. So now, if we're in manual mode, we always stay there.