### PR TITLE
Replace docker.io with docker-ce-cli

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,15 +47,30 @@ jobs:
 
   test-docker:
     runs-on: ubuntu-24.04
-    name: Test docker image
+    name: Test docker image (${{ matrix.docker-backend }})
+    strategy:
+      fail-fast: false
+      matrix:
+        docker-backend: [github-native, docker.io]
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-
       - name: Set up Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3
+
+      - name: Swap runner's Docker for docker.io (to match the docker used in the backend)
+        if: matrix.docker-backend == 'docker.io'
+        run: |
+          sudo systemctl stop docker
+          sudo apt-get remove -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          sudo apt-get update
+          sudo apt-get install -y docker.io
+          sudo systemctl start docker
+
+      - name: Confirm docker server version
+        run: docker version
 
       - name: Build image
         run: just docker/build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,28 @@ FROM ghcr.io/opensafely-core/base-docker:${UBUNTU_VERSION} AS base-python
 # docker clean up that deletes that cache on every apt install
 RUN rm -f /etc/apt/apt.conf.d/docker-clean
 
-# install any additional system dependencies
+#
+# Docker CLI
+#
+# Previously we have used docker.io from the Ubuntu archive, which lags
+# upstream Docker Engine releases (see e.g. CVE-2025-68121, fixed in
+# 29.3.0 upstream but not yet (as of 2026-07-24) backported to
+# Ubuntu 24.04's docker.io).
+# Installing from Docker's own apt repo instead gets us immediate security
+# patches on every image rebuild. However, it does require the additional
+# apt key/repo retrieval below
+
+RUN --mount=type=cache,target=/var/cache/apt <<'EOF'
+UBUNTU_CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
+KEY_PATH=/etc/apt/keyrings/docker.asc
+KEY_URL='https://download.docker.com/linux/ubuntu/gpg'
+install -m 0755 -d /etc/apt/keyrings
+/usr/lib/apt/apt-helper download-file "$KEY_URL" "$KEY_PATH"
+chmod a+r "$KEY_PATH"
+echo "deb [arch=$(dpkg --print-architecture) signed-by=$KEY_PATH] https://download.docker.com/linux/ubuntu ${UBUNTU_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
+EOF
+
+# install any additional system dependencies, including docker-ce-cli
 # NOTE: ensure .python-version is not excluded in .dockerignore
 RUN --mount=type=cache,target=/var/cache/apt \
     --mount=type=bind,source=docker/dependencies.txt,target=/dependencies.txt \

--- a/docker/dependencies.txt
+++ b/docker/dependencies.txt
@@ -1,6 +1,9 @@
 # list ubuntu packages needed in production, one per line
-docker.io
 sqlite3
 git
 tzdata
 ca-certificates
+# Job-runner only ever shells out to `docker` against a mounted host socket,
+# so we don't need a local daemon, containerd, or buildx/compose plugins,
+# just the CLI.
+docker-ce-cli


### PR DESCRIPTION
docker.io is the apt package from the Ubuntu archive. We use this
on the backend because we can get security updates for it, and we
can't access the docker ubuntu package inside the backend.

However, the ubuntu package lags behind the upstream docker package,
(see e.g. https://github.com/advisories/GHSA-h355-32pf-p2xm, fixed in 29.3.0 upstream but not yet
(as of 2026-07-24) backported to Ubuntu 24.04's docker.io).

We don't have the same restrictions on the docker apt package in
the job-runner image, since it's built outside of the backend.
Replacing docker.io with docker-ce-cli also gets rid of a whole
load of dependencies in the image, because we only actually need
the cli, and not the various other things (containerd, buildx plugin
etc) that docker.io pulls in.

Also updates the CI docker tests to run on both github's native docker, and with the docker.io package.

See [slack thread](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1784808490055209)