### PR TITLE
Temporarily pin ruff to <0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,8 @@ dev = [
     "pytest-freezer",
     "pytest-responses",
     "pytest-xdist>=3.8.0",
-    "ruff",
+    # temporarily pin ruff until https://github.com/opensafely-core/job-runner/issues/1473
+    "ruff<0.16",
     # OpenAPI tools
     "schemathesis",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -446,7 +446,7 @@ dev = [
     { name = "pytest-freezer" },
     { name = "pytest-responses" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "ruff" },
+    { name = "ruff", specifier = "<0.16" },
     { name = "schemathesis" },
 ]
 


### PR DESCRIPTION
Pending https://github.com/opensafely-core/job-runner/issues/1473