### PR TITLE
Use job's creation time to determine log directory partition

### DIFF
--- a/agent/executors/local.py
+++ b/agent/executors/local.py
@@ -73,10 +73,13 @@ def get_medium_privacy_workspace(workspace):
         return None
 
 
-def get_log_dir(job_id):
+def get_log_dir(job_definition):
+    created_at = datetime.datetime.fromtimestamp(
+        job_definition.created_at, datetime.UTC
+    )
     # Split log directory up by month to make things slightly more manageable
-    month_dir = datetime.date.today().strftime("%Y-%m")
-    return config.JOB_LOG_DIR / month_dir / container_name(job_id)
+    month_dir = created_at.strftime("%Y-%m")
+    return config.JOB_LOG_DIR / month_dir / container_name(job_definition.id)
 
 
 def read_job_metadata(job_id):
@@ -103,7 +106,7 @@ def read_job_task_metadata(job_definition):
 
 
 def write_job_metadata(job_definition, job_metadata):
-    metadata_path = get_log_dir(job_definition.id) / METADATA_FILE
+    metadata_path = get_log_dir(job_definition) / METADATA_FILE
     metadata_path.parent.mkdir(exist_ok=True, parents=True)
     metadata_path.write_text(json.dumps(job_metadata, indent=2))
 
@@ -111,17 +114,19 @@ def write_job_metadata(job_definition, job_metadata):
 def job_metadata_path(job_id):
     """Return the expected path for the metadata for a job.
 
-    Due to writing to a directory path that includes the month at the time the
-    job was completed. We now need to be able to look up the metadata of a job
-    that may have completed in a previous month, so we use a glob to find it.
+    Because the path we write metadata to includes the month at the time the job was
+    created, and because sometimes we need to look up metadata from a job ID without
+    knowing the creation time, we have to search for it.
 
-    This is hopefully a temporary hack (2025-04)
+    This is tech debt we knowingly incurred when we prioritised finishing the
+    Agent/Controller split in order to unblock the RAP API work.
+
+    For further details see:
+    https://github.com/opensafely-core/job-runner/pull/1454
     """
-    metadata_path = get_log_dir(job_id) / METADATA_FILE
-    if metadata_path.exists():
-        return metadata_path
-    paths = list(config.JOB_LOG_DIR.glob(f"*/{container_name(job_id)}/{METADATA_FILE}"))
-    assert len(paths) <= 1  # There can be only one. Or zero.
+    job_metadata_file = container_name(job_id) + "/" + METADATA_FILE
+    paths = list(config.JOB_LOG_DIR.glob(f"*/{job_metadata_file}"))
+    assert len(paths) <= 1, f"Expected at most one path, got: {paths!r}"
     if paths:
         return paths[0]
 
@@ -601,7 +606,7 @@ def write_job_logs(
 ):
     """Copy logs to log dir and workspace."""
     # Dump useful info in log directory
-    log_dir = get_log_dir(job_definition.id)
+    log_dir = get_log_dir(job_definition)
     write_log_file(job_definition, job_metadata, log_dir / "logs.txt", excluded)
     write_job_metadata(job_definition, job_metadata)
     if copy_log_to_workspace:

--- a/tests/agent/cli/test_ehrql_telemetry.py
+++ b/tests/agent/cli/test_ehrql_telemetry.py
@@ -138,7 +138,7 @@ def test_ehrql_telemetry_main_with_id(monkeypatch, tmp_path):
     monkeypatch.setattr(local.config, "JOB_LOG_DIR", tmp_path)
     job_id = "1234"
     meta = metadata(job_id)
-    logdir = local.get_log_dir(job_id)
+    logdir = tmp_path / "2026-06" / f"os-job-{job_id}"
     logdir.mkdir(parents=True)
 
     metadata_path = logdir / "metadata.json"

--- a/tests/agent/test_local_executor.py
+++ b/tests/agent/test_local_executor.py
@@ -158,24 +158,23 @@ def test_get_log_dir(job_definition):
 def test_read_metadata_path(job_definition):
     assert local.read_job_metadata(job_definition.id) == {}
 
-    globbed_path = (
-        config.JOB_LOG_DIR
-        / "last-month"
-        / local.container_name(job_definition.id)
-        / local.METADATA_FILE
-    )
-    globbed_path.parent.mkdir(parents=True)
-    globbed_path.write_text(json.dumps({"test": "globbed"}))
-    assert local.read_job_metadata(job_definition.id) == local.METADATA_DEFAULTS | {
-        "test": "globbed"
-    }
-
     actual_path = local.get_log_dir(job_definition) / local.METADATA_FILE
     actual_path.parent.mkdir(parents=True)
     actual_path.write_text(json.dumps({"test": "actual"}))
     assert local.read_job_metadata(job_definition.id) == local.METADATA_DEFAULTS | {
         "test": "actual"
     }
+
+    old_path = (
+        config.JOB_LOG_DIR
+        / "last-month"
+        / local.container_name(job_definition.id)
+        / local.METADATA_FILE
+    )
+    old_path.parent.mkdir(parents=True)
+    old_path.write_text(json.dumps({"test": "old"}))
+    with pytest.raises(AssertionError, match="Expected at most one path"):
+        local.read_job_metadata(job_definition.id)
 
 
 @pytest.mark.parametrize(

--- a/tests/agent/test_local_executor.py
+++ b/tests/agent/test_local_executor.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import time
@@ -125,7 +126,7 @@ def list_repo_files(path):
 
 
 def log_dir_log_file_exists(job_definition):
-    log_dir = local.get_log_dir(job_definition.id)
+    log_dir = local.get_log_dir(job_definition)
     if not log_dir.exists():
         return False
     log_file = log_dir / "logs.txt"
@@ -144,6 +145,16 @@ def workspace_log_file_exists(job_definition):
     return get_workspace_log_filepath(job_definition).exists()
 
 
+def test_get_log_dir(job_definition):
+    job_definition.id = "12345"
+    job_definition.created_at = int(
+        datetime.datetime.fromisoformat("2025-10-20T12:13:14Z").timestamp()
+    )
+    assert local.get_log_dir(job_definition) == (
+        local.config.JOB_LOG_DIR / "2025-10/os-job-12345"
+    )
+
+
 def test_read_metadata_path(job_definition):
     assert local.read_job_metadata(job_definition.id) == {}
 
@@ -159,7 +170,7 @@ def test_read_metadata_path(job_definition):
         "test": "globbed"
     }
 
-    actual_path = local.get_log_dir(job_definition.id) / local.METADATA_FILE
+    actual_path = local.get_log_dir(job_definition) / local.METADATA_FILE
     actual_path.parent.mkdir(parents=True)
     actual_path.write_text(json.dumps({"test": "actual"}))
     assert local.read_job_metadata(job_definition.id) == local.METADATA_DEFAULTS | {
@@ -406,7 +417,7 @@ def test_finalize_success(docker_cleanup, job_definition, tmp_work_dir):
     assert status.results["status_message"] == "Completed successfully"
     assert status.results["job_metrics"] == {"test": 1.0}
 
-    log_dir = local.get_log_dir(job_definition.id)
+    log_dir = local.get_log_dir(job_definition)
     log_file = log_dir / "logs.txt"
     assert log_dir.exists()
     assert log_file.exists()
@@ -676,7 +687,7 @@ def test_finalize_large_level4_outputs(docker_cleanup, job_definition, tmp_work_
         "output/output.txt": "File size of 1.0Mb is larger that limit of 0.5Mb.",
     }
 
-    log_file = local.get_log_dir(job_definition.id) / "logs.txt"
+    log_file = local.get_log_dir(job_definition) / "logs.txt"
     log = log_file.read_text()
     assert "Invalid moderately_sensitive outputs:" in log
     assert (
@@ -730,7 +741,7 @@ def test_finalize_invalid_file_type(docker_cleanup, job_definition, tmp_work_dir
     txt = message_file.read_text()
     assert "output/output.rds" in txt
 
-    log_file = local.get_log_dir(job_definition.id) / "logs.txt"
+    log_file = local.get_log_dir(job_definition) / "logs.txt"
     log = log_file.read_text()
     assert "Invalid moderately_sensitive outputs:" in log
     assert "output/output.rds  - File type of .rds is not valid level 4 file" in log
@@ -773,7 +784,7 @@ def test_finalize_patient_id_header(docker_cleanup, job_definition, tmp_work_dir
         "output/output.csv": "File has patient_id column",
     }
 
-    log_file = local.get_log_dir(job_definition.id) / "logs.txt"
+    log_file = local.get_log_dir(job_definition) / "logs.txt"
     log = log_file.read_text()
     assert "Invalid moderately_sensitive outputs:" in log
     assert "output/output.csv  - File has patient_id column" in log
@@ -826,7 +837,7 @@ def test_finalize_csv_max_rows(docker_cleanup, job_definition, tmp_work_dir):
         "output/output.csv": "File row count (11) exceeds maximum allowed rows (10)",
     }
 
-    log_file = local.get_log_dir(job_definition.id) / "logs.txt"
+    log_file = local.get_log_dir(job_definition) / "logs.txt"
     log = log_file.read_text()
     assert "Invalid moderately_sensitive outputs:" in log
     assert (


### PR DESCRIPTION
The previous behaviour was to use the current time at whatever point the logs and metadata were being written to determine the partition directory to use. Where a job took multiple attempts (e.g. because previous attempts were interrupted for db maintenance or reboots), and where these attempts spanned a month boundary, the job could end up with multiple log directories.

Additionally, the code which retrieved the metadata for a given job had some unexpected behaviour: for jobs completed in the current month it would retrieve the metadata directly, but for older jobs it would do a search and then assert that only one result was found. This meant that the system worked fine until someone ran a job which depended on the results of another job which had run more than a month ago and had multiple attempts which spanned the month boundary. At this point it would fail the assertion and refuse to start the job, which is exactly what happened at the [beginning of this week](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1782752075360859).

The absolute simplest fix here would be to remove the assertion, treat multiple matches as normal, and always use the lexically greatest match (i.e. the most recent). However, I think it would be preferable to maintain the invariant that each job has exactly one corresponding metadata file. This means that as well as deploying this fix we'll need to manually clean up the tiny handful of duplicated metadata files (see Slack [for details](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1782841874248189?thread_ts=1782752075.360859&cid=C069YDR4NCA)) to avoid future problems.

That's slightly more work but not loads, and it avoids doubling down on a hack.


## How we got here and where we should go next

When we first started storing a persistent archive of job logs and metadata we decided to partition this by month in order to keep the directory sizes manageable. And while these files were – from the system's point of view – written once and then never read, it was easiest to do this by using the current date to determine the log partition.

However, during the work to refactor the original system into separate Agent and Controller components we ended up with a need for the Agent to retrieve historical job metadata. This was driven by a last minute change of requirements that meant we couldn't send output filenames out of the secure environment up to the Controller as originally planned. Because completing the Agent/Controller split was a blocker on beginning planned work on developing the RAP API a conscious decision was made to take on technical debt here. The intention was to pay this down during a third phase of Agent/Controller work, after the RAP API was up and running.

The correct approach here is to treat job/task metadata as a first class component of the Agent's state and design the storage model around that. It would make sense to do this alongside another long-discussed change which is to store output files from individual tasks separately, rather than in a workspace directory shared between tasks.